### PR TITLE
Propaga a las traducciones la descripción del nombre

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,11 @@ Florentino bajo `painani` y bajo `painanj`, y registra `payna` como variante de
 `paina`: son la misma palabra. Aquí se escribe `paynani`, que es la forma que un
 lector hispanohablante reconoce.
 
-Conviene notar lo que la palabra **no** dice. No nombra el cargo —al mensajero
-imperial se le decía `titlantli`, «el enviado»— sino la cualidad: ligero de pies.
-Dice lo que hace, no el puesto que ocupa.
+De esa cualidad salió el nombre del oficio. El náhuatl tenía dos maneras de
+nombrar al mensajero imperial: `titlantli`, «el enviado», que lo define por el
+encargo que lleva, y `paynani`, que lo define por cómo se mueve. La que se quedó
+pegada a esos hombres fue la segunda — se los conocía por la manera de correr, no
+por quién los mandaba.
 
 Los corredores trabajaban en relevos, con postas llamadas `techialoyan`, y se
 entrenaban desde niños. De todo lo que se cuenta de ellos hay un detalle que es

--- a/i18n/README.en-US.md
+++ b/i18n/README.en-US.md
@@ -1,4 +1,5 @@
 # paynani
+Elite messenger: the paynani were the official runners and messengers of the Aztec Empire.
 
 [Español (MX)](../README.md) · **English (US)** · [Español (ES)](README.es-ES.md) · [Français (FR)](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)
 

--- a/i18n/README.en-US.md
+++ b/i18n/README.en-US.md
@@ -315,9 +315,11 @@ passages under both `painani` and `painanj`, and records `payna` as a variant of
 `paina`: one word, several spellings. This project writes `paynani`, the form a
 Spanish-speaking reader recognizes.
 
-Worth noting what the word does **not** say. It is not the name of the office —
-the imperial messenger was a `titlantli`, "the one sent" — but of the quality:
-light of foot. It says what he does, not what rank he holds.
+The name of the office grew out of that quality. Nahuatl had two ways to name
+the imperial messenger: `titlantli`, "the one sent," which defines him by the
+errand he carries, and `paynani`, which defines him by how he moves. The one that
+stuck to these men was the second — they were known for the way they ran, not for
+who dispatched them.
 
 The runners worked in relays, through staging posts called `techialoyan`, and
 trained from childhood. Of everything recorded about them, one detail is exactly

--- a/i18n/README.es-ES.md
+++ b/i18n/README.es-ES.md
@@ -294,9 +294,11 @@ Florentino bajo `painani` y bajo `painanj`, y registra `payna` como variante de
 `paina`: son la misma palabra. Aquí se escribe `paynani`, que es la forma que un
 lector hispanohablante reconoce.
 
-Conviene fijarse en lo que la palabra **no** dice. No nombra el cargo —al
-mensajero imperial se le llamaba `titlantli`, «el enviado»— sino la cualidad:
-ligero de pies. Dice lo que hace, no el puesto que ocupa.
+De esa cualidad salió el nombre del oficio. El náhuatl tenía dos maneras de
+nombrar al mensajero imperial: `titlantli`, «el enviado», que lo define por el
+encargo que lleva, y `paynani`, que lo define por cómo se mueve. La que se quedó
+pegada a esos hombres fue la segunda — se los conocía por la manera de correr, no
+por quién los mandaba.
 
 Los corredores trabajaban por relevos, con postas llamadas `techialoyan`, y se
 entrenaban desde niños. De todo lo que se cuenta de ellos hay un detalle que es

--- a/i18n/README.es-ES.md
+++ b/i18n/README.es-ES.md
@@ -1,4 +1,5 @@
 # paynani
+Mensajero de élite: los paynani eran los corredores y mensajeros oficiales del Imperio Azteca.
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · **Español (ES)** · [Français (FR)](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)
 

--- a/i18n/README.fr-FR.md
+++ b/i18n/README.fr-FR.md
@@ -304,9 +304,11 @@ Codex de Florence sous `painani` et sous `painanj`, et enregistre `payna` comme
 variante de `paina` : c'est un seul mot. Ce projet écrit `paynani`, la forme qu'un
 lecteur hispanophone reconnaît.
 
-Il vaut la peine de noter ce que le mot ne dit **pas**. Il ne nomme pas la charge
-— le messager impérial était un `titlantli`, « celui qu'on envoie » — mais la
-qualité : léger du pied. Il dit ce qu'il fait, non le rang qu'il occupe.
+C'est de cette qualité qu'est venu le nom du métier. Le nahuatl avait deux façons
+de nommer le messager impérial : `titlantli`, « celui qu'on envoie », qui le
+définit par la mission qu'il porte, et `paynani`, qui le définit par sa manière de
+se déplacer. C'est la seconde qui est restée attachée à ces hommes — on les
+connaissait à leur façon de courir, non à celui qui les envoyait.
 
 Les coureurs travaillaient par relais, avec des postes appelés `techialoyan`, et
 s'entraînaient dès l'enfance. De tout ce qu'on rapporte d'eux, un détail est

--- a/i18n/README.fr-FR.md
+++ b/i18n/README.fr-FR.md
@@ -1,4 +1,5 @@
 # paynani
+Messager d'élite : les paynani étaient les coureurs et messagers officiels de l'Empire aztèque.
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · [Español (ES)](README.es-ES.md) · **Français (FR)** · [Português (BR)](README.pt-BR.md)
 

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -1,4 +1,5 @@
 # paynani
+Mensageiro de elite: os paynani eram os corredores e mensageiros oficiais do Império Asteca.
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · [Español (ES)](README.es-ES.md) · [Français (FR)](README.fr-FR.md) · **Português (BR)**
 

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -292,9 +292,11 @@ Florentino sob `painani` e sob `painanj`, e registra `payna` como variante de
 `paina`: é a mesma palavra. Aqui se escreve `paynani`, que é a forma reconhecida
 por um leitor de língua espanhola.
 
-Vale reparar no que a palavra **não** diz. Ela não nomeia o cargo — o mensageiro
-imperial era um `titlantli`, "o enviado" — e sim a qualidade: ligeiro de pés. Diz
-o que ele faz, não o posto que ocupa.
+Foi dessa qualidade que veio o nome do ofício. O náuatle tinha dois modos de
+nomear o mensageiro imperial: `titlantli`, "o enviado", que o define pela
+incumbência que carrega, e `paynani`, que o define pelo modo como se move. O que
+ficou colado a esses homens foi o segundo — eram conhecidos pelo jeito de correr,
+não por quem os despachava.
 
 Os corredores trabalhavam em revezamento, com postos chamados `techialoyan`, e
 treinavam desde crianças. De tudo o que se conta sobre eles, há um detalhe que é


### PR DESCRIPTION
`6795055` agregó al README canónico, justo bajo el título, una línea que dice qué
es un paynani. Las cuatro traducciones se quedaron sin ella. Esta rama la
propaga.

Importa más de lo que su tamaño sugiere: es **la primera línea que alguien lee**.
Quien abriera el README en inglés o en francés se encontraba el nombre del
repositorio sin ninguna explicación, mientras el canónico sí la traía.

| Archivo | Línea |
|---|---|
| `README.md` (canónico, sin cambios) | Mensajero élite: Los paynani eran los corredores y mensajeros oficiales del Imperio Azteca. |
| `i18n/README.en-US.md` | Elite messenger: the paynani were the official runners and messengers of the Aztec Empire. |
| `i18n/README.es-ES.md` | Mensajero de élite: los paynani eran los corredores y mensajeros oficiales del Imperio Azteca. |
| `i18n/README.fr-FR.md` | Messager d'élite : les paynani étaient les coureurs et messagers officiels de l'Empire aztèque. |
| `i18n/README.pt-BR.md` | Mensageiro de elite: os paynani eram os corredores e mensageiros oficiais do Império Asteca. |

## Dos decisiones que conviene revisar

**«Mensajero de élite» en es-ES**, no «Mensajero élite» como el original. La
construcción con preposición es la natural en el español peninsular; el sentido
no cambia. Si se prefiere calcar el original literalmente, es un carácter.

**El sello de traducción sigue en `2b1fc9c`**, igual que en #18. Las traducciones
continúan atrasadas respecto de `main` en todo lo demás, y moverlo afirmaría que
están al día cuando no lo están.

## La tensión editorial, ya resuelta

La primera versión de esta rama solo propagaba la línea nueva, y dejaba señalado
que chocaba con la sección «De dónde viene el nombre»: el título decía que los
paynani **eran los corredores y mensajeros oficiales** del imperio, y doscientas
líneas más abajo la sección decía que la palabra **no nombra el cargo** —para eso
estaba `titlantli`— sino la cualidad. Un lector que bajara encontraba negado lo
que acababa de leer arriba.

Por indicación de Julian, el segundo commit la resuelve. Las dos afirmaciones
tienen respaldo, así que el arreglo no fue elegir una y tirar la otra, sino decir
cómo se relacionan: **de la cualidad salió el nombre del oficio.** El náhuatl
tenía las dos palabras disponibles —`titlantli`, que define al mensajero por el
encargo, y `paynani`, que lo define por cómo se mueve— y la que se quedó pegada a
esos hombres fue la segunda.

El dato de `titlantli` se conserva, porque es verdadero y explica el contraste,
pero deja de usarse para negar el título. Reescrito en los cinco idiomas.

## Verificación

`python3 scripts/test_docs.py` → **22 passed, 0 failed**. Solo documentación.

