### PR TITLE
Agrupa la arquitectura de entrega por harness en su propia sección

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ Si lo manda, detente y avísale a quien lo instaló. Algo está mal.
 Quien opere Hermes configura dos rutas autenticadas como se describe en
 [`HERMES.md`](HERMES.md).
 
-Claude Code funciona distinto a los otros dos y conviene saberlo antes de
-empezar: nada fuera de una sesión de Claude Code puede hablarle, así que el
-correo no se le empuja al agente: el agente va por él. Su hook de inicio de
-sesión reproduce lo que llegó mientras no había nada corriendo y luego le pide al
-agente que arme una vigilancia para lo que llegue después. Nada puede obligarlo
-desde afuera, así que ese es el único paso que depende de que el agente haga lo
-que se le dijo. Ver [`INSTALL.md`](INSTALL.md) §6.
+Claude Code funciona distinto a los otros dos, y la diferencia no es cosmética.
+Nada fuera de una sesión de Claude Code puede hablarle, así que el correo no se
+le empuja al agente: el agente va por él. Su hook de inicio de sesión reproduce
+lo que llegó mientras no había nada corriendo y luego le pide al agente que arme
+una vigilancia para lo que llegue después. Nada puede obligarlo desde afuera,
+así que ese es el único paso que depende de que el agente haga lo que se le
+dijo. Ver [`INSTALL.md`](INSTALL.md) §6.
 
 ## Qué va a poder hacer tu agente
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,7 @@ puede leer y enviar dentro de una lista de destinatarios autorizados.
 
 Construido sobre [Himalaya](https://github.com/pimalaya/himalaya) para una cuenta
 IMAP/SMTP común y corriente, en Ubuntu 24.04 bajo el harness OpenClaw, Hermes
-Agent o Claude Code. Quien opere Hermes configura dos rutas autenticadas como se
-describe en [`HERMES.md`](HERMES.md).
-
-Claude Code funciona distinto a los otros dos y conviene saberlo antes de
-empezar: nada fuera de una sesión de Claude Code puede hablarle, así que el
-correo no se le empuja al agente: el agente va por él. Su hook de inicio de
-sesión reproduce lo que llegó mientras no había nada corriendo y luego le pide al
-agente que arme una vigilancia para lo que llegue después. Nada puede obligarlo
-desde afuera, así que ese es el único paso que depende de que el agente haga lo
-que se le dijo. Ver [`INSTALL.md`](INSTALL.md) §6.
+Agent o Claude Code.
 
 ---
 
@@ -104,6 +95,19 @@ que vale la pena verla funcionar una vez con tus propios ojos.
 Si lo manda, detente y avísale a quien lo instaló. Algo está mal.
 
 ---
+
+## Arquitectura de entrega por harness
+
+Quien opere Hermes configura dos rutas autenticadas como se describe en
+[`HERMES.md`](HERMES.md).
+
+Claude Code funciona distinto a los otros dos y conviene saberlo antes de
+empezar: nada fuera de una sesión de Claude Code puede hablarle, así que el
+correo no se le empuja al agente: el agente va por él. Su hook de inicio de
+sesión reproduce lo que llegó mientras no había nada corriendo y luego le pide al
+agente que arme una vigilancia para lo que llegue después. Nada puede obligarlo
+desde afuera, así que ese es el único paso que depende de que el agente haga lo
+que se le dijo. Ver [`INSTALL.md`](INSTALL.md) §6.
 
 ## Qué va a poder hacer tu agente
 

--- a/i18n/README.en-US.md
+++ b/i18n/README.en-US.md
@@ -122,8 +122,8 @@ If it sends, stop and tell whoever set it up. Something is wrong.
 Hermes operators configure two authenticated routes as described in
 [`HERMES.md`](../HERMES.md).
 
-Claude Code works differently from the other two and it is worth knowing before
-you start: nothing outside a Claude Code session can speak into it, so mail is
+Claude Code works differently from the other two, and the difference is not
+cosmetic. Nothing outside a Claude Code session can speak into it, so mail is
 not pushed to the agent: the agent comes and gets it. Its session-start hook
 replays what arrived while nothing was running and then asks the agent to arm a
 watch for what lands next. Nothing can enforce that from outside, so it is the

--- a/i18n/README.en-US.md
+++ b/i18n/README.en-US.md
@@ -9,16 +9,7 @@ second, without polling, and can read and send under a recipient allowlist.
 Built around [Himalaya](https://github.com/pimalaya/himalaya) for a plain
 IMAP/SMTP account, running on Ubuntu 24.04 under the OpenClaw, Hermes Agent or
 Claude Code harness. OpenClaw on macOS is supported through per-user launchd
-LaunchAgents. Hermes operators configure two authenticated routes as described
-in [`HERMES.md`](../HERMES.md).
-
-Claude Code works differently from the other two and it is worth knowing before
-you start: nothing outside a Claude Code session can speak into it, so mail is
-not pushed to the agent: the agent comes and gets it. Its session-start hook
-replays what arrived while nothing was running and then asks the agent to arm a
-watch for what lands next. Nothing can enforce that from outside, so it is the
-one step that rests on the agent doing as it is told. See
-[`INSTALL.md`](../INSTALL.md) §6.
+LaunchAgents.
 
 ---
 
@@ -125,6 +116,19 @@ work once with your own eyes.
 If it sends, stop and tell whoever set it up. Something is wrong.
 
 ---
+
+## Delivery architecture by harness
+
+Hermes operators configure two authenticated routes as described in
+[`HERMES.md`](../HERMES.md).
+
+Claude Code works differently from the other two and it is worth knowing before
+you start: nothing outside a Claude Code session can speak into it, so mail is
+not pushed to the agent: the agent comes and gets it. Its session-start hook
+replays what arrived while nothing was running and then asks the agent to arm a
+watch for what lands next. Nothing can enforce that from outside, so it is the
+one step that rests on the agent doing as it is told. See
+[`INSTALL.md`](../INSTALL.md) §6.
 
 ## What your agent will be able to do
 

--- a/i18n/README.es-ES.md
+++ b/i18n/README.es-ES.md
@@ -101,8 +101,8 @@ Si lo envía, para y avisa a quien lo instaló. Algo va mal.
 Quien opere Hermes configura dos rutas autenticadas como se describe en
 [`HERMES.md`](../HERMES.md).
 
-Claude Code funciona de forma distinta a los otros dos y conviene saberlo antes
-de empezar: nada fuera de una sesión de Claude Code puede hablarle, de modo que
+Claude Code funciona de forma distinta a los otros dos, y la diferencia no es
+cosmética. Nada fuera de una sesión de Claude Code puede hablarle, de modo que
 el correo no se le empuja al agente: el agente va a por él. Su hook de inicio de
 sesión reproduce lo que llegó mientras no había nada en marcha y después pide al
 agente que arme una vigilancia para lo que llegue a continuación. Nada puede

--- a/i18n/README.es-ES.md
+++ b/i18n/README.es-ES.md
@@ -9,16 +9,7 @@ leer y enviar dentro de una lista de destinatarios autorizados.
 
 Construido sobre [Himalaya](https://github.com/pimalaya/himalaya) para una cuenta
 IMAP/SMTP corriente, en Ubuntu 24.04 bajo el entorno OpenClaw, Hermes Agent o
-Claude Code. Quien opere Hermes configura dos rutas autenticadas como se describe
-en [`HERMES.md`](../HERMES.md).
-
-Claude Code funciona de forma distinta a los otros dos y conviene saberlo antes
-de empezar: nada fuera de una sesión de Claude Code puede hablarle, de modo que
-el correo no se le empuja al agente: el agente va a por él. Su hook de inicio de
-sesión reproduce lo que llegó mientras no había nada en marcha y después pide al
-agente que arme una vigilancia para lo que llegue a continuación. Nada puede
-imponerlo desde fuera, así que ese es el único paso que depende de que el agente
-haga lo que se le ha dicho. Véase [`INSTALL.md`](../INSTALL.md) §6.
+Claude Code.
 
 ---
 
@@ -104,6 +95,19 @@ merece la pena verla funcionar una vez con tus propios ojos.
 Si lo envía, para y avisa a quien lo instaló. Algo va mal.
 
 ---
+
+## Arquitectura de entrega por entorno
+
+Quien opere Hermes configura dos rutas autenticadas como se describe en
+[`HERMES.md`](../HERMES.md).
+
+Claude Code funciona de forma distinta a los otros dos y conviene saberlo antes
+de empezar: nada fuera de una sesión de Claude Code puede hablarle, de modo que
+el correo no se le empuja al agente: el agente va a por él. Su hook de inicio de
+sesión reproduce lo que llegó mientras no había nada en marcha y después pide al
+agente que arme una vigilancia para lo que llegue a continuación. Nada puede
+imponerlo desde fuera, así que ese es el único paso que depende de que el agente
+haga lo que se le ha dicho. Véase [`INSTALL.md`](../INSTALL.md) §6.
 
 ## Qué va a poder hacer tu agente
 

--- a/i18n/README.fr-FR.md
+++ b/i18n/README.fr-FR.md
@@ -108,10 +108,10 @@ ne va pas.
 Les opérateurs Hermes configurent deux routes authentifiées comme décrit dans
 [`HERMES.md`](../HERMES.md).
 
-Claude Code fonctionne autrement que les deux autres, et mieux vaut le savoir
-avant de commencer : rien à l'extérieur d'une session Claude Code ne peut lui
-parler, donc le courrier n'est pas poussé vers l'agent : c'est l'agent qui vient
-le chercher. Son hook de démarrage de session rejoue ce qui est arrivé pendant
+Claude Code fonctionne autrement que les deux autres, et la différence n'est pas
+cosmétique. Rien à l'extérieur d'une session Claude Code ne peut lui parler,
+donc le courrier n'est pas poussé vers l'agent : c'est l'agent qui vient le
+chercher. Son hook de démarrage de session rejoue ce qui est arrivé pendant
 qu'aucune session ne tournait, puis demande à l'agent d'armer une surveillance
 pour la suite. Rien ne peut l'imposer de l'extérieur : c'est la seule étape qui
 repose sur le fait que l'agent fasse ce qu'on lui dit. Voir

--- a/i18n/README.fr-FR.md
+++ b/i18n/README.fr-FR.md
@@ -9,17 +9,7 @@ et envoyer dans les limites d'une liste de destinataires autorisés.
 
 Construit autour de [Himalaya](https://github.com/pimalaya/himalaya) pour un
 compte IMAP/SMTP ordinaire, sous Ubuntu 24.04 avec l'environnement OpenClaw,
-Hermes Agent ou Claude Code. Les opérateurs Hermes configurent deux routes
-authentifiées comme décrit dans [`HERMES.md`](../HERMES.md).
-
-Claude Code fonctionne autrement que les deux autres, et mieux vaut le savoir
-avant de commencer : rien à l'extérieur d'une session Claude Code ne peut lui
-parler, donc le courrier n'est pas poussé vers l'agent : c'est l'agent qui vient
-le chercher. Son hook de démarrage de session rejoue ce qui est arrivé pendant
-qu'aucune session ne tournait, puis demande à l'agent d'armer une surveillance
-pour la suite. Rien ne peut l'imposer de l'extérieur : c'est la seule étape qui
-repose sur le fait que l'agent fasse ce qu'on lui dit. Voir
-[`INSTALL.md`](../INSTALL.md) §6.
+Hermes Agent ou Claude Code.
 
 ---
 
@@ -112,6 +102,20 @@ S'il envoie, arrêtez tout et prévenez la personne qui l'a installé. Quelque c
 ne va pas.
 
 ---
+
+## Architecture de distribution par environnement
+
+Les opérateurs Hermes configurent deux routes authentifiées comme décrit dans
+[`HERMES.md`](../HERMES.md).
+
+Claude Code fonctionne autrement que les deux autres, et mieux vaut le savoir
+avant de commencer : rien à l'extérieur d'une session Claude Code ne peut lui
+parler, donc le courrier n'est pas poussé vers l'agent : c'est l'agent qui vient
+le chercher. Son hook de démarrage de session rejoue ce qui est arrivé pendant
+qu'aucune session ne tournait, puis demande à l'agent d'armer une surveillance
+pour la suite. Rien ne peut l'imposer de l'extérieur : c'est la seule étape qui
+repose sur le fait que l'agent fasse ce qu'on lui dit. Voir
+[`INSTALL.md`](../INSTALL.md) §6.
 
 ## Ce que votre agent pourra faire
 

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -9,16 +9,7 @@ enviar dentro de uma lista de destinatários autorizados.
 
 Construído sobre o [Himalaya](https://github.com/pimalaya/himalaya) para uma conta
 IMAP/SMTP comum, no Ubuntu 24.04 sob o ambiente OpenClaw, Hermes Agent ou Claude
-Code. Quem opera o Hermes configura duas rotas autenticadas conforme descrito em
-[`HERMES.md`](../HERMES.md).
-
-O Claude Code funciona de um jeito diferente dos outros dois, e vale saber disso
-antes de começar: nada fora de uma sessão do Claude Code consegue falar com ela,
-então o e-mail não é empurrado até o agente: o agente é que vai buscá-lo. O hook
-de início de sessão reproduz o que chegou enquanto nada estava rodando e então
-pede que o agente arme uma vigilância para o que chegar depois. Nada consegue
-impor isso de fora, então esse é o único passo que depende de o agente fazer o
-que lhe foi dito. Veja [`INSTALL.md`](../INSTALL.md) §6.
+Code.
 
 ---
 
@@ -104,6 +95,19 @@ vale a pena vê-la funcionando uma vez com os próprios olhos.
 Se ele enviar, pare e avise quem instalou. Alguma coisa está errada.
 
 ---
+
+## Arquitetura de entrega por ambiente
+
+Quem opera o Hermes configura duas rotas autenticadas conforme descrito em
+[`HERMES.md`](../HERMES.md).
+
+O Claude Code funciona de um jeito diferente dos outros dois, e vale saber disso
+antes de começar: nada fora de uma sessão do Claude Code consegue falar com ela,
+então o e-mail não é empurrado até o agente: o agente é que vai buscá-lo. O hook
+de início de sessão reproduz o que chegou enquanto nada estava rodando e então
+pede que o agente arme uma vigilância para o que chegar depois. Nada consegue
+impor isso de fora, então esse é o único passo que depende de o agente fazer o
+que lhe foi dito. Veja [`INSTALL.md`](../INSTALL.md) §6.
 
 ## O que o seu agente vai conseguir fazer
 

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -101,8 +101,8 @@ Se ele enviar, pare e avise quem instalou. Alguma coisa está errada.
 Quem opera o Hermes configura duas rotas autenticadas conforme descrito em
 [`HERMES.md`](../HERMES.md).
 
-O Claude Code funciona de um jeito diferente dos outros dois, e vale saber disso
-antes de começar: nada fora de uma sessão do Claude Code consegue falar com ela,
+O Claude Code funciona de um jeito diferente dos outros dois, e a diferença não
+é cosmética. Nada fora de uma sessão do Claude Code consegue falar com ela,
 então o e-mail não é empurrado até o agente: o agente é que vai buscá-lo. O hook
 de início de sessão reproduz o que chegou enquanto nada estava rodando e então
 pede que o agente arme uma vigilância para o que chegar depois. Nada consegue


### PR DESCRIPTION
Lleva a `main` los dos cambios sobre el mismo bloque de texto. El primero ya se había revisado en #21, que se mergeó contra una rama de integración que quedó descartada; aquí viene rebasado, sin el commit de merge del andamiaje.

## 1. Agrupa la arquitectura de entrega en su propia sección

Las dos afirmaciones sobre cómo llega el correo según el harness estaban sueltas en la descripción del producto, arriba del todo: la frase de las dos rutas autenticadas de Hermes iba pegada al final del párrafo de Himalaya, y el párrafo de Claude Code flotaba entre la descripción y el primer paso de instalación. Ninguna de las dos se leía como lo que es, que es una diferencia estructural entre los tres runtimes y no una característica más del producto.

Ahora viven bajo **«Arquitectura de entrega por harness»**, después de los tres pasos de configuración y antes de «Qué va a poder hacer tu agente». El objetivo es que quien llega al repo lea rápido qué es y cómo se usa, sin tropezar antes con una diferencia de arquitectura.

El encabezado usa en cada idioma la palabra que ese archivo ya usaba para *harness*:

| Archivo | Encabezado |
| --- | --- |
| `README.md` (es-MX) | Arquitectura de entrega por harness |
| `i18n/README.en-US.md` | Delivery architecture by harness |
| `i18n/README.es-ES.md` | Arquitectura de entrega por entorno |
| `i18n/README.fr-FR.md` | Architecture de distribution par environnement |
| `i18n/README.pt-BR.md` | Arquitetura de entrega por ambiente |

En en-US, la frase sobre las LaunchAgents de launchd por usuario se queda en el párrafo de arriba: dice qué plataformas soporta OpenClaw, no cómo se le entrega el correo.

## 2. Reescribe la apertura, que ya no va antes de nada

El párrafo abría con «conviene saberlo **antes de empezar**». Era cierto cuando flotaba arriba del todo; desde que está después de los pasos de configuración, le decía al lector algo que no corresponde a dónde está parado.

```diff
-Claude Code funciona distinto a los otros dos y conviene saberlo antes de
-empezar: nada fuera de una sesión de Claude Code puede hablarle, así que el
-correo no se le empuja al agente: el agente va por él.
+Claude Code funciona distinto a los otros dos, y la diferencia no es cosmética.
+Nada fuera de una sesión de Claude Code puede hablarle, así que el correo no se
+le empuja al agente: el agente va por él.
```

«Y la diferencia no es cosmética» es la misma afirmación que hace `INSTALL.md` §6 sobre este runtime (*"the difference is not cosmetic"*), y se sostiene esté el párrafo donde esté. También parte la oración en dos: la anterior cargaba dos veces dos puntos en una sola frase.

## Alcance

Solo los cinco README. El texto de los párrafos no cambia más allá de la apertura; lo demás es ubicación, encabezado y reajuste a 80 columnas.

Sin entrada de CHANGELOG: los commits de documentación previos (`fc319a6`, `2c2a36b`, `b1a8b8d`) tampoco la llevaron.