### PR TITLE
Usa dominios reservados en los placeholders de la webapp

### DIFF
--- a/webapp/index.php
+++ b/webapp/index.php
@@ -147,7 +147,7 @@ $existing = existing_config();
     <h3>Si tu correo vino con tu hosting web (cPanel)</h3>
     <p>Es el caso más común, y los datos ya están escritos ahí para ti.</p>
     <ol>
-      <li>Entra a cPanel, normalmente <code>tudominio.com/cpanel</code>, o el enlace que te mandó tu proveedor.</li>
+      <li>Entra a cPanel, normalmente <code>tudominio.example/cpanel</code>, o el enlace que te mandó tu proveedor.</li>
       <li>Abre <strong>Email Accounts</strong> (Cuentas de correo).</li>
       <li>Busca la dirección que va a usar el agente y haz clic en <strong>Connect Devices</strong>
           (en versiones viejas se llama <em>Set Up Mail Client</em>).</li>
@@ -206,7 +206,7 @@ $existing = existing_config();
       <label for="account">Dirección de correo</label>
       <input type="email" id="account" name="AGENT_EMAIL_ACCOUNT" required
              value="<?= e($values['AGENT_EMAIL_ACCOUNT']) ?>"
-             placeholder="agente@tudominio.com">
+             placeholder="agente@tudominio.example">
       <?php if (isset($errors['AGENT_EMAIL_ACCOUNT'])): ?>
         <p class="err"><?= e($errors['AGENT_EMAIL_ACCOUNT']) ?></p>
       <?php endif; ?>
@@ -239,7 +239,7 @@ $existing = existing_config();
           <label for="imaphost">Servidor</label>
           <input type="text" id="imaphost" name="AGENT_EMAIL_INCOMING_SERVER_IMAP_HOST" required
                  value="<?= e($values['AGENT_EMAIL_INCOMING_SERVER_IMAP_HOST']) ?>"
-                 placeholder="imap.tuproveedor.com">
+                 placeholder="imap.tuproveedor.example">
         </div>
         <div class="narrow">
           <label for="imapport">Puerto</label>
@@ -263,7 +263,7 @@ $existing = existing_config();
           <label for="smtphost">Servidor</label>
           <input type="text" id="smtphost" name="AGENT_EMAIL_OUTGOING_SERVER_SMTP_HOST" required
                  value="<?= e($values['AGENT_EMAIL_OUTGOING_SERVER_SMTP_HOST']) ?>"
-                 placeholder="smtp.tuproveedor.com">
+                 placeholder="smtp.tuproveedor.example">
         </div>
         <div class="narrow">
           <label for="smtpport">Puerto</label>

--- a/webapp/lib/probe.php
+++ b/webapp/lib/probe.php
@@ -39,7 +39,7 @@ function explain_connect_error(string $raw, string $host): string
         || str_contains($lower, 'certificate_verify_failed')) {
         return "El servidor contestó, pero su certificado de seguridad no está emitido para “{$host}”. "
              . "Normalmente eso significa que el nombre del servidor está un poco mal; muchos proveedores "
-             . "quieren algo como imap.tuproveedor.com y no mail.tudominio.com. Pídele a tu proveedor el "
+             . "quieren algo como imap.tuproveedor.example y no mail.tudominio.example. Pídele a tu proveedor el "
              . "nombre exacto que publica.";
     }
     if (str_contains($lower, 'getaddrinfo') || str_contains($lower, 'name or service not known')

--- a/webapp/lib/validate.php
+++ b/webapp/lib/validate.php
@@ -46,7 +46,7 @@ function validate(array $in): array
         // exist, and the error arrives as a connection failure.
         if (ctype_digit($host)) {
             $errors[$key] = 'Eso es un número de puerto, no un nombre de servidor. El nombre se ve así: '
-                          . 'imap.tuproveedor.com.';
+                          . 'imap.tuproveedor.example.';
             continue;
         }
         if (str_contains($host, '/') || str_contains($host, ' ') || str_contains($host, '@')) {


### PR DESCRIPTION
`tuproveedor.com` y `tudominio.com` se leen como nombres inventados, pero los dos están registrados y resuelven:

```
tuproveedor.com -> 3.21.119.174
tudominio.com   -> 103.224.182.246   (IP de dominio estacionado)
```

La webapp los mostraba en los campos donde se captura **a qué servidor conectarse**, que es justo donde un nombre que apunta a la máquina de un desconocido no debe estar. Es la misma clase de descuido que #23 arregla en `MAILBOX_SETUP`, en el otro extremo del proyecto.

## El cambio

Cambia el TLD y nada más. El [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606) reserva `.example` como TLD para documentación, así que `tuproveedor.example` no puede registrarse y no va a resolver nunca. La palabra que hacía el trabajo pedagógico, «tu proveedor» y «tu dominio», se queda intacta, así que el formulario sigue diciéndole al lector qué escribir.

## Alcance

Siete apariciones en tres archivos:

| Archivo | Qué |
| --- | --- |
| `webapp/index.php` | los tres placeholders del formulario y la línea de cPanel |
| `webapp/lib/validate.php` | el ejemplo del mensaje de validación |
| `webapp/lib/probe.php` | los dos nombres que contrasta cuando falla el certificado |

## Verificación

- `php -l` limpio en los tres archivos.
- Página servida y revisada en vivo con `scripts/setup_web.sh`: los tres placeholders del formulario ahora rinden `agente@tudominio.example`, `imap.tuproveedor.example` y `smtp.tuproveedor.example`, y no queda ninguna aparición de los dominios viejos en el HTML.