### PR TITLE
Quita las rayas de la documentación pública para humanos

### DIFF
--- a/MAILBOX_SETUP.md
+++ b/MAILBOX_SETUP.md
@@ -80,7 +80,7 @@ Si tu agente corre bajo un harness, este archivo va en la carpeta workspace de
 ese harness, que es donde se le dice al agente que mire:
 
 ```bash
-cd ~/.hermes/workspace        # o ~/.openclaw/workspace, ~/.claude/workspace — tu harness
+cd ~/.hermes/workspace        # o ~/.openclaw/workspace, ~/.claude/workspace (tu harness)
 touch .env
 chmod 600 .env
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ describe en [`HERMES.md`](HERMES.md).
 
 Claude Code funciona distinto a los otros dos y conviene saberlo antes de
 empezar: nada fuera de una sesión de Claude Code puede hablarle, así que el
-correo no se le empuja al agente — el agente va por él. Su hook de inicio de
+correo no se le empuja al agente: el agente va por él. Su hook de inicio de
 sesión reproduce lo que llegó mientras no había nada corriendo y luego le pide al
 agente que arme una vigilancia para lo que llegue después. Nada puede obligarlo
 desde afuera, así que ese es el único paso que depende de que el agente haga lo
@@ -31,8 +31,8 @@ tercero son dos minutos para revisar que de verdad funciona.
 
 El agente necesita su propia cuenta de correo, y los datos de conexión de esa
 cuenta escritos en un archivo `.env`. **Si tu agente corre bajo un harness, ese
-archivo va en la carpeta workspace del propio harness** — `~/.hermes/workspace/.env`,
-`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env` —, que es donde se le
+archivo va en la carpeta workspace del propio harness** (`~/.hermes/workspace/.env`,
+`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env`), que es donde se le
 dice al agente que mire y de donde esta herramienta lo lee. En un host sin
 harness, ponlo dentro del clon.
 
@@ -124,8 +124,8 @@ Vale la pena saberlo antes de aceptar. El agente tiene instrucciones de reportar
 todo esto cuando termine, y puedes exigirle la lista:
 
 - Cuatro unidades de usuario de systemd, no una. Dos corren todo el tiempo y se
-  reinician solas si fallan —el escucha (`paynani-idle.service`) y el repartidor
-  (`paynani-dispatch.service`)—, y las otras dos rotan las bitácoras:
+  reinician solas si fallan: el escucha (`paynani-idle.service`) y el repartidor
+  (`paynani-dispatch.service`). Las otras dos rotan las bitácoras:
   `paynani-logrotate.timer`, que se activa solo, y `paynani-logrotate.service`,
   que es `static` porque la dispara el temporizador y no se habilita por su
   cuenta. En macOS son tres *LaunchAgents* equivalentes: `com.paynani.idle`,
@@ -174,8 +174,8 @@ quién**.
   aprobado no otorga nada, así que un desconocido no puede tomar prestada una
   dirección de la lista con un encabezado.
 - **Con una excepción que tú declaras:** los *notificadores*. Si tu equipo se
-  coordina en una plataforma que manda correo en nombre de la gente —GitHub,
-  Jira, Linear—, puedes declarar su dirección, el encabezado que trae el nombre
+  coordina en una plataforma que manda correo en nombre de la gente (GitHub,
+  Jira, Linear), puedes declarar su dirección, el encabezado que trae el nombre
   del autor, y contra qué columna de tu roster cotejarlo. Entonces esa
   notificación cuenta como correo de esa persona. Declarar un notificador amplía
   a quién le hace caso tu agente, igual que agregar una fila, y se decide igual:
@@ -251,17 +251,17 @@ elegir dónde clonar es cómo eliges dónde instalar.
   `~/.hermes/workspace/paynani` en Hermes Agent o
   `~/.claude/workspace/paynani` en Claude Code si no hay preferencia
 - Credenciales: el `.env` del workspace de tu harness cuando hay exactamente uno
-  —`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
-  `~/.claude/workspace/.env`— y `<clon>/.env` cuando no. Permisos `600`, ignorado
+  (`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
+  `~/.claude/workspace/.env`) y `<clon>/.env` cuando no. Permisos `600`, ignorado
   por git, nunca se sube. Se lee donde está y nunca se copia al clon: una segunda
   copia de una contraseña es una segunda cosa que se puede filtrar. Pregúntale a
   la instalación en vez de adivinar, con `python3 harness/paths.py env`
 - Estado y eventos: `<clon>/state/`
-- Secretos de ruta: `<clon>/hermes/`, permisos `600` — **solo en Hermes**; en
+- Secretos de ruta: `<clon>/hermes/`, permisos `600`. **Solo en Hermes**: en
   OpenClaw y en Claude Code ese directorio no existe y no falta nada
 - Unidades de usuario: `~/.config/systemd/user/paynani-idle.service`,
   `paynani-dispatch.service`, `paynani-logrotate.service` y
-  `paynani-logrotate.timer` — lo único que queda fuera del clon, porque systemd
+  `paynani-logrotate.timer`, lo único que queda fuera del clon, porque systemd
   no lee unidades de otro lado. En macOS, los tres `.plist` de
   `com.paynani.*` en `~/Library/LaunchAgents/`
 
@@ -288,8 +288,8 @@ Construido y verificado de extremo a extremo el 2026-08-09.
 ## De dónde viene el nombre
 
 **paynani** es náhuatl clásico y quiere decir, sin adornos, *«el que corre
-ligeramente»*: del verbo `paina` —«correr ligeramente», en el vocabulario de
-Alonso de Molina, 1571— más el sufijo `-ni`, que convierte una acción en quien la
+ligeramente»*: del verbo `paina` («correr ligeramente», en el vocabulario de
+Alonso de Molina, 1571) más el sufijo `-ni`, que convierte una acción en quien la
 hace de oficio.
 
 La grafía varía porque los frailes del siglo XVI escribieron el náhuatl con las
@@ -302,7 +302,7 @@ lector hispanohablante reconoce.
 De esa cualidad salió el nombre del oficio. El náhuatl tenía dos maneras de
 nombrar al mensajero imperial: `titlantli`, «el enviado», que lo define por el
 encargo que lleva, y `paynani`, que lo define por cómo se mueve. La que se quedó
-pegada a esos hombres fue la segunda — se los conocía por la manera de correr, no
+pegada a esos hombres fue la segunda: se los conocía por la manera de correr, no
 por quién los mandaba.
 
 Los corredores trabajaban en relevos, con postas llamadas `techialoyan`, y se
@@ -315,8 +315,8 @@ palacio. Eso es lo que hace aquí la etiqueta `roster`: el sobre dice cómo reci
 la noticia antes de que se lea.
 
 De la misma raíz viene Paynal, el que corría en lugar de Huitzilopochtli en las
-procesiones. El Códice Florentino lo explica en tres palabras —*«el delegado, el
-sustituto, el suplente»*— porque «lo apuraban, lo hacían correr». Un agente que va
+procesiones. El Códice Florentino lo explica en tres palabras, *«el delegado, el
+sustituto, el suplente»*, porque «lo apuraban, lo hacían correr». Un agente que va
 por el correo en lugar de quien no puede estar en todas partes.
 
 <sub>Fuentes: [Gran Diccionario Náhuatl](https://gdn.iib.unam.mx/diccionario/painani/233892)

--- a/UNINSTALL.md
+++ b/UNINSTALL.md
@@ -116,8 +116,8 @@ pgrep -af idle_listener.py                           # no debe salir nada
 
 **Primero averigua dónde están, porque en la mayoría de las instalaciones no
 están en el clon.** Cuando el host tiene un harness, la contraseña del buzón vive
-en el `.env` del workspace de ese harness —`~/.openclaw/workspace/.env`,
-`~/.hermes/workspace/.env`, `~/.claude/workspace/.env`— y `<clon>/.env` ni
+en el `.env` del workspace de ese harness (`~/.openclaw/workspace/.env`,
+`~/.hermes/workspace/.env`, `~/.claude/workspace/.env`) y `<clon>/.env` ni
 siquiera existe. Un `rm -f .env` desde el clon no borraría nada en ese caso, y te
 dejaría creyendo que borraste la contraseña.
 
@@ -129,8 +129,8 @@ python3 harness/paths.py env
 
 Si lo que responde está **fuera** del clon, es un archivo del harness y no de
 esta herramienta: otras cosas lo usan y **no se borra entero.** Quita de ahí
-únicamente las claves que agregó esta instalación —las `PAYNANI_*`, y las
-`AGENT_EMAIL_*` si fueron para este buzón y ninguna otra cosa las lee— y deja el
+únicamente las claves que agregó esta instalación (las `PAYNANI_*`, y las
+`AGENT_EMAIL_*` si fueron para este buzón y ninguna otra cosa las lee) y deja el
 resto del archivo en pie. Lo mismo aplica si es un enlace simbólico: **no borres
 lo que apunta.**
 

--- a/i18n/MAILBOX_SETUP.en-US.md
+++ b/i18n/MAILBOX_SETUP.en-US.md
@@ -80,7 +80,7 @@ If your agent runs under a harness, this file belongs in that harness's own
 workspace folder, which is where the agent is told to look:
 
 ```bash
-cd ~/.hermes/workspace        # or ~/.openclaw/workspace, ~/.claude/workspace — your harness
+cd ~/.hermes/workspace        # or ~/.openclaw/workspace, ~/.claude/workspace (your harness)
 touch .env
 chmod 600 .env
 ```
@@ -132,4 +132,4 @@ that is not a step in any of these instructions.
 
 ---
 
-<sub>Translated from [`MAILBOX_SETUP.md`](../MAILBOX_SETUP.md) at commit `a7b1040`, which is the source of truth. Where this contradicts the Spanish (MX) original, **the Spanish wins** — and say so, because it means this translation has fallen behind.</sub>
+<sub>Translated from [`MAILBOX_SETUP.md`](../MAILBOX_SETUP.md) at commit `a7b1040`, which is the source of truth. Where this contradicts the Spanish (MX) original, **the Spanish wins**, and say so, because it means this translation has fallen behind.</sub>

--- a/i18n/MAILBOX_SETUP.es-ES.md
+++ b/i18n/MAILBOX_SETUP.es-ES.md
@@ -82,7 +82,7 @@ Si tu agente corre bajo un harness, este fichero va en la carpeta workspace de
 ese harness, que es donde se le dice al agente que mire:
 
 ```bash
-cd ~/.hermes/workspace        # o ~/.openclaw/workspace, ~/.claude/workspace — tu harness
+cd ~/.hermes/workspace        # o ~/.openclaw/workspace, ~/.claude/workspace (tu harness)
 touch .env
 chmod 600 .env
 ```

--- a/i18n/MAILBOX_SETUP.fr-FR.md
+++ b/i18n/MAILBOX_SETUP.fr-FR.md
@@ -84,7 +84,7 @@ Si votre agent tourne sous un harness, ce fichier appartient au dossier workspac
 de ce harness, c'est là qu'on demande à l'agent de regarder :
 
 ```bash
-cd ~/.hermes/workspace        # ou ~/.openclaw/workspace, ~/.claude/workspace — votre harness
+cd ~/.hermes/workspace        # ou ~/.openclaw/workspace, ~/.claude/workspace (votre harness)
 touch .env
 chmod 600 .env
 ```

--- a/i18n/MAILBOX_SETUP.pt-BR.md
+++ b/i18n/MAILBOX_SETUP.pt-BR.md
@@ -79,7 +79,7 @@ Se o seu agente roda sob um harness, este arquivo fica na pasta workspace desse
 harness, que é onde o agente é instruído a olhar:
 
 ```bash
-cd ~/.hermes/workspace        # ou ~/.openclaw/workspace, ~/.claude/workspace — o seu harness
+cd ~/.hermes/workspace        # ou ~/.openclaw/workspace, ~/.claude/workspace (o seu harness)
 touch .env
 chmod 600 .env
 ```

--- a/i18n/README.en-US.md
+++ b/i18n/README.en-US.md
@@ -14,7 +14,7 @@ in [`HERMES.md`](../HERMES.md).
 
 Claude Code works differently from the other two and it is worth knowing before
 you start: nothing outside a Claude Code session can speak into it, so mail is
-not pushed to the agent — the agent comes and gets it. Its session-start hook
+not pushed to the agent: the agent comes and gets it. Its session-start hook
 replays what arrived while nothing was running and then asks the agent to arm a
 watch for what lands next. Nothing can enforce that from outside, so it is the
 one step that rests on the agent doing as it is told. See
@@ -31,8 +31,8 @@ minutes of checking that it really works.
 
 The agent needs an email account of its own and the connection details for it,
 written into a `.env` file. **If your agent runs under a harness, that file
-belongs in the harness's own workspace folder** — `~/.hermes/workspace/.env`,
-`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env` — which is where the
+belongs in the harness's own workspace folder** (`~/.hermes/workspace/.env`,
+`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env`), which is where the
 agent is told to look and where this tool reads it from. On a host with no
 harness, put it in the clone.
 
@@ -145,14 +145,14 @@ Worth knowing before you agree to it. The agent is instructed to report all of
 this back when it finishes, and you can hold it to the list:
 
 - Four supervised user units, not one. Two run continuously and restart on
-  failure — the listener (`paynani-idle.service`) and the dispatcher
-  (`paynani-dispatch.service`) — and two rotate the logs:
+  failure: the listener (`paynani-idle.service`) and the dispatcher
+  (`paynani-dispatch.service`). Two more rotate the logs:
   `paynani-logrotate.timer`, which enables itself, and
   `paynani-logrotate.service`, which is `static` because the timer starts it and
   it is never enabled on its own. On macOS these are three equivalent
   LaunchAgents: `com.paynani.idle`, `com.paynani.dispatch` and
   `com.paynani.logrotate`
-- A credentials file at mode `600` — your harness's workspace `.env` if you keep
+- A credentials file at mode `600`: your harness's workspace `.env` if you keep
   one there, otherwise `.env` inside the clone. It is read where it lies and
   never copied
 - Log and state files under `state/` inside the clone
@@ -269,24 +269,24 @@ to clone is how you choose where to install.
   `~/.claude/workspace/paynani` on Claude Code, if you have no preference;
   every generated path is resolved from where the scripts are, so an existing
   clone needs no move.
-- Secret env: your harness's workspace `.env` when there is exactly one —
-  `~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
-  `~/.claude/workspace/.env` — and `<clone>/.env` when there is not. Mode `600`,
+- Secret env: your harness's workspace `.env` when there is exactly one
+  (`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
+  `~/.claude/workspace/.env`), and `<clone>/.env` when there is not. Mode `600`,
   ignored by git, never committed. It is read where it lies and never copied into
   the clone: a second copy of a password is a second thing that can leak. Ask the
   install rather than guessing, with `python3 harness/paths.py env`.
 - Event state: `<clone>/state/`
-- Route secrets: `<clone>/hermes/`, mode `600` — **Hermes only**; on OpenClaw
+- Route secrets: `<clone>/hermes/`, mode `600`. **Hermes only**: on OpenClaw
   and Claude Code that directory does not exist and nothing is missing
 - User units: `~/.config/systemd/user/paynani-idle.service`,
   `paynani-dispatch.service`, `paynani-logrotate.service` and
   `paynani-logrotate.timer` on Ubuntu, or the three `com.paynani.*.plist` files
-  in `~/Library/LaunchAgents/` on macOS — the only thing outside the clone,
+  in `~/Library/LaunchAgents/` on macOS. This is the only thing outside the clone,
   because systemd does not read units from anywhere else
 
 Secrets inside a git working tree are kept out of `git status` by `.gitignore`,
 and `scripts/install.sh` refuses to write if any of them is tracked or unignored.
-`git clean -xdf` still deletes them all — use `git clean -df` on a live install.
+`git clean -xdf` still deletes them all, so use `git clean -df` on a live install.
 
 ## The property everything serves
 
@@ -304,8 +304,8 @@ Built and verified end to end on 2026-08-09.
 ## Where the name comes from
 
 **paynani** is Classical Nahuatl, and it means something plainer than it sounds:
-*"the one who runs lightly."* From the verb `paina` — "correr ligeramente," in
-Alonso de Molina's 1571 vocabulary — plus the suffix `-ni`, which turns an action
+*"the one who runs lightly."* From the verb `paina` ("correr ligeramente," in
+Alonso de Molina's 1571 vocabulary) plus the suffix `-ni`, which turns an action
 into the one who does it for a living.
 
 The spelling varies because sixteenth-century friars wrote Nahuatl with the
@@ -318,7 +318,7 @@ Spanish-speaking reader recognizes.
 The name of the office grew out of that quality. Nahuatl had two ways to name
 the imperial messenger: `titlantli`, "the one sent," which defines him by the
 errand he carries, and `paynani`, which defines him by how he moves. The one that
-stuck to these men was the second — they were known for the way they ran, not for
+stuck to these men was the second: they were known for the way they ran, not for
 who dispatched them.
 
 The runners worked in relays, through staging posts called `techialoyan`, and
@@ -331,8 +331,8 @@ and club, meant a victory, and crowds followed him to the palace. That is what t
 reads it.
 
 The same root gave Paynal, who ran in Huitzilopochtli's place during processions.
-The Florentine Codex explains him in three words — *"the delegate, the substitute,
-the deputy"* — because "they pressed him on quickly; he was made to hasten." An
+The Florentine Codex explains him in three words, *"the delegate, the substitute,
+the deputy"*, because "they pressed him on quickly; he was made to hasten." An
 agent that goes for the mail on behalf of whoever cannot be everywhere at once.
 
 <sub>Sources: [Gran Diccionario Náhuatl](https://gdn.iib.unam.mx/diccionario/painani/233892)
@@ -341,4 +341,4 @@ agent that goes for the mail on behalf of whoever cannot be everywhere at once.
 
 ---
 
-<sub>Translated from [`README.md`](../README.md) at commit `2b1fc9c`, which is the source of truth. Where this contradicts the Spanish (MX) original, **the Spanish wins** — and say so, because it means this translation has fallen behind.</sub>
+<sub>Translated from [`README.md`](../README.md) at commit `2b1fc9c`, which is the source of truth. Where this contradicts the Spanish (MX) original, **the Spanish wins**, and say so, because it means this translation has fallen behind.</sub>

--- a/i18n/README.es-ES.md
+++ b/i18n/README.es-ES.md
@@ -14,7 +14,7 @@ en [`HERMES.md`](../HERMES.md).
 
 Claude Code funciona de forma distinta a los otros dos y conviene saberlo antes
 de empezar: nada fuera de una sesión de Claude Code puede hablarle, de modo que
-el correo no se le empuja al agente — el agente va a por él. Su hook de inicio de
+el correo no se le empuja al agente: el agente va a por él. Su hook de inicio de
 sesión reproduce lo que llegó mientras no había nada en marcha y después pide al
 agente que arme una vigilancia para lo que llegue a continuación. Nada puede
 imponerlo desde fuera, así que ese es el único paso que depende de que el agente
@@ -31,8 +31,8 @@ tercero son dos minutos para comprobar que funciona de verdad.
 
 El agente necesita su propia cuenta de correo, y los datos de conexión de esa
 cuenta escritos en un fichero `.env`. **Si tu agente corre bajo un harness, ese
-fichero va en la carpeta workspace del propio harness** — `~/.hermes/workspace/.env`,
-`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env` —, que es donde se le
+fichero va en la carpeta workspace del propio harness** (`~/.hermes/workspace/.env`,
+`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env`), que es donde se le
 dice al agente que mire y de donde esta herramienta lo lee. En un host sin
 harness, ponlo dentro del clon.
 
@@ -124,8 +124,8 @@ Merece la pena saberlo antes de aceptarlo. El agente tiene instrucciones de
 informarte de todo esto cuando termine, y puedes exigirle la lista:
 
 - Cuatro unidades de usuario de systemd, no una. Dos se ejecutan continuamente y
-  se reinician solas si fallan —el escucha (`paynani-idle.service`) y el
-  repartidor (`paynani-dispatch.service`)—, y las otras dos rotan los registros:
+  se reinician solas si fallan: el escucha (`paynani-idle.service`) y el
+  repartidor (`paynani-dispatch.service`). Las otras dos rotan los registros:
   `paynani-logrotate.timer`, que se activa solo, y `paynani-logrotate.service`,
   que es `static` porque lo dispara el temporizador y no se habilita por su
   cuenta. En macOS son tres *LaunchAgents* equivalentes: `com.paynani.idle`,
@@ -246,17 +246,17 @@ elegir dónde clonar es cómo eliges dónde instalar.
   `~/.hermes/workspace/paynani` en Hermes Agent o
   `~/.claude/workspace/paynani` en Claude Code si no hay preferencia
 - Credenciales: el `.env` del workspace de tu harness cuando hay exactamente uno
-  —`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
-  `~/.claude/workspace/.env`— y `<clon>/.env` cuando no. Permisos `600`, ignorado
+  (`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
+  `~/.claude/workspace/.env`) y `<clon>/.env` cuando no. Permisos `600`, ignorado
   por git, nunca se sube. Se lee donde está y nunca se copia al clon: una segunda
   copia de una contraseña es una segunda cosa que se puede filtrar. Pregúntale a
   la instalación en vez de adivinar, con `python3 harness/paths.py env`
 - Estado y eventos: `<clon>/state/`
-- Secretos de ruta: `<clon>/hermes/`, permisos `600` — **solo en Hermes**; en
+- Secretos de ruta: `<clon>/hermes/`, permisos `600`. **Solo en Hermes**: en
   OpenClaw y en Claude Code ese directorio no existe y no falta nada
 - Unidades de usuario: `~/.config/systemd/user/paynani-idle.service`,
   `paynani-dispatch.service`, `paynani-logrotate.service` y
-  `paynani-logrotate.timer` — lo único que queda fuera del clon, porque systemd
+  `paynani-logrotate.timer`, lo único que queda fuera del clon, porque systemd
   no lee unidades de otro sitio. En macOS, los tres `.plist` de
   `com.paynani.*` en `~/Library/LaunchAgents/`
 
@@ -283,8 +283,8 @@ Construido y verificado de extremo a extremo el 2026-08-09.
 ## De dónde viene el nombre
 
 **paynani** es náhuatl clásico y significa, sin adornos, *«el que corre
-ligeramente»*: del verbo `paina` —«correr ligeramente», en el vocabulario de
-Alonso de Molina, 1571— más el sufijo `-ni`, que convierte una acción en quien la
+ligeramente»*: del verbo `paina` («correr ligeramente», en el vocabulario de
+Alonso de Molina, 1571) más el sufijo `-ni`, que convierte una acción en quien la
 hace de oficio.
 
 La grafía varía porque los frailes del siglo XVI escribieron el náhuatl con las
@@ -297,7 +297,7 @@ lector hispanohablante reconoce.
 De esa cualidad salió el nombre del oficio. El náhuatl tenía dos maneras de
 nombrar al mensajero imperial: `titlantli`, «el enviado», que lo define por el
 encargo que lleva, y `paynani`, que lo define por cómo se mueve. La que se quedó
-pegada a esos hombres fue la segunda — se los conocía por la manera de correr, no
+pegada a esos hombres fue la segunda: se los conocía por la manera de correr, no
 por quién los mandaba.
 
 Los corredores trabajaban por relevos, con postas llamadas `techialoyan`, y se
@@ -310,8 +310,8 @@ lo que hace aquí la etiqueta `roster`: el sobre dice cómo recibir la noticia a
 de que se lea.
 
 De la misma raíz viene Paynal, el que corría en lugar de Huitzilopochtli en las
-procesiones. El Códice Florentino lo explica en tres palabras —*«el delegado, el
-sustituto, el suplente»*— porque «lo apremiaban, lo hacían correr». Un agente que
+procesiones. El Códice Florentino lo explica en tres palabras, *«el delegado, el
+sustituto, el suplente»*, porque «lo apremiaban, lo hacían correr». Un agente que
 va a por el correo en lugar de quien no puede estar en todas partes.
 
 <sub>Fuentes: [Gran Diccionario Náhuatl](https://gdn.iib.unam.mx/diccionario/painani/233892)

--- a/i18n/README.fr-FR.md
+++ b/i18n/README.fr-FR.md
@@ -14,7 +14,7 @@ authentifiées comme décrit dans [`HERMES.md`](../HERMES.md).
 
 Claude Code fonctionne autrement que les deux autres, et mieux vaut le savoir
 avant de commencer : rien à l'extérieur d'une session Claude Code ne peut lui
-parler, donc le courrier n'est pas poussé vers l'agent — c'est l'agent qui vient
+parler, donc le courrier n'est pas poussé vers l'agent : c'est l'agent qui vient
 le chercher. Son hook de démarrage de session rejoue ce qui est arrivé pendant
 qu'aucune session ne tournait, puis demande à l'agent d'armer une surveillance
 pour la suite. Rien ne peut l'imposer de l'extérieur : c'est la seule étape qui
@@ -33,9 +33,9 @@ vraiment.
 
 L'agent a besoin de son propre compte de messagerie, et des paramètres de
 connexion de ce compte écrits dans un fichier `.env`. **Si votre agent tourne sous
-un harness, ce fichier appartient au dossier workspace de ce harness** —
-`~/.hermes/workspace/.env`, `~/.openclaw/workspace/.env`,
-`~/.claude/workspace/.env` —, c'est là qu'on demande
+un harness, ce fichier appartient au dossier workspace de ce harness**
+(`~/.hermes/workspace/.env`, `~/.openclaw/workspace/.env`,
+`~/.claude/workspace/.env`), c'est là qu'on demande
 à l'agent de regarder et c'est de là que cet outil le lit. Sur un hôte sans
 harness, placez-le au sein du clone.
 
@@ -133,9 +133,9 @@ Bon à savoir avant d'accepter. L'agent a pour consigne de vous rendre compte de
 tout ceci en terminant, et vous pouvez lui en demander la liste :
 
 - Quatre unités utilisateur systemd, pas une. Deux tournent en continu et
-  redémarrent d'elles-mêmes en cas d'échec — l'écouteur
-  (`paynani-idle.service`) et le distributeur (`paynani-dispatch.service`) — et
-  les deux autres font tourner les journaux : `paynani-logrotate.timer`, qui
+  redémarrent d'elles-mêmes en cas d'échec : l'écouteur
+  (`paynani-idle.service`) et le distributeur (`paynani-dispatch.service`). Les
+  deux autres font tourner les journaux : `paynani-logrotate.timer`, qui
   s'active seul, et `paynani-logrotate.service`, qui est `static` parce que le
   minuteur le déclenche et qu'il ne s'active pas de lui-même. Sur macOS, ce sont
   trois *LaunchAgents* équivalents : `com.paynani.idle`, `com.paynani.dispatch`
@@ -255,24 +255,24 @@ choisir où cloner, c'est choisir où installer.
   `~/.hermes/workspace/paynani` sur Hermes Agent ou
   `~/.claude/workspace/paynani` sur Claude Code à défaut de préférence
 - Identifiants : le `.env` du workspace de votre harness lorsqu'il y en a
-  exactement un — `~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
-  `~/.claude/workspace/.env` — et `<clone>/.env` sinon. En `600`, ignoré par git,
+  exactement un (`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
+  `~/.claude/workspace/.env`), et `<clone>/.env` sinon. En `600`, ignoré par git,
   jamais versionné. Il est lu où il se trouve et jamais copié dans le clone : une
   seconde copie d'un mot de passe est une seconde chose qui peut fuiter.
   Demandez-le à l'installation plutôt que de le deviner, avec
   `python3 harness/paths.py env`
 - État et événements : `<clone>/state/`
-- Secrets de route : `<clone>/hermes/`, en `600` — **uniquement sous Hermes** ;
+- Secrets de route : `<clone>/hermes/`, en `600`. **Uniquement sous Hermes** :
   sous OpenClaw et Claude Code ce répertoire n'existe pas et rien ne manque
 - Unités utilisateur : `~/.config/systemd/user/paynani-idle.service`,
   `paynani-dispatch.service`, `paynani-logrotate.service` et
-  `paynani-logrotate.timer` — la seule chose hors du clone, car systemd ne lit
+  `paynani-logrotate.timer`, la seule chose hors du clone, car systemd ne lit
   les unités de nulle part ailleurs. Sur macOS, les trois `.plist`
   `com.paynani.*` dans `~/Library/LaunchAgents/`
 
 `.gitignore` garde les secrets hors de `git status`, et `scripts/install.sh`
 refuse d'écrire si l'un d'eux est versionné ou non ignoré. Ce que cela n'empêche
-pas : `git clean -xdf` supprime les fichiers ignorés — sur une installation vivante,
+pas : `git clean -xdf` supprime les fichiers ignorés ; sur une installation vivante,
 c'est le mot de passe de la boîte, les deux secrets de route, la liste des
 destinataires et le dernier UID. Utilisez `git clean -df`.
 
@@ -293,8 +293,8 @@ Construit et vérifié de bout en bout le 09/08/2026.
 ## D'où vient le nom
 
 **paynani** est du nahuatl classique et signifie, sans ornement, *« celui qui court
-légèrement »* : du verbe `paina` — « correr ligeramente », dans le vocabulaire
-d'Alonso de Molina, 1571 — auquel s'ajoute le suffixe `-ni`, qui transforme une
+légèrement »* : du verbe `paina` (« correr ligeramente », dans le vocabulaire
+d'Alonso de Molina, 1571) auquel s'ajoute le suffixe `-ni`, qui transforme une
 action en celui qui l'exerce comme métier.
 
 La graphie varie parce que les religieux du XVIe siècle ont écrit le nahuatl avec
@@ -307,7 +307,7 @@ lecteur hispanophone reconnaît.
 C'est de cette qualité qu'est venu le nom du métier. Le nahuatl avait deux façons
 de nommer le messager impérial : `titlantli`, « celui qu'on envoie », qui le
 définit par la mission qu'il porte, et `paynani`, qui le définit par sa manière de
-se déplacer. C'est la seconde qui est restée attachée à ces hommes — on les
+se déplacer. C'est la seconde qui est restée attachée à ces hommes : on les
 connaissait à leur façon de courir, non à celui qui les envoyait.
 
 Les coureurs travaillaient par relais, avec des postes appelés `techialoyan`, et
@@ -321,8 +321,8 @@ l'étiquette `roster` : l'enveloppe dit comment recevoir la nouvelle avant qu'on
 la lise.
 
 De la même racine vient Paynal, celui qui courait à la place de Huitzilopochtli
-lors des processions. Le Codex de Florence l'explique en trois mots — *« le
-délégué, le substitut, le suppléant »* — parce qu'« on le pressait, on le faisait
+lors des processions. Le Codex de Florence l'explique en trois mots, *« le
+délégué, le substitut, le suppléant »*, parce qu'« on le pressait, on le faisait
 courir ». Un agent qui va chercher le courrier à la place de qui ne peut être
 partout à la fois.
 

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -14,7 +14,7 @@ Code. Quem opera o Hermes configura duas rotas autenticadas conforme descrito em
 
 O Claude Code funciona de um jeito diferente dos outros dois, e vale saber disso
 antes de começar: nada fora de uma sessão do Claude Code consegue falar com ela,
-então o e-mail não é empurrado até o agente — o agente é que vai buscá-lo. O hook
+então o e-mail não é empurrado até o agente: o agente é que vai buscá-lo. O hook
 de início de sessão reproduz o que chegou enquanto nada estava rodando e então
 pede que o agente arme uma vigilância para o que chegar depois. Nada consegue
 impor isso de fora, então esse é o único passo que depende de o agente fazer o
@@ -31,8 +31,8 @@ dois minutos conferindo que funciona de verdade.
 
 O agente precisa de uma conta de e-mail própria, e dos dados de conexão dessa
 conta escritos em um arquivo `.env`. **Se o seu agente roda sob um harness, esse
-arquivo fica na pasta workspace do próprio harness** — `~/.hermes/workspace/.env`,
-`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env` —, que é onde o agente é
+arquivo fica na pasta workspace do próprio harness** (`~/.hermes/workspace/.env`,
+`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env`), que é onde o agente é
 instruído a olhar e de onde esta ferramenta o lê. Em um host sem harness,
 coloque-o dentro do clone.
 
@@ -124,8 +124,8 @@ Vale saber antes de aceitar. O agente tem instrução de relatar tudo isso ao
 terminar, e você pode cobrar a lista:
 
 - Quatro units de usuário do systemd, não uma. Duas rodam continuamente e
-  reiniciam sozinhas em caso de falha — o ouvinte (`paynani-idle.service`) e o
-  despachante (`paynani-dispatch.service`) — e as outras duas rotacionam os
+  reiniciam sozinhas em caso de falha: o ouvinte (`paynani-idle.service`) e o
+  despachante (`paynani-dispatch.service`). As outras duas rotacionam os
   registros: `paynani-logrotate.timer`, que se ativa sozinho, e
   `paynani-logrotate.service`, que é `static` porque o timer o dispara e ele não
   se habilita por conta própria. No macOS são três *LaunchAgents* equivalentes:
@@ -242,19 +242,19 @@ escolher onde clonar é como você escolhe onde instalar.
 - Repositório: em qualquer lugar; `~/.openclaw/workspace/paynani` no OpenClaw,
   `~/.hermes/workspace/paynani` no Hermes Agent ou
   `~/.claude/workspace/paynani` no Claude Code se não houver preferência
-- Credenciais: o `.env` do workspace do seu harness quando há exatamente um —
-  `~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
-  `~/.claude/workspace/.env` — e `<clone>/.env` quando não. Permissão `600`,
+- Credenciais: o `.env` do workspace do seu harness quando há exatamente um
+  (`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
+  `~/.claude/workspace/.env`), e `<clone>/.env` quando não. Permissão `600`,
   ignorado pelo git, nunca versionado. Ele é lido onde está e nunca é copiado
   para o clone: uma segunda cópia de uma senha é uma segunda coisa que pode
   vazar. Pergunte à instalação em vez de adivinhar, com
   `python3 harness/paths.py env`
 - Estado e eventos: `<clone>/state/`
-- Segredos de rota: `<clone>/hermes/`, permissão `600` — **apenas no Hermes**; no
+- Segredos de rota: `<clone>/hermes/`, permissão `600`. **Apenas no Hermes**: no
   OpenClaw e no Claude Code esse diretório não existe e não falta nada
 - Units de usuário: `~/.config/systemd/user/paynani-idle.service`,
   `paynani-dispatch.service`, `paynani-logrotate.service` e
-  `paynani-logrotate.timer` — a única coisa fora do clone, porque o systemd não
+  `paynani-logrotate.timer`, a única coisa fora do clone, porque o systemd não
   lê units de outro lugar. No macOS, os três `.plist` de `com.paynani.*` em
   `~/Library/LaunchAgents/`
 
@@ -281,8 +281,8 @@ Construído e verificado de ponta a ponta em 09/08/2026.
 ## De onde vem o nome
 
 **paynani** é náuatle clássico e quer dizer, sem enfeite, *"aquele que corre
-ligeiro"*: do verbo `paina` — "correr ligeramente", no vocabulário de Alonso de
-Molina, 1571 — mais o sufixo `-ni`, que transforma uma ação em quem a exerce como
+ligeiro"*: do verbo `paina` ("correr ligeramente", no vocabulário de Alonso de
+Molina, 1571) mais o sufixo `-ni`, que transforma uma ação em quem a exerce como
 ofício.
 
 A grafia varia porque os frades do século XVI escreveram o náuatle com as
@@ -295,7 +295,7 @@ por um leitor de língua espanhola.
 Foi dessa qualidade que veio o nome do ofício. O náuatle tinha dois modos de
 nomear o mensageiro imperial: `titlantli`, "o enviado", que o define pela
 incumbência que carrega, e `paynani`, que o define pelo modo como se move. O que
-ficou colado a esses homens foi o segundo — eram conhecidos pelo jeito de correr,
+ficou colado a esses homens foi o segundo: eram conhecidos pelo jeito de correr,
 não por quem os despachava.
 
 Os corredores trabalhavam em revezamento, com postos chamados `techialoyan`, e
@@ -308,8 +308,8 @@ que a etiqueta `roster` faz aqui: o envelope diz como receber a notícia antes q
 alguém a leia.
 
 Da mesma raiz vem Paynal, aquele que corria no lugar de Huitzilopochtli nas
-procissões. O Códice Florentino o explica em três palavras — *"o delegado, o
-substituto, o suplente"* — porque "o apressavam, faziam-no correr". Um agente que
+procissões. O Códice Florentino o explica em três palavras, *"o delegado, o
+substituto, o suplente"*, porque "o apressavam, faziam-no correr". Um agente que
 vai buscar o correio no lugar de quem não pode estar em toda parte.
 
 <sub>Fontes: [Gran Diccionario Náhuatl](https://gdn.iib.unam.mx/diccionario/painani/233892)

--- a/i18n/UNINSTALL.en-US.md
+++ b/i18n/UNINSTALL.en-US.md
@@ -113,8 +113,8 @@ pgrep -af idle_listener.py                           # expect nothing
 
 **Find out where they are first, because on most installs they are not in the
 clone.** When the host has a harness, the mailbox password lives in that
-harness's workspace `.env` — `~/.openclaw/workspace/.env`,
-`~/.hermes/workspace/.env`, `~/.claude/workspace/.env` — and `<clone>/.env` does
+harness's workspace `.env` (`~/.openclaw/workspace/.env`,
+`~/.hermes/workspace/.env`, `~/.claude/workspace/.env`) and `<clone>/.env` does
 not exist at all. An `rm -f .env` from the clone would delete nothing in that
 case, and leave you believing you had removed the password.
 
@@ -126,8 +126,8 @@ python3 harness/paths.py env
 
 If what it answers is **outside** the clone, that file belongs to the harness and
 not to this tool: other things use it and it is **not deleted whole.** Remove
-only the keys this install added — the `PAYNANI_*` ones, and the `AGENT_EMAIL_*`
-ones if they were for this mailbox and nothing else reads them — and leave the
+only the keys this install added (the `PAYNANI_*` ones, and the `AGENT_EMAIL_*`
+ones if they were for this mailbox and nothing else reads them) and leave the
 rest of the file standing. The same holds for a symlink: **do not delete what it
 points at.**
 
@@ -254,4 +254,4 @@ Four clean results and the machine is back where it started.
 
 ---
 
-<sub>Translated from [`UNINSTALL.md`](../UNINSTALL.md) at commit `2b1fc9c`, which is the source of truth. Where this contradicts the Spanish (MX) original, **the Spanish wins** — and say so, because it means this translation has fallen behind.</sub>
+<sub>Translated from [`UNINSTALL.md`](../UNINSTALL.md) at commit `2b1fc9c`, which is the source of truth. Where this contradicts the Spanish (MX) original, **the Spanish wins**, and say so, because it means this translation has fallen behind.</sub>


### PR DESCRIPTION
Las **91 rayas** (`—`) que había en los doce documentos que lee una persona
quedan reescritas. Verificado: `grep -c '—'` devuelve `0` en los doce, y tampoco
quedaron rayas cortas (`–`) escondidas.

## Cómo se quitaron

No se sustituyeron por un signo equivalente. Una raya hace trabajos distintos
según la frase, y cambiarlas todas por el mismo signo habría dejado el texto peor
de como estaba. Cada una se resolvió por lo que hacía:

| Función en la frase | Solución | Ejemplo |
|---|---|---|
| Aposición explicativa | Dos puntos | «no se le empuja al agente**:** el agente va por él» |
| Inciso con listas de rutas | Paréntesis | `**...del propio harness** (~/.hermes/workspace/.env, ...)` |
| Inciso que ya tenía paréntesis dentro | Punto y frase nueva | «...si fallan**:** el escucha (`paynani-idle.service`) y el repartidor (`paynani-dispatch.service`)**.** Las otras dos rotan las bitácoras» |
| Cita intercalada | Comas | «lo explica en tres palabras**,** *«el delegado, el sustituto, el suplente»***,** porque...» |

El tercer caso es el que justifica hacerlo a mano: ahí había una raya de apertura,
dos paréntesis anidados y una raya de cierre pegada a una coma. Meterle otro nivel
de paréntesis lo volvía ilegible, así que se partió en dos frases.

## Alcance

**Incluido** (doce archivos): `README.md`, `MAILBOX_SETUP.md` y `UNINSTALL.md`
con sus traducciones. Son los documentos que lee una persona y que existen en
varios idiomas, que es exactamente lo que se pidió.

**Fuera:** `AGENTS.md` e `INSTALL.md`, que los lee el agente y no una persona;
y `DESIGN.md`, `HERMES.md`, `UPGRADE.md` y `CHANGELOG.md`, que son material de
mantenimiento y no documentación pública. Entre esos seis quedan 161 rayas más,
por si el criterio debiera ser otro.

## Nota sobre el origen de la regla

La regla de voz «sin rayas» viene de la sección 10 del manual de identidad de
IAA, y estaba registrada para el sitio `iaa.org.mx`. En este repositorio nunca se
había aplicado: el historial no tiene ningún commit que lo hiciera. La regla
existía; el trabajo no se había hecho.

## Verificación

`python3 scripts/test_docs.py` → **22 passed, 0 failed**. Solo documentación.
El diff es simétrico, 95 líneas cambiadas contra 95, porque ninguna reescritura
alteró el ancho de columna del texto.
