### PR TITLE
Deja de partir a media palabra el código dentro de la página de configuración

### DIFF
--- a/webapp/assets/app.css
+++ b/webapp/assets/app.css
@@ -63,7 +63,11 @@ code {
   border: 1px solid var(--line);
   border-radius: 4px;
   padding: .1em .35em;
-  word-break: break-all;
+  /* break-all rompe en cualquier carácter aunque la palabra quepa entera en la
+     línea siguiente, y partía `imap.` como `ima` + `p.`. Con esto una ruta larga
+     sigue partiéndose, porque no cabe de otro modo, pero un token corto se va
+     completo al siguiente renglón. */
+  overflow-wrap: anywhere;
 }
 
 fieldset {


### PR DESCRIPTION
`webapp/assets/app.css` traía `word-break: break-all` en `code`, que autoriza el corte en cualquier carácter y no solo cuando hace falta. El navegador entonces parte la palabra aunque quepa entera en el renglón siguiente.

En la página se veía así:

| Dónde | Se renderizaba |
| --- | --- |
| La ruta del `.env`, en el aviso ámbar | `/home/julianflores/.cl` + `aude/workspace/.env` |
| La ayuda del campo IMAP | `ima` + `p.` |

## El cambio

`overflow-wrap: anywhere` en lugar de `word-break: break-all`. Solo rompe cuando la palabra de verdad no cabe, así que un token corto como `imap.` se va entero al siguiente renglón. Una línea de CSS, con el comentario que explica por qué no puede volver a `break-all`.

## Verificación

Capturas de la página real servida por `scripts/setup_web.sh`, tomadas con Playwright a 1280px de ancho, antes y después:

- **Antes:** la ruta parte en `.cl` / `aude`, y el `imap.` en `ima` / `p.`
- **Después:** la ruta cabe completa en un renglón, y `imap.` sale entero

Se ve solo renderizado, que es la razón por la que llevaba tiempo ahí sin que nadie lo notara.