### PR TITLE
Documenta de dónde viene el nombre y localiza el selector de idioma

### DIFF
--- a/MAILBOX_SETUP.md
+++ b/MAILBOX_SETUP.md
@@ -1,6 +1,6 @@
 # Configurar el archivo del buzón
 
-**Español (MX)** · [English](i18n/MAILBOX_SETUP.en-US.md) · [Español (ES)](i18n/MAILBOX_SETUP.es-ES.md) · [Français](i18n/MAILBOX_SETUP.fr-FR.md) · [Português (BR)](i18n/MAILBOX_SETUP.pt-BR.md)
+**Español (MX)** · [English (US)](i18n/MAILBOX_SETUP.en-US.md) · [Español (ES)](i18n/MAILBOX_SETUP.es-ES.md) · [Français (FR)](i18n/MAILBOX_SETUP.fr-FR.md) · [Português (BR)](i18n/MAILBOX_SETUP.pt-BR.md)
 
 Paso 1 del [README](README.md#cómo-configurarlo-en-tu-agente). Esto lo haces
 tú, antes de meter al agente, porque hace falta una contraseña y una contraseña no

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # paynani
 
-**Español (MX)** · [English](i18n/README.en-US.md) · [Español (ES)](i18n/README.es-ES.md) · [Français](i18n/README.fr-FR.md) · [Português (BR)](i18n/README.pt-BR.md)
+**Español (MX)** · [English (US)](i18n/README.en-US.md) · [Español (ES)](i18n/README.es-ES.md) · [Français (FR)](i18n/README.fr-FR.md) · [Português (BR)](i18n/README.pt-BR.md)
 
 Correo electrónico por notificación inmediata para un agente de IA. Se entera de
 que llegó un correo en más o menos un segundo, sin andar revisando cada rato, y
@@ -283,6 +283,42 @@ verdad está corriendo. [`DESIGN.md`](DESIGN.md) explica cada uno y qué se romp
 sin él.
 
 Construido y verificado de extremo a extremo el 2026-08-09.
+
+## De dónde viene el nombre
+
+**paynani** es náhuatl clásico y quiere decir, sin adornos, *«el que corre
+ligeramente»*: del verbo `paina` —«correr ligeramente», en el vocabulario de
+Alonso de Molina, 1571— más el sufijo `-ni`, que convierte una acción en quien la
+hace de oficio.
+
+La grafía varía porque los frailes del siglo XVI escribieron el náhuatl con las
+convenciones del español de su época, donde `i`, `y` y `j` se usaban casi
+indistintamente. El Gran Diccionario Náhuatl indexa los mismos pasajes del Códice
+Florentino bajo `painani` y bajo `painanj`, y registra `payna` como variante de
+`paina`: son la misma palabra. Aquí se escribe `paynani`, que es la forma que un
+lector hispanohablante reconoce.
+
+Conviene notar lo que la palabra **no** dice. No nombra el cargo —al mensajero
+imperial se le decía `titlantli`, «el enviado»— sino la cualidad: ligero de pies.
+Dice lo que hace, no el puesto que ocupa.
+
+Los corredores trabajaban en relevos, con postas llamadas `techialoyan`, y se
+entrenaban desde niños. De todo lo que se cuenta de ellos hay un detalle que es
+justamente lo que hace esta herramienta: **el mensajero clasificaba la noticia
+antes de abrir la boca.** Si llegaba con el pelo suelto y revuelto traía una
+derrota, y no se le daba ni el saludo; si llegaba con el pelo trenzado y una cinta
+de color, con escudo y macana, traía una victoria y la gente lo seguía hasta el
+palacio. Eso es lo que hace aquí la etiqueta `roster`: el sobre dice cómo recibir
+la noticia antes de que se lea.
+
+De la misma raíz viene Paynal, el que corría en lugar de Huitzilopochtli en las
+procesiones. El Códice Florentino lo explica en tres palabras —*«el delegado, el
+sustituto, el suplente»*— porque «lo apuraban, lo hacían correr». Un agente que va
+por el correo en lugar de quien no puede estar en todas partes.
+
+<sub>Fuentes: [Gran Diccionario Náhuatl](https://gdn.iib.unam.mx/diccionario/painani/233892)
+(UNAM) · [Nahuatl Dictionary](https://nahuatl.wired-humanities.org/content/paina)
+(Wired Humanities) · [Mexicolore](https://www.mexicolore.co.uk/aztecs/ask-experts/did-they-send-post-mail).</sub>
 
 ---
 

--- a/UNINSTALL.md
+++ b/UNINSTALL.md
@@ -1,6 +1,6 @@
 # Cómo quitar paynani
 
-**Español (MX)** · [English](i18n/UNINSTALL.en-US.md)
+**Español (MX)** · [English (US)](i18n/UNINSTALL.en-US.md)
 
 Esto instala un servicio en segundo plano que toca seis lugares de la
 computadora. Aquí está cómo quitarlo todo, sea para reinstalar limpio, para

--- a/i18n/MAILBOX_SETUP.en-US.md
+++ b/i18n/MAILBOX_SETUP.en-US.md
@@ -1,6 +1,6 @@
 # Setting up the mailbox file
 
-[Español (MX)](../MAILBOX_SETUP.md) · **English** · [Español (ES)](MAILBOX_SETUP.es-ES.md) · [Français](MAILBOX_SETUP.fr-FR.md) · [Português (BR)](MAILBOX_SETUP.pt-BR.md)
+[Español (MX)](../MAILBOX_SETUP.md) · **English (US)** · [Español (ES)](MAILBOX_SETUP.es-ES.md) · [Français (FR)](MAILBOX_SETUP.fr-FR.md) · [Português (BR)](MAILBOX_SETUP.pt-BR.md)
 
 Step 1 of [the README](README.en-US.md#setting-this-up-on-your-agent). You do this
 yourself, before involving the agent, because it needs a password and a password

--- a/i18n/MAILBOX_SETUP.es-ES.md
+++ b/i18n/MAILBOX_SETUP.es-ES.md
@@ -1,6 +1,6 @@
 # Configurar el fichero del buzón
 
-[Español (MX)](../MAILBOX_SETUP.md) · [English](MAILBOX_SETUP.en-US.md) · **Español (ES)** · [Français](MAILBOX_SETUP.fr-FR.md) · [Português (BR)](MAILBOX_SETUP.pt-BR.md)
+[Español (MX)](../MAILBOX_SETUP.md) · [English (US)](MAILBOX_SETUP.en-US.md) · **Español (ES)** · [Français (FR)](MAILBOX_SETUP.fr-FR.md) · [Português (BR)](MAILBOX_SETUP.pt-BR.md)
 
 Paso 1 del [README](README.es-ES.md#cómo-configurarlo-en-tu-agente). Esto lo haces
 tú, antes de involucrar al agente, porque hace falta una contraseña y una

--- a/i18n/MAILBOX_SETUP.fr-FR.md
+++ b/i18n/MAILBOX_SETUP.fr-FR.md
@@ -1,6 +1,6 @@
 # Configurer le fichier de la boîte aux lettres
 
-[Español (MX)](../MAILBOX_SETUP.md) · [English](MAILBOX_SETUP.en-US.md) · [Español (ES)](MAILBOX_SETUP.es-ES.md) · **Français** · [Português (BR)](MAILBOX_SETUP.pt-BR.md)
+[Español (MX)](../MAILBOX_SETUP.md) · [English (US)](MAILBOX_SETUP.en-US.md) · [Español (ES)](MAILBOX_SETUP.es-ES.md) · **Français (FR)** · [Português (BR)](MAILBOX_SETUP.pt-BR.md)
 
 Étape 1 du [README](README.fr-FR.md#mise-en-place-sur-votre-agent). Vous faites
 ceci vous-même, avant d'impliquer l'agent, parce qu'il faut un mot de passe et

--- a/i18n/MAILBOX_SETUP.pt-BR.md
+++ b/i18n/MAILBOX_SETUP.pt-BR.md
@@ -1,6 +1,6 @@
 # Configurar o arquivo da caixa de e-mail
 
-[Español (MX)](../MAILBOX_SETUP.md) · [English](MAILBOX_SETUP.en-US.md) · [Español (ES)](MAILBOX_SETUP.es-ES.md) · [Français](MAILBOX_SETUP.fr-FR.md) · **Português (BR)**
+[Español (MX)](../MAILBOX_SETUP.md) · [English (US)](MAILBOX_SETUP.en-US.md) · [Español (ES)](MAILBOX_SETUP.es-ES.md) · [Français (FR)](MAILBOX_SETUP.fr-FR.md) · **Português (BR)**
 
 Passo 1 do [README](README.pt-BR.md#como-configurar-no-seu-agente). Isto é você
 quem faz, antes de envolver o agente, porque é preciso uma senha e senha não deve

--- a/i18n/README.en-US.md
+++ b/i18n/README.en-US.md
@@ -1,6 +1,6 @@
 # paynani
 
-[Español (MX)](../README.md) · **English** · [Español (ES)](README.es-ES.md) · [Français](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)
+[Español (MX)](../README.md) · **English (US)** · [Español (ES)](README.es-ES.md) · [Français (FR)](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)
 
 Push-style email for an AI agent. It finds out about new mail within about a
 second, without polling, and can read and send under a recipient allowlist.
@@ -299,6 +299,42 @@ why the session-start hook asks whether the service is actually running.
 [`DESIGN.md`](../DESIGN.md) explains each one and what breaks without it.
 
 Built and verified end to end on 2026-08-09.
+
+## Where the name comes from
+
+**paynani** is Classical Nahuatl, and it means something plainer than it sounds:
+*"the one who runs lightly."* From the verb `paina` — "correr ligeramente," in
+Alonso de Molina's 1571 vocabulary — plus the suffix `-ni`, which turns an action
+into the one who does it for a living.
+
+The spelling varies because sixteenth-century friars wrote Nahuatl with the
+Spanish conventions of their day, in which `i`, `y` and `j` were used almost
+interchangeably. The Gran Diccionario Náhuatl indexes the same Florentine Codex
+passages under both `painani` and `painanj`, and records `payna` as a variant of
+`paina`: one word, several spellings. This project writes `paynani`, the form a
+Spanish-speaking reader recognizes.
+
+Worth noting what the word does **not** say. It is not the name of the office —
+the imperial messenger was a `titlantli`, "the one sent" — but of the quality:
+light of foot. It says what he does, not what rank he holds.
+
+The runners worked in relays, through staging posts called `techialoyan`, and
+trained from childhood. Of everything recorded about them, one detail is exactly
+what this tool does: **the messenger classified the news before he opened his
+mouth.** Arriving with loose, disheveled hair meant a defeat, and he was given no
+greeting at all; arriving with braided hair and a coloured ribbon, carrying shield
+and club, meant a victory, and crowds followed him to the palace. That is what the
+`roster` tag does here: the envelope says how to receive the news before anyone
+reads it.
+
+The same root gave Paynal, who ran in Huitzilopochtli's place during processions.
+The Florentine Codex explains him in three words — *"the delegate, the substitute,
+the deputy"* — because "they pressed him on quickly; he was made to hasten." An
+agent that goes for the mail on behalf of whoever cannot be everywhere at once.
+
+<sub>Sources: [Gran Diccionario Náhuatl](https://gdn.iib.unam.mx/diccionario/painani/233892)
+(UNAM) · [Nahuatl Dictionary](https://nahuatl.wired-humanities.org/content/paina)
+(Wired Humanities) · [Mexicolore](https://www.mexicolore.co.uk/aztecs/ask-experts/did-they-send-post-mail).</sub>
 
 ---
 

--- a/i18n/README.es-ES.md
+++ b/i18n/README.es-ES.md
@@ -1,6 +1,6 @@
 # paynani
 
-[Español (MX)](../README.md) · [English](README.en-US.md) · **Español (ES)** · [Français](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)
+[Español (MX)](../README.md) · [English (US)](README.en-US.md) · **Español (ES)** · [Français (FR)](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)
 
 Correo electrónico por notificación inmediata para un agente de IA. Se entera de
 que ha llegado correo en un segundo aproximadamente, sin sondear el buzón, y puede
@@ -278,6 +278,42 @@ realmente en marcha. [`DESIGN.md`](../DESIGN.md) explica cada uno y qué se romp
 él.
 
 Construido y verificado de extremo a extremo el 2026-08-09.
+
+## De dónde viene el nombre
+
+**paynani** es náhuatl clásico y significa, sin adornos, *«el que corre
+ligeramente»*: del verbo `paina` —«correr ligeramente», en el vocabulario de
+Alonso de Molina, 1571— más el sufijo `-ni`, que convierte una acción en quien la
+hace de oficio.
+
+La grafía varía porque los frailes del siglo XVI escribieron el náhuatl con las
+convenciones del español de su época, en las que `i`, `y` y `j` se usaban casi
+indistintamente. El Gran Diccionario Náhuatl indexa los mismos pasajes del Códice
+Florentino bajo `painani` y bajo `painanj`, y registra `payna` como variante de
+`paina`: son la misma palabra. Aquí se escribe `paynani`, que es la forma que un
+lector hispanohablante reconoce.
+
+Conviene fijarse en lo que la palabra **no** dice. No nombra el cargo —al
+mensajero imperial se le llamaba `titlantli`, «el enviado»— sino la cualidad:
+ligero de pies. Dice lo que hace, no el puesto que ocupa.
+
+Los corredores trabajaban por relevos, con postas llamadas `techialoyan`, y se
+entrenaban desde niños. De todo lo que se cuenta de ellos hay un detalle que es
+justo lo que hace esta herramienta: **el mensajero clasificaba la noticia antes de
+abrir la boca.** Si llegaba con el pelo suelto y revuelto traía una derrota, y no
+se le daba ni el saludo; si llegaba con el pelo trenzado y una cinta de color, con
+escudo y macana, traía una victoria y la gente lo seguía hasta el palacio. Eso es
+lo que hace aquí la etiqueta `roster`: el sobre dice cómo recibir la noticia antes
+de que se lea.
+
+De la misma raíz viene Paynal, el que corría en lugar de Huitzilopochtli en las
+procesiones. El Códice Florentino lo explica en tres palabras —*«el delegado, el
+sustituto, el suplente»*— porque «lo apremiaban, lo hacían correr». Un agente que
+va a por el correo en lugar de quien no puede estar en todas partes.
+
+<sub>Fuentes: [Gran Diccionario Náhuatl](https://gdn.iib.unam.mx/diccionario/painani/233892)
+(UNAM) · [Nahuatl Dictionary](https://nahuatl.wired-humanities.org/content/paina)
+(Wired Humanities) · [Mexicolore](https://www.mexicolore.co.uk/aztecs/ask-experts/did-they-send-post-mail).</sub>
 
 ---
 

--- a/i18n/README.fr-FR.md
+++ b/i18n/README.fr-FR.md
@@ -1,6 +1,6 @@
 # paynani
 
-[Español (MX)](../README.md) · [English](README.en-US.md) · [Español (ES)](README.es-ES.md) · **Français** · [Português (BR)](README.pt-BR.md)
+[Español (MX)](../README.md) · [English (US)](README.en-US.md) · [Español (ES)](README.es-ES.md) · **Français (FR)** · [Português (BR)](README.pt-BR.md)
 
 Notification immédiate des courriels pour un agent IA. Il apprend l'arrivée d'un
 message en une seconde environ, sans interroger la boîte en boucle, et peut lire
@@ -288,6 +288,44 @@ D'où le dernier UID enregistré message par message, la vérification d'`UIDVAL
 réellement. [`DESIGN.md`](../DESIGN.md) explique chacun d'eux et ce qui casse sans.
 
 Construit et vérifié de bout en bout le 09/08/2026.
+
+## D'où vient le nom
+
+**paynani** est du nahuatl classique et signifie, sans ornement, *« celui qui court
+légèrement »* : du verbe `paina` — « correr ligeramente », dans le vocabulaire
+d'Alonso de Molina, 1571 — auquel s'ajoute le suffixe `-ni`, qui transforme une
+action en celui qui l'exerce comme métier.
+
+La graphie varie parce que les religieux du XVIe siècle ont écrit le nahuatl avec
+les conventions de l'espagnol de leur temps, où `i`, `y` et `j` s'employaient
+presque indifféremment. Le Gran Diccionario Náhuatl indexe les mêmes passages du
+Codex de Florence sous `painani` et sous `painanj`, et enregistre `payna` comme
+variante de `paina` : c'est un seul mot. Ce projet écrit `paynani`, la forme qu'un
+lecteur hispanophone reconnaît.
+
+Il vaut la peine de noter ce que le mot ne dit **pas**. Il ne nomme pas la charge
+— le messager impérial était un `titlantli`, « celui qu'on envoie » — mais la
+qualité : léger du pied. Il dit ce qu'il fait, non le rang qu'il occupe.
+
+Les coureurs travaillaient par relais, avec des postes appelés `techialoyan`, et
+s'entraînaient dès l'enfance. De tout ce qu'on rapporte d'eux, un détail est
+exactement ce que fait cet outil : **le messager classait la nouvelle avant
+d'ouvrir la bouche.** Arrivait-il les cheveux dénoués et en désordre, il apportait
+une défaite, et on ne lui adressait pas même un salut ; arrivait-il les cheveux
+tressés et ornés d'un ruban de couleur, bouclier et massue à la main, il apportait
+une victoire, et la foule le suivait jusqu'au palais. C'est ce que fait ici
+l'étiquette `roster` : l'enveloppe dit comment recevoir la nouvelle avant qu'on ne
+la lise.
+
+De la même racine vient Paynal, celui qui courait à la place de Huitzilopochtli
+lors des processions. Le Codex de Florence l'explique en trois mots — *« le
+délégué, le substitut, le suppléant »* — parce qu'« on le pressait, on le faisait
+courir ». Un agent qui va chercher le courrier à la place de qui ne peut être
+partout à la fois.
+
+<sub>Sources : [Gran Diccionario Náhuatl](https://gdn.iib.unam.mx/diccionario/painani/233892)
+(UNAM) · [Nahuatl Dictionary](https://nahuatl.wired-humanities.org/content/paina)
+(Wired Humanities) · [Mexicolore](https://www.mexicolore.co.uk/aztecs/ask-experts/did-they-send-post-mail).</sub>
 
 ---
 

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -1,6 +1,6 @@
 # paynani
 
-[Español (MX)](../README.md) · [English](README.en-US.md) · [Español (ES)](README.es-ES.md) · [Français](README.fr-FR.md) · **Português (BR)**
+[Español (MX)](../README.md) · [English (US)](README.en-US.md) · [Español (ES)](README.es-ES.md) · [Français (FR)](README.fr-FR.md) · **Português (BR)**
 
 E-mail com aviso imediato para um agente de IA. Ele fica sabendo que chegou
 mensagem em cerca de um segundo, sem ficar consultando a caixa, e consegue ler e
@@ -276,6 +276,42 @@ serviço está mesmo rodando. O [`DESIGN.md`](../DESIGN.md) explica cada um e o 
 quebra sem ele.
 
 Construído e verificado de ponta a ponta em 09/08/2026.
+
+## De onde vem o nome
+
+**paynani** é náuatle clássico e quer dizer, sem enfeite, *"aquele que corre
+ligeiro"*: do verbo `paina` — "correr ligeramente", no vocabulário de Alonso de
+Molina, 1571 — mais o sufixo `-ni`, que transforma uma ação em quem a exerce como
+ofício.
+
+A grafia varia porque os frades do século XVI escreveram o náuatle com as
+convenções do espanhol da época, em que `i`, `y` e `j` eram usados quase
+indistintamente. O Gran Diccionario Náhuatl indexa as mesmas passagens do Códice
+Florentino sob `painani` e sob `painanj`, e registra `payna` como variante de
+`paina`: é a mesma palavra. Aqui se escreve `paynani`, que é a forma reconhecida
+por um leitor de língua espanhola.
+
+Vale reparar no que a palavra **não** diz. Ela não nomeia o cargo — o mensageiro
+imperial era um `titlantli`, "o enviado" — e sim a qualidade: ligeiro de pés. Diz
+o que ele faz, não o posto que ocupa.
+
+Os corredores trabalhavam em revezamento, com postos chamados `techialoyan`, e
+treinavam desde crianças. De tudo o que se conta sobre eles, há um detalhe que é
+exatamente o que esta ferramenta faz: **o mensageiro classificava a notícia antes
+de abrir a boca.** Se chegasse de cabelo solto e desgrenhado, trazia uma derrota,
+e não recebia nem o cumprimento; se chegasse de cabelo trançado e fita colorida,
+com escudo e clava, trazia uma vitória, e o povo o seguia até o palácio. É isso o
+que a etiqueta `roster` faz aqui: o envelope diz como receber a notícia antes que
+alguém a leia.
+
+Da mesma raiz vem Paynal, aquele que corria no lugar de Huitzilopochtli nas
+procissões. O Códice Florentino o explica em três palavras — *"o delegado, o
+substituto, o suplente"* — porque "o apressavam, faziam-no correr". Um agente que
+vai buscar o correio no lugar de quem não pode estar em toda parte.
+
+<sub>Fontes: [Gran Diccionario Náhuatl](https://gdn.iib.unam.mx/diccionario/painani/233892)
+(UNAM) · [Nahuatl Dictionary](https://nahuatl.wired-humanities.org/content/paina)
+(Wired Humanities) · [Mexicolore](https://www.mexicolore.co.uk/aztecs/ask-experts/did-they-send-post-mail).</sub>
 
 ---
 

--- a/i18n/UNINSTALL.en-US.md
+++ b/i18n/UNINSTALL.en-US.md
@@ -1,6 +1,6 @@
 # Removing paynani
 
-[Español (MX)](../UNINSTALL.md) · **English**
+[Español (MX)](../UNINSTALL.md) · **English (US)**
 
 This installs a background service that touches six places on a machine. Here is
 how to take all of it back off, for a clean reinstall, for handing the machine


### PR DESCRIPTION
El repositorio se llama `paynani` y en ningún archivo se decía por qué. Esta rama
agrega una sección final **«De dónde viene el nombre»** a los cinco READMEs, y de
paso localiza el selector de idioma.

## Qué dice la nota

Tres cosas, en este orden:

1. **Qué significa.** `paynani` es náhuatl clásico: del verbo `paina` —«correr
   ligeramente», en el vocabulario de Alonso de Molina, 1571— más el sufijo
   agentivo `-ni`. «El que corre ligeramente».
2. **Por qué se escribe con `y` si los diccionarios encabezan con `i`.** Porque
   los frailes del siglo XVI escribieron el náhuatl con las convenciones del
   español de su época, donde `i`, `y` y `j` se usaban casi indistintamente. La
   prueba concreta: el Gran Diccionario Náhuatl indexa **los mismos pasajes** del
   Códice Florentino (II-125, VII-29, XI-12) bajo `painani` y bajo `painanj`, y
   registra `payna` como variante de `paina`. Una palabra, tres grafías. Ninguna
   está mal.
3. **Qué tiene que ver el corredor con esta herramienta**, que es lo que
   justifica la nota más allá de la curiosidad.

## El punto que vale la pena

De todo lo que se cuenta de los corredores, hay un detalle que describe el diseño
de `paynani` mejor que la especificación: **el mensajero clasificaba la noticia
antes de abrir la boca.** Si llegaba despeinado traía una derrota y no se le daba
ni el saludo; si llegaba con el pelo trenzado, cinta de color, escudo y macana,
traía una victoria y la gente lo seguía hasta el palacio.

Eso es exactamente lo que hace aquí la etiqueta `roster`: el sobre dice cómo
recibir la noticia antes de que se lea.

También se anota que la palabra **no** nombra el cargo —el mensajero imperial era
`titlantli`, «el enviado»— sino la cualidad, ligero de pies. Y que de la misma
raíz sale Paynal, «el delegado, el sustituto, el suplente» según el Códice
Florentino, que corría en lugar de Huitzilopochtli: un agente que va por el correo
en lugar de quien no puede estar en todas partes.

## Decisiones que conviene revisar

- **La sección va en los cinco READMEs**, no solo en el canónico, para que las
  traducciones no nazcan atrasadas en esto.
- **El sello de traducción se queda en `2b1fc9c` a propósito.** Las versiones
  traducidas siguen atrasadas respecto de `main` en todo lo demás; moverlo diría
  que están al día cuando no lo están. Sigue pendiente una pasada de
  sincronización completa, y este PR no la hace.
- **El selector de idioma se localiza en los doce documentos**, no solo en el
  README: `English` → `English (US)` y `Français` → `Français (FR)`, en README,
  MAILBOX_SETUP y UNINSTALL. Dejarlos distintos entre documentos hermanos sería
  el defecto que el cambio viene a quitar. Si se prefiere acotarlo al README, se
  revierte en un commit.

## Verificación

`python3 scripts/test_docs.py` → **22 passed, 0 failed**. El cambio es solo de
documentación: no toca código, unidades ni instalación.

## Fuentes

- [Gran Diccionario Náhuatl (UNAM) — `painani`](https://gdn.iib.unam.mx/diccionario/painani/233892) y [`painanj`](https://gdn.iib.unam.mx/diccionario/painanj/216730)
- [Nahuatl Dictionary (Wired Humanities) — `paina`](https://nahuatl.wired-humanities.org/content/paina)
- [Mexicolore — Did they send post (mail)?](https://www.mexicolore.co.uk/aztecs/ask-experts/did-they-send-post-mail) y [The art of Aztec running](https://mexicolore.co.uk/aztecs/home/the-art-of-aztec-running)
