### PR TITLE
Quita el nombre real de un servidor de hosting del ejemplo de MAILBOX_SETUP

### DIFF
--- a/MAILBOX_SETUP.md
+++ b/MAILBOX_SETUP.md
@@ -44,7 +44,7 @@ equivoca, así que tiene su propia sección abajo.
 
 Tu dirección de correo termina en un dominio: `ejemplo.com`. El servidor donde de
 verdad vive tu correo casi nunca es `ejemplo.com`, y casi nunca es
-`mail.ejemplo.com` tampoco. Suele ser algo como `nc-ph-2488.xmhosting.com` o
+`mail.ejemplo.com` tampoco. Suele ser algo como `s1042.hosting.example.net` o
 `imappro.zoho.com`.
 
 `mail.ejemplo.com` muchas veces **sí** resuelve, y ahí está la trampa: se ve bien,

--- a/i18n/MAILBOX_SETUP.en-US.md
+++ b/i18n/MAILBOX_SETUP.en-US.md
@@ -43,7 +43,7 @@ its own section below.
 
 Your email address ends in a domain, `example.com`. The server your mail actually
 lives on is usually **not** `example.com`, and usually not `mail.example.com`
-either. It is something like `nc-ph-2488.xmhosting.com` or
+either. It is something like `s1042.hosting.example.net` or
 `imappro.zoho.com`.
 
 `mail.example.com` frequently *does* resolve, which is what makes this a trap: it

--- a/i18n/MAILBOX_SETUP.es-ES.md
+++ b/i18n/MAILBOX_SETUP.es-ES.md
@@ -45,7 +45,7 @@ equivoca, así que tiene su propia sección más abajo.
 
 Tu dirección de correo termina en un dominio: `ejemplo.com`. El servidor donde
 realmente vive tu correo casi nunca es `ejemplo.com`, ni suele ser
-`mail.ejemplo.com`. Suele ser algo como `nc-ph-2488.xmhosting.com` o
+`mail.ejemplo.com`. Suele ser algo como `s1042.hosting.example.net` o
 `imappro.zoho.com`.
 
 `mail.ejemplo.com` a menudo **sí** resuelve, y ahí está la trampa: parece

--- a/i18n/MAILBOX_SETUP.fr-FR.md
+++ b/i18n/MAILBOX_SETUP.fr-FR.md
@@ -45,8 +45,8 @@ elle a donc sa propre section plus bas.
 
 Votre adresse se termine par un domaine, `exemple.com`. Le serveur où vit
 réellement votre courrier n'est en général **pas** `exemple.com`, ni
-`mail.exemple.com`. C'est plutôt quelque chose comme `nc-ph-2488.xmhosting.com` ou
-`imappro.zoho.com`.
+`mail.exemple.com`. C'est plutôt quelque chose comme
+`s1042.hosting.example.net` ou `imappro.zoho.com`.
 
 `mail.exemple.com` résout pourtant souvent, et c'est là le piège : cela a l'air
 correct, la connexion s'établit, puis il s'avère que le certificat TLS est émis

--- a/i18n/MAILBOX_SETUP.pt-BR.md
+++ b/i18n/MAILBOX_SETUP.pt-BR.md
@@ -44,7 +44,7 @@ tem uma seção só dela mais abaixo.
 
 Seu endereço termina num domínio, `exemplo.com`. O servidor onde o seu e-mail
 realmente mora quase nunca é `exemplo.com`, e quase nunca é `mail.exemplo.com`
-também. Costuma ser algo como `nc-ph-2488.xmhosting.com` ou `imappro.zoho.com`.
+também. Costuma ser algo como `s1042.hosting.example.net` ou `imappro.zoho.com`.
 
 `mail.exemplo.com` frequentemente **resolve**, e é aí que está a armadilha: parece
 certo, conecta, e depois se descobre que o certificado TLS foi emitido para o


### PR DESCRIPTION
`nc-ph-2488.xmhosting.com` es una máquina real de un proveedor real, y estaba en **los cinco** `MAILBOX_SETUP` como ejemplo de cómo se ve el nombre de un servidor de hosting compartido. La documentación no tiene por qué nombrar la infraestructura de un tercero, y menos en la página donde se explica a qué servidor conectarse.

## Qué queda en su lugar

`s1042.hosting.example.net`, que conserva lo que el ejemplo enseñaba: un identificador de máquina generado, ajeno al dominio del lector, y feo a propósito. Ese contraste con `mail.ejemplo.com` es todo el punto del párrafo, así que sustituir es mejor que borrar.

`example.net` está reservado para documentación por el [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606), así que no puede registrarse y nunca va a resolver a la máquina de nadie.

`imappro.zoho.com` se queda: es un endpoint público y documentado de Zoho, no la máquina de un cliente.

## Alcance

| Archivo | |
| --- | --- |
| `MAILBOX_SETUP.md` | ✓ |
| `i18n/MAILBOX_SETUP.en-US.md` | ✓ |
| `i18n/MAILBOX_SETUP.es-ES.md` | ✓ |
| `i18n/MAILBOX_SETUP.fr-FR.md` | ✓ (además reajustado a 80 columnas) |
| `i18n/MAILBOX_SETUP.pt-BR.md` | ✓ |

Verificado que no queda ninguna mención de `nc-ph-2488` ni de `xmhosting` en el árbol, incluidos archivos no rastreados. La webapp de captura (`webapp/`) nunca lo mencionó; usa sus propios placeholders.

## Lo que este PR no hace

El nombre sigue en la historia de git, en `a7b1040` («Bifurca agenteiamail 1.9.1 como Paynani 0.1.0»), que es donde entró. Sacarlo de ahí significa reescribir historia ya publicada y forzar el push sobre `main`; es una decisión aparte y no se toma de pasada en un PR de documentación.