### PR TITLE
Agrega un selector de idioma a la página de configuración del buzón

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -98,6 +98,38 @@ stops them, which is almost always an app password rather than a wrong server
 name. It is a `<details>` block, so it collapses with no JavaScript on a page
 whose policy forbids scripts entirely.
 
+## The language it speaks
+
+The person filling this form is not always the person who runs the agent, and is
+not always the person who chose the language the rest of the install speaks. They
+are handing over a mailbox password, so they get to read what they are agreeing
+to in their own language.
+
+A selector sits next to the title, offering the same five languages the
+documentation is translated into, with **Español (MX)** selected by default.
+Everything the page can say is translated with it: the form, the provider help,
+the field validation, the live check's step-by-step report, and the three refusal
+screens in `guard.php`.
+
+**Switching does not lose what has been typed.** The selector and its button
+belong to the main form through the `form=` attribute even though they sit above
+it, so changing language posts the whole form and the fields come back filled.
+That submit carries `formnovalidate`, because without it the browser refuses to
+send while the password box is empty, which would mean nobody could change
+language until they had finished the form.
+
+**There is no JavaScript in it.** `guard.php` serves `default-src 'none'` with no
+`script-src`, so an `onchange` handler would be blocked and the selector would
+silently do nothing. Hence a real button rather than an automatic switch: a page
+that collects a mail password is the wrong place to loosen that policy to save a
+click.
+
+Catalogues are flat `key => string` arrays in `webapp/i18n/`. A key a translation
+is missing falls back to `es-MX` rather than rendering blank, so a half-finished
+catalogue degrades to a mixed page instead of an empty one. `es-MX` is the source
+language; every other file is translated from it and carries exactly the same
+keys.
+
 ## What the check does
 
 It opens a real connection to both servers and signs in, then signs straight out.
@@ -131,6 +163,8 @@ webapp/lib/guard.php    loopback check, one-time key, CSRF, headers
 webapp/lib/validate.php field checks, each one a mistake seen in the wild
 webapp/lib/probe.php    live IMAP and SMTP sign-in
 webapp/lib/envfile.php  writing the resolved credentials file, and the symlink
+webapp/lib/i18n.php     which language this render speaks, and t()/th()
+webapp/i18n/*.php       one flat array of strings per language
 webapp/assets/app.css   no webfonts: this host may have no internet route
 scripts/setup_web.sh    generates the key, serves the page, stops when saved
 ```

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -43,8 +43,9 @@ exposed to a network in either case.
 
 ## Requirements
 
-PHP 8.1 or newer, CLI only. No composer, no framework, no database, no
-JavaScript. On Ubuntu:
+PHP 8.1 or newer, CLI only. No composer, no framework, no database. The only
+JavaScript is `assets/lang.js`, twenty lines that switch language when the
+selector changes; everything the page does works without it. On Ubuntu:
 
 ```bash
 sudo apt-get install -y php8.3-cli
@@ -95,8 +96,7 @@ people miss next to the non-SSL one.
 
 Then Gmail, Outlook, Zoho and Fastmail, each with the caveat that actually
 stops them, which is almost always an app password rather than a wrong server
-name. It is a `<details>` block, so it collapses with no JavaScript on a page
-whose policy forbids scripts entirely.
+name. It is a `<details>` block, so it collapses on its own with no script involved.
 
 ## The language it speaks
 
@@ -118,11 +118,22 @@ That submit carries `formnovalidate`, because without it the browser refuses to
 send while the password box is empty, which would mean nobody could change
 language until they had finished the form.
 
-**There is no JavaScript in it.** `guard.php` serves `default-src 'none'` with no
-`script-src`, so an `onchange` handler would be blocked and the selector would
-silently do nothing. Hence a real button rather than an automatic switch: a page
-that collects a mail password is the wrong place to loosen that policy to save a
-click.
+**The selector switches on change, and degrades to a button.** That needs a
+script, so the policy carries `script-src 'self'`: same-origin files only, no
+`'unsafe-inline'`, no `'unsafe-eval'`, no remote origin. Inline handlers stay
+forbidden, which is the part that matters — a string injected into this page
+still cannot execute. The one file allowed is `assets/lang.js`.
+
+The page ships a real submit button and the script hides it on load. That is
+deliberately not a `<noscript>` fallback: a script blocked by CSP still counts as
+scripting being enabled, so `<noscript>` would render nothing and leave a dead
+selector. This way, if the script does not run for any reason, what is left on
+screen is a button that works. The failure mode is one extra click.
+
+**The caret is drawn in CSS, not loaded as an image.** The policy does not
+declare `img-src`, so it falls back to `default-src 'none'` and a `data:` URI is
+blocked without a word — which is exactly what happened first, leaving a control
+with nothing to mark it as a dropdown. Two rotated borders need no permission.
 
 Catalogues are flat `key => string` arrays in `webapp/i18n/`. A key a translation
 is missing falls back to `es-MX` rather than rendering blank, so a half-finished
@@ -166,6 +177,7 @@ webapp/lib/envfile.php  writing the resolved credentials file, and the symlink
 webapp/lib/i18n.php     which language this render speaks, and t()/th()
 webapp/i18n/*.php       one flat array of strings per language
 webapp/assets/app.css   no webfonts: this host may have no internet route
+webapp/assets/lang.js   switches language on change; the button works without it
 scripts/setup_web.sh    generates the key, serves the page, stops when saved
 ```
 

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -141,6 +141,27 @@ catalogue degrades to a mixed page instead of an empty one. `es-MX` is the sourc
 language; every other file is translated from it and carries exactly the same
 keys.
 
+## Coming back to change something
+
+The form is not only a first-time screen. Open it against an install that already
+has credentials and the fields arrive filled from the file, so a password can be
+rotated, or a server name corrected, without retyping the other six.
+
+**The password is the exception, and stays the exception.** It is never written
+into the HTML, not even masked. The box shows bullets as a *placeholder*, the
+value attribute is empty, and leaving it that way means "keep the one already on
+disk". Type in it only to replace it. The promise above — that the password is
+never rendered back — is what makes a screenshot of this screen safe, and
+prefilling it would have quietly broken that.
+
+**Only the seven keys this form owns are written.** A real installation keeps
+more than mail settings in that file, tokens for other services among them, and
+this page has no idea what any of it is. An existing file is therefore edited
+line by line: comments, blank lines, key order and unknown keys all survive.
+Rewriting the file wholesale stayed harmless only while this was a screen you ran
+once; the moment somebody can come back to change a password, it would mean
+losing every other secret in the file to do it.
+
 ## What the check does
 
 It opens a real connection to both servers and signs in, then signs straight out.

--- a/webapp/assets/app.css
+++ b/webapp/assets/app.css
@@ -204,3 +204,62 @@ button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
   .row .narrow { flex: 1 1 auto; }
   .actions button { flex: 1 1 100%; }
 }
+
+/* ── El selector de idioma ──────────────────────────────────────────────────
+   Va en el renglón del título, alineado a la derecha, y se pasa abajo cuando
+   la pantalla es angosta en lugar de apretar al h1. */
+.topbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: .5rem 1rem;
+}
+
+/* El título cede el ancho y envuelve; el selector nunca se encoge ni se cae a
+   otro renglón, que es donde el título francés lo mandaba. */
+.topbar h1 { margin-bottom: 0; flex: 1 1 12rem; min-width: 0; }
+
+.langpick {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: .4rem;
+  font-size: .85rem;
+  color: var(--quiet);
+}
+
+.langpick select {
+  font: inherit;
+  color: var(--ink);
+  /* background-color, no background: la flecha se pinta como background-image
+     abajo, y la forma corta la borraría. --card sigue al modo oscuro. */
+  background-color: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: .25rem 1.6rem .25rem .5rem;
+  /* La flecha va dibujada aquí para no depender del control nativo, que en
+     Linux se pinta muy distinto que en macOS y desalinea el renglón. */
+  appearance: none;
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%23666' stroke-width='1.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right .5rem center;
+}
+
+.langpick select:focus-visible {
+  outline: 2px solid var(--accent, #1f5f4a);
+  outline-offset: 1px;
+}
+
+.langpick button {
+  font: inherit;
+  color: var(--ink);
+  background-color: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: .25rem .6rem;
+  cursor: pointer;
+}
+
+.langpick button:hover { border-color: var(--accent); }
+.langpick button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }

--- a/webapp/assets/app.css
+++ b/webapp/assets/app.css
@@ -225,39 +225,62 @@ button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
   flex: 0 0 auto;
   align-items: center;
   gap: .4rem;
-  font-size: .85rem;
-  color: var(--quiet);
 }
 
+/* Se ve como los demás campos del formulario, no como el botón de al lado:
+   mismo fondo, mismo borde, mismo radio, y una flecha que lo delata como
+   desplegable. La flecha va dibujada aquí y no se deja al control nativo,
+   que en Linux se pinta muy distinto que en macOS y desalinea el renglón. */
 .langpick select {
   font: inherit;
+  font-size: .9rem;
   color: var(--ink);
-  /* background-color, no background: la flecha se pinta como background-image
-     abajo, y la forma corta la borraría. --card sigue al modo oscuro. */
-  background-color: var(--card);
+  background-color: var(--bg);
   border: 1px solid var(--line);
   border-radius: 6px;
-  padding: .25rem 1.6rem .25rem .5rem;
-  /* La flecha va dibujada aquí para no depender del control nativo, que en
-     Linux se pinta muy distinto que en macOS y desalinea el renglón. */
+  padding: .45rem 2rem .45rem .7rem;
   appearance: none;
-  background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%23666' stroke-width='1.5'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right .5rem center;
+  cursor: pointer;
+  width: 100%;
 }
+
+/* La flecha va aquí, en dos bordes girados 45 grados, y no como imagen: la
+   política de guard.php es `default-src 'none'` y no declara img-src, así que
+   un data: URI se bloquea sin decir nada y el control queda sin nada que lo
+   distinga de un botón. Esto no carga nada, así que no hay qué permitir. */
+.combo { position: relative; display: inline-flex; }
+
+.combo::after {
+  content: "";
+  position: absolute;
+  right: .75rem;
+  top: 50%;
+  width: .4rem;
+  height: .4rem;
+  border-right: 1.5px solid var(--quiet);
+  border-bottom: 1.5px solid var(--quiet);
+  transform: translateY(-70%) rotate(45deg);
+  pointer-events: none;
+}
+
+.langpick select:hover { border-color: var(--accent); }
 
 .langpick select:focus-visible {
-  outline: 2px solid var(--accent, #1f5f4a);
+  outline: 2px solid var(--accent);
   outline-offset: 1px;
+  border-color: transparent;
 }
 
+/* El botón de reserva. assets/lang.js lo esconde en cuanto arranca; solo se
+   queda a la vista si el script no corrió, y entonces es lo único que sirve. */
 .langpick button {
   font: inherit;
+  font-size: .9rem;
   color: var(--ink);
   background-color: var(--card);
   border: 1px solid var(--line);
   border-radius: 6px;
-  padding: .25rem .6rem;
+  padding: .45rem .7rem;
   cursor: pointer;
 }
 

--- a/webapp/assets/lang.js
+++ b/webapp/assets/lang.js
@@ -1,0 +1,35 @@
+/**
+ * Switch language when the selector changes.
+ *
+ * Progressive enhancement, in that order on purpose: the page ships a real
+ * submit button that works with no scripting at all, and this file hides it and
+ * takes over. If the script does not run for any reason, including the
+ * Content-Security-Policy refusing it, what is left on screen is the button
+ * that still works. The failure mode is one extra click, never a dead control.
+ *
+ * That matters more than usual here: `noscript` does not help, because a script
+ * blocked by CSP still counts as scripting being enabled, so a `noscript`
+ * fallback would render nothing and the selector would do nothing.
+ */
+(function () {
+  'use strict';
+
+  function wire() {
+    var select = document.getElementById('lang');
+    var button = document.getElementById('langgo');
+    if (!select || !button) {
+      return;
+    }
+    // Only now, once we know the listener is about to be attached.
+    button.hidden = true;
+    select.addEventListener('change', function () {
+      button.click();
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', wire);
+  } else {
+    wire();
+  }
+}());

--- a/webapp/i18n/en-US.php
+++ b/webapp/i18n/en-US.php
@@ -19,7 +19,6 @@ return [
 'saved.next_p2'     => 'The one thing worth doing yourself: send the agent an email and ask what just arrived. If it answers within a couple of seconds, everything works.',
 'saved.forgot'      => 'This page has already forgotten the password. Opening it again will not show it.',
 
-'warn.existing_p1'  => '<strong>Careful.</strong> There is already mail configuration at <code>{path}</code>. Finishing this form replaces it.',
 
 'help.summary'      => 'Where do I find these?',
 

--- a/webapp/i18n/en-US.php
+++ b/webapp/i18n/en-US.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+/** English (US). Translated from es-MX. */
+
+return [
+
+'page.title'        => 'paynani: mailbox setup',
+'page.h1'           => 'Give the agent a mailbox',
+'page.lead'         => 'Seven details from your mail provider. Everything stays on this computer. This page is not reachable from the internet.',
+'lang.label'        => 'Language',
+'lang.apply'        => 'Change',
+
+'saved.h1'          => 'Done',
+'saved.lead'        => 'Your mail server accepted the account and the settings are saved. You can close this page.',
+'saved.where'       => 'Saved to <code>{path}</code>, and only this account can read it.',
+'saved.next_h2'     => 'What happens next',
+'saved.next_p1'     => 'Tell the agent the settings are in place. It installs the rest and checks that mail arrives; that part is its job, not yours.',
+'saved.next_p2'     => 'The one thing worth doing yourself: send the agent an email and ask what just arrived. If it answers within a couple of seconds, everything works.',
+'saved.forgot'      => 'This page has already forgotten the password. Opening it again will not show it.',
+
+'warn.existing_p1'  => '<strong>Careful.</strong> There is already mail configuration at <code>{path}</code>. Finishing this form replaces it.',
+'warn.existing_p2'  => 'If the agent is already handling mail, close this page and check with whoever set it up before going on.',
+
+'help.summary'      => 'Where do I find these?',
+
+'help.cpanel_h3'    => 'If your mail came with your web hosting (cPanel)',
+'help.cpanel_p'     => 'This is the most common case, and the details are already written down there for you.',
+'help.cpanel_li1'   => 'Sign in to cPanel, usually <code>yourdomain.example/cpanel</code>, or the link your provider sent you.',
+'help.cpanel_li2'   => 'Open <strong>Email Accounts</strong>.',
+'help.cpanel_li3'   => 'Find the address the agent will use and click <strong>Connect Devices</strong> (older versions call it <em>Set Up Mail Client</em>).',
+'help.cpanel_li4'   => 'Look for <strong>Mail Client Manual Settings</strong> and use the <strong>Secure SSL/TLS Settings</strong> column, not the one without SSL.',
+'help.cpanel_after' => 'Copy <em>Incoming Server</em> and its IMAP port into the reading section below, and <em>Outgoing Server</em> with its SMTP port into the sending one. The username is the full email address, and the password is the one you gave that mailbox when you created it. If you do not remember it, cPanel lets you change it on that same page.',
+
+'help.gmail_h3'     => 'Gmail or Google Workspace',
+'help.gmail_p1'     => 'The hostnames are always the same: <code>imap.gmail.com</code> port <code>993</code> for reading, <code>smtp.gmail.com</code> port <code>465</code> for sending.',
+'help.gmail_p2'     => 'The password is where people get stuck. Google will not accept the normal one here. You need an <strong>app password</strong>, which first requires two-step verification to be on. Create it at <code>myaccount.google.com</code> → Security → App passwords, and paste the 16-character code it gives you.',
+'help.gmail_p3'     => 'Check that IMAP is switched on too: Gmail → Settings → Forwarding and POP/IMAP.',
+
+'help.ms_h3'        => 'Outlook.com, Hotmail or Microsoft 365',
+'help.ms_p1'        => '<code>outlook.office365.com</code> port <code>993</code> for reading, <code>smtp.office365.com</code> port <code>587</code> for sending.',
+'help.ms_p2'        => 'Many Microsoft business accounts now block sign-ins like this one by policy. If the check below rejects the password even though it is right, that is usually why, and your administrator has to allow it.',
+
+'help.zoho_h3'      => 'Zoho',
+'help.zoho_p'       => '<code>imappro.zoho.com</code> port <code>993</code>, <code>smtp.zoho.com</code> port <code>465</code>. Zoho also wants an app password, not the normal one.',
+
+'help.fastmail_h3'  => 'Fastmail',
+'help.fastmail_p'   => '<code>imap.fastmail.com</code> port <code>993</code>, <code>smtp.fastmail.com</code> port <code>465</code>, with an app password.',
+
+'help.other_h3'     => 'Anyone else',
+'help.other_p1'     => 'Ask your provider, or search their name plus <em>IMAP and SMTP settings</em>. You are after four things: the incoming hostname, the outgoing one, and a port for each. Prefer the ports marked SSL or TLS.',
+'help.other_p2'     => 'One warning worth repeating: do not guess the hostname by putting <code>mail.</code> in front of your domain. It often works just enough to look right and then fails on the security certificate, which is horrible to diagnose afterwards. The check below catches it and tells you plainly.',
+
+'form.account_legend' => 'The account',
+'form.account_label'  => 'Email address',
+'form.account_ph'     => 'agent@yourdomain.example',
+'form.account_hint'   => 'The agent\'s own mailbox, not yours.',
+
+'form.password_label' => 'Password',
+'form.password_kept'  => '••••••••  the previous one was kept',
+'form.password_hint'  => 'If your provider offers <em>app passwords</em>, use one of those. It is the detail that most often ends up rejected otherwise.',
+
+'form.fromname_label' => 'Display name',
+'form.optional'       => 'optional',
+'form.fromname_ph'    => 'Atenea',
+'form.fromname_hint'  => 'The name people see when the agent writes to them.',
+
+'form.imap_legend'    => 'Reading mail (IMAP)',
+'form.smtp_legend'    => 'Sending mail (SMTP)',
+'form.server'         => 'Server',
+'form.port'           => 'Port',
+'form.imap_host_ph'   => 'imap.yourprovider.example',
+'form.smtp_host_ph'   => 'smtp.yourprovider.example',
+'form.imap_hint'      => 'Ask your provider for the exact hostname. Guessing it by putting <code>imap.</code> in front of your domain often produces a name that works for everything except the security certificate, and that failure is hard to diagnose afterwards.',
+'form.smtp_hint'      => '465 or 587. Both are checked the same way.',
+
+'form.submit'         => 'Check and save',
+'form.footnote'       => 'This signs in to your mailbox and straight back out; it does not read, send or change anything. The settings are only saved if your mail server accepts them, so there is nothing to undo if something here is wrong.',
+
+'report.h2'           => 'Not saved yet: something here is wrong',
+'report.imap_h3'      => 'Reading mail',
+'report.smtp_h3'      => 'Sending mail',
+
+'v.account_missing'   => 'The agent needs an email address.',
+'v.account_bad'       => 'That does not look like an email address.',
+'v.password_missing'  => 'Without the password the agent cannot open the mailbox.',
+'v.fromname_oneline'  => 'The display name has to fit on a single line.',
+'v.host_missing'      => 'The {proto} hostname is missing.',
+'v.host_is_port'      => 'That is a port number, not a hostname. A hostname looks like this: imap.yourprovider.example.',
+'v.host_has_junk'     => 'Only the hostname goes here: no https://, no spaces, no address.',
+'v.host_bad_chars'    => 'That contains characters a hostname cannot have.',
+'v.port_missing'      => 'The {proto} port is missing.',
+'v.port_range'        => 'A port is a number between 1 and 65535.',
+
+'p.cert_mismatch'     => 'The server answered, but its security certificate is not issued for “{host}”. That usually means the hostname is slightly wrong; many providers want something like imap.yourprovider.example rather than mail.yourdomain.example. Ask your provider for the exact name they publish.',
+'p.no_dns'            => '“{host}” does not resolve to any machine. Check the spelling.',
+'p.refused'           => '“{host}” is reachable but refused the connection on that port. Most likely the port is wrong.',
+'p.timed_out'         => '“{host}” did not answer within {seconds} seconds. Either the hostname or the port is wrong, or a firewall is in the way.',
+'p.failed_silent'     => 'The connection failed without saying why.',
+
+'p.imap143'           => 'Port 143 does not work with this tool.',
+'p.imap143_detail'    => 'The listener opens IMAP over TLS immediately (IMAP4_SSL), and port 143 starts unencrypted. Use 993, which almost every provider offers.',
+'p.no_tls'            => 'Could not open an encrypted connection to {host}:{port}.',
+'p.tls_ok'            => 'Connected to {host}:{port} over TLS, and the certificate checks out.',
+'p.not_imap'          => 'That port answered, but it is not speaking IMAP.',
+'p.said'              => 'It said: {greeting}',
+'p.said_nothing'      => 'It said nothing at all.',
+'p.is_imap'           => 'The server identified itself as an IMAP server.',
+'p.auth_rejected'     => 'The server rejected that address and password.',
+'p.auth_rejected_d'   => 'Many providers want an app password here instead of the one you type on their website. If yours offers two-step verification, that is almost certainly the case.',
+'p.signed_in'         => 'Signed in successfully.',
+'p.signed_in_smtp'    => 'Signed in successfully, so the agent will be able to reply.',
+'p.idle_yes'          => 'The server supports IDLE, so new mail arrives within about a second.',
+'p.idle_no'           => 'This server does not offer IDLE.',
+'p.idle_no_detail'    => 'Without it there is no way to find out about new mail as it arrives, and this tool has nothing to fall back on. It is worth asking your provider before going on.',
+
+'p.no_reach'          => 'Could not reach {host}:{port}.',
+'p.not_smtp'          => 'That port answered, but it is not speaking SMTP.',
+'p.no_session'        => 'The server would not start a session.',
+'p.tls_upgraded'      => 'Connected to {host}:{port} and upgraded to TLS; the certificate checks out.',
+'p.no_encryption'     => 'This server does not encrypt the connection on that port.',
+'p.no_encryption_d'   => 'Sending a password over an unencrypted link is not something this tool will configure. Try port 465, or 587 if your provider supports STARTTLS.',
+'p.starttls_refused'  => 'The server refused to switch to an encrypted connection.',
+'p.tls_failed'        => 'The encrypted connection could not be established.',
+'p.no_auth_offered'   => 'The server offers no way to sign in on that port.',
+'p.no_auth_offered_d' => 'That usually means the port is for something else. 465 and 587 are the two worth trying.',
+'p.auth_method_bad'   => 'The server did not accept this way of signing in.',
+'p.address_rejected'  => 'The server rejected the address.',
+'p.send_auth_bad'     => 'The server rejected that address and password for sending.',
+'p.send_auth_bad_d'   => 'If signing in for reading worked, some providers still want a separate app password for sending, or need SMTP switched on in your account settings.',
+
+'g.loopback_1'        => 'This page only answers requests from the computer it runs on.',
+'g.loopback_2'        => 'If the agent is on a remote host, forward the port instead of this:',
+'g.token_1'           => 'This link is missing its one-time key, or the key changed.',
+'g.token_2'           => 'Ask the agent to run scripts/setup_web.sh again and send you the new link.',
+'g.csrf'              => 'That form expired. Reload the page and fill it in again.',
+];

--- a/webapp/i18n/en-US.php
+++ b/webapp/i18n/en-US.php
@@ -20,7 +20,6 @@ return [
 'saved.forgot'      => 'This page has already forgotten the password. Opening it again will not show it.',
 
 'warn.existing_p1'  => '<strong>Careful.</strong> There is already mail configuration at <code>{path}</code>. Finishing this form replaces it.',
-'warn.existing_p2'  => 'If the agent is already handling mail, close this page and check with whoever set it up before going on.',
 
 'help.summary'      => 'Where do I find these?',
 
@@ -134,4 +133,10 @@ return [
 'g.token_1'           => 'This link is missing its one-time key, or the key changed.',
 'g.token_2'           => 'Ask the agent to run scripts/setup_web.sh again and send you the new link.',
 'g.csrf'              => 'That form expired. Reload the page and fill it in again.',
+
+'f.mkdir_failed'        => 'Could not create {dir}.',
+'f.write_failed'        => 'Could not write in {dir}.',
+'f.incomplete'          => 'The file could not be written in full.',
+'f.symlink_failed'      => 'Could not write through the symlink to {target}.',
+'f.rename_failed'       => 'Could not put the file in place at {path}.',
 ];

--- a/webapp/i18n/es-ES.php
+++ b/webapp/i18n/es-ES.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+/** Español (ES). Traducido de es-MX: ordenador, léxico peninsular. */
+
+return [
+
+'page.title'        => 'paynani: configuración del buzón',
+'page.h1'           => 'Dale un buzón al agente',
+'page.lead'         => 'Siete datos de tu proveedor de correo. Todo se queda en este ordenador. Esta página no es accesible desde internet.',
+'lang.label'        => 'Idioma',
+'lang.apply'        => 'Cambiar',
+
+'saved.h1'          => 'Listo',
+'saved.lead'        => 'Tu servidor de correo aceptó la cuenta y la configuración ha quedado guardada. Ya puedes cerrar esta página.',
+'saved.where'       => 'Se ha guardado en <code>{path}</code>, y solo esta cuenta puede leerlo.',
+'saved.next_h2'     => 'Qué viene ahora',
+'saved.next_p1'     => 'Avisa al agente de que la configuración ya está. Él instala el resto y comprueba que el correo llegue; esa parte es su trabajo, no el tuyo.',
+'saved.next_p2'     => 'Lo único que merece la pena hacer tú: mándale un correo al agente y pregúntale qué acaba de llegar. Si te contesta en un par de segundos, todo funciona.',
+'saved.forgot'      => 'Esta página ya ha olvidado la contraseña. Volver a abrirla no la muestra otra vez.',
+
+'warn.existing_p1'  => '<strong>Cuidado.</strong> Ya hay configuración de correo en <code>{path}</code>. Si terminas este formulario, la reemplaza.',
+'warn.existing_p2'  => 'Si el agente ya está atendiendo correo, cierra esta página y confírmalo con quien lo configuró antes de seguir.',
+
+'help.summary'      => '¿Dónde encuentro estos datos?',
+
+'help.cpanel_h3'    => 'Si tu correo vino con tu alojamiento web (cPanel)',
+'help.cpanel_p'     => 'Es el caso más común, y los datos ya están escritos ahí para ti.',
+'help.cpanel_li1'   => 'Entra en cPanel, normalmente <code>tudominio.example/cpanel</code>, o el enlace que te mandó tu proveedor.',
+'help.cpanel_li2'   => 'Abre <strong>Email Accounts</strong> (Cuentas de correo).',
+'help.cpanel_li3'   => 'Busca la dirección que va a usar el agente y haz clic en <strong>Connect Devices</strong> (en versiones antiguas se llama <em>Set Up Mail Client</em>).',
+'help.cpanel_li4'   => 'Busca <strong>Mail Client Manual Settings</strong> y usa la columna <strong>Secure SSL/TLS Settings</strong>, no la que no lleva SSL.',
+'help.cpanel_after' => 'Copia <em>Incoming Server</em> y su puerto IMAP en la sección de lectura de abajo, y <em>Outgoing Server</em> con su puerto SMTP en la de envío. El usuario es la dirección de correo completa, y la contraseña es la que le pusiste a ese buzón al crearlo. Si no la recuerdas, cPanel te deja cambiarla en esa misma página.',
+
+'help.gmail_h3'     => 'Gmail o Google Workspace',
+'help.gmail_p1'     => 'Los nombres de servidor son siempre los mismos: <code>imap.gmail.com</code> puerto <code>993</code> para leer, <code>smtp.gmail.com</code> puerto <code>465</code> para enviar.',
+'help.gmail_p2'     => 'La contraseña es donde se atasca la gente. Google no acepta aquí la normal. Necesitas una <strong>contraseña de aplicación</strong>, que requiere tener activada antes la verificación en dos pasos. Créala en <code>myaccount.google.com</code> → Seguridad → Contraseñas de aplicaciones, y pega el código de 16 caracteres que te dé.',
+'help.gmail_p3'     => 'Comprueba también que IMAP esté activado: Gmail → Configuración → Reenvío y correo POP/IMAP.',
+
+'help.ms_h3'        => 'Outlook.com, Hotmail o Microsoft 365',
+'help.ms_p1'        => '<code>outlook.office365.com</code> puerto <code>993</code> para leer, <code>smtp.office365.com</code> puerto <code>587</code> para enviar.',
+'help.ms_p2'        => 'Muchas cuentas de empresa de Microsoft ya bloquean por política los inicios de sesión como este. Si la comprobación de abajo rechaza la contraseña aunque sea correcta, normalmente es por eso, y tu administrador tiene que permitirlo.',
+
+'help.zoho_h3'      => 'Zoho',
+'help.zoho_p'       => '<code>imappro.zoho.com</code> puerto <code>993</code>, <code>smtp.zoho.com</code> puerto <code>465</code>. Zoho también pide una contraseña de aplicación, no la normal.',
+
+'help.fastmail_h3'  => 'Fastmail',
+'help.fastmail_p'   => '<code>imap.fastmail.com</code> puerto <code>993</code>, <code>smtp.fastmail.com</code> puerto <code>465</code>, con contraseña de aplicación.',
+
+'help.other_h3'     => 'Cualquier otro',
+'help.other_p1'     => 'Pregunta a tu proveedor, o busca su nombre más <em>configuración IMAP y SMTP</em>. Buscas cuatro cosas: el nombre del servidor de entrada, el de salida, y un puerto para cada uno. Prefiere los puertos marcados como SSL o TLS.',
+'help.other_p2'     => 'Una advertencia que merece la pena repetir: no adivines el nombre del servidor poniendo <code>mail.</code> delante de tu dominio. A menudo funciona lo justo para parecer correcto y luego falla en el certificado de seguridad, que es horrible de diagnosticar después. La comprobación de abajo lo detecta y te lo dice claro.',
+
+'form.account_legend' => 'La cuenta',
+'form.account_label'  => 'Dirección de correo',
+'form.account_ph'     => 'agente@tudominio.example',
+'form.account_hint'   => 'El buzón propio del agente, no el tuyo.',
+
+'form.password_label' => 'Contraseña',
+'form.password_kept'  => '••••••••  se ha conservado la anterior',
+'form.password_hint'  => 'Si tu proveedor ofrece <em>contraseñas de aplicación</em>, usa una de esas. Es el dato que más a menudo acaba rechazado si no.',
+
+'form.fromname_label' => 'Nombre visible',
+'form.optional'       => 'opcional',
+'form.fromname_ph'    => 'Atenea',
+'form.fromname_hint'  => 'El nombre que ve la gente cuando el agente les escribe.',
+
+'form.imap_legend'    => 'Lectura de correo (IMAP)',
+'form.smtp_legend'    => 'Envío de correo (SMTP)',
+'form.server'         => 'Servidor',
+'form.port'           => 'Puerto',
+'form.imap_host_ph'   => 'imap.tuproveedor.example',
+'form.smtp_host_ph'   => 'smtp.tuproveedor.example',
+'form.imap_hint'      => 'Pide a tu proveedor el nombre exacto del servidor. Adivinarlo poniendo <code>imap.</code> delante de tu dominio produce a menudo un nombre que funciona en todo menos en el certificado de seguridad, y ese fallo es difícil de diagnosticar después.',
+'form.smtp_hint'      => '465 o 587. Los dos se comprueban igual.',
+
+'form.submit'         => 'Comprobar y guardar',
+'form.footnote'       => 'Esto entra en tu buzón y sale de inmediato; no lee, no envía ni cambia nada. La configuración se guarda solo si tu servidor de correo la acepta, así que no hay nada que deshacer si algo aquí está mal.',
+
+'report.h2'           => 'Todavía no se guarda: algo aquí no está bien',
+'report.imap_h3'      => 'Lectura de correo',
+'report.smtp_h3'      => 'Envío de correo',
+
+'v.account_missing'   => 'El agente necesita una dirección de correo.',
+'v.account_bad'       => 'Eso no parece una dirección de correo.',
+'v.password_missing'  => 'Sin la contraseña el agente no puede abrir el buzón.',
+'v.fromname_oneline'  => 'El nombre visible tiene que caber en una sola línea.',
+'v.host_missing'      => 'Falta el nombre del servidor {proto}.',
+'v.host_is_port'      => 'Eso es un número de puerto, no un nombre de servidor. El nombre se ve así: imap.tuproveedor.example.',
+'v.host_has_junk'     => 'Aquí va solo el nombre del servidor: sin https://, sin espacios, sin dirección.',
+'v.host_bad_chars'    => 'Eso lleva caracteres que un nombre de servidor no puede tener.',
+'v.port_missing'      => 'Falta el puerto {proto}.',
+'v.port_range'        => 'Un puerto es un número entre 1 y 65535.',
+
+'p.cert_mismatch'     => 'El servidor contestó, pero su certificado de seguridad no está emitido para «{host}». Normalmente eso significa que el nombre del servidor está un poco mal; muchos proveedores quieren algo como imap.tuproveedor.example y no mail.tudominio.example. Pide a tu proveedor el nombre exacto que publica.',
+'p.no_dns'            => '«{host}» no resuelve a ninguna máquina. Revisa cómo está escrito.',
+'p.refused'           => 'Se llega a «{host}» pero rechazó la conexión en ese puerto. Lo más probable es que el puerto esté mal.',
+'p.timed_out'         => '«{host}» no contestó en {seconds} segundos. O el nombre del servidor o el puerto están mal, o hay un cortafuegos estorbando.',
+'p.failed_silent'     => 'La conexión falló sin decir por qué.',
+
+'p.imap143'           => 'El puerto 143 no sirve con esta herramienta.',
+'p.imap143_detail'    => 'El listener abre IMAP sobre TLS de inmediato (IMAP4_SSL), y el puerto 143 empieza sin cifrar. Usa el 993, que es el que ofrece casi cualquier proveedor.',
+'p.no_tls'            => 'No se pudo abrir una conexión cifrada a {host}:{port}.',
+'p.tls_ok'            => 'Conectado a {host}:{port} por TLS, y el certificado es correcto.',
+'p.not_imap'          => 'Ese puerto contestó, pero no está hablando IMAP.',
+'p.said'              => 'Dijo: {greeting}',
+'p.said_nothing'      => 'No dijo absolutamente nada.',
+'p.is_imap'           => 'El servidor se identificó como un servidor IMAP.',
+'p.auth_rejected'     => 'El servidor rechazó esa dirección y contraseña.',
+'p.auth_rejected_d'   => 'Muchos proveedores piden aquí una contraseña de aplicación en lugar de la que escribes en su web. Si el tuyo ofrece verificación en dos pasos, casi seguro es el caso.',
+'p.signed_in'         => 'Sesión iniciada correctamente.',
+'p.signed_in_smtp'    => 'Sesión iniciada correctamente, así que el agente va a poder responder.',
+'p.idle_yes'          => 'El servidor soporta IDLE, así que el correo nuevo llega en un segundo aproximadamente.',
+'p.idle_no'           => 'Este servidor no ofrece IDLE.',
+'p.idle_no_detail'    => 'Sin eso no hay manera de enterarse del correo nuevo cuando llega, y esta herramienta no tiene nada a lo que recurrir. Merece la pena preguntar a tu proveedor antes de seguir.',
+
+'p.no_reach'          => 'No se pudo llegar a {host}:{port}.',
+'p.not_smtp'          => 'Ese puerto contestó, pero no está hablando SMTP.',
+'p.no_session'        => 'El servidor no quiso iniciar una sesión.',
+'p.tls_upgraded'      => 'Conectado a {host}:{port} y elevado a TLS; el certificado es correcto.',
+'p.no_encryption'     => 'Este servidor no cifra la conexión en ese puerto.',
+'p.no_encryption_d'   => 'Mandar una contraseña por un enlace sin cifrar no es algo que esta herramienta vaya a configurar. Prueba el puerto 465, o el 587 si tu proveedor soporta STARTTLS.',
+'p.starttls_refused'  => 'El servidor se negó a cambiar a una conexión cifrada.',
+'p.tls_failed'        => 'No se pudo establecer la conexión cifrada.',
+'p.no_auth_offered'   => 'El servidor no ofrece manera de iniciar sesión en ese puerto.',
+'p.no_auth_offered_d' => 'Normalmente eso significa que el puerto es para otra cosa. El 465 y el 587 son los dos que hay que probar.',
+'p.auth_method_bad'   => 'El servidor no aceptó esta forma de iniciar sesión.',
+'p.address_rejected'  => 'El servidor rechazó la dirección.',
+'p.send_auth_bad'     => 'El servidor rechazó esa dirección y contraseña para enviar.',
+'p.send_auth_bad_d'   => 'Si el inicio de sesión para leer sí funcionó, hay proveedores que además piden una contraseña de aplicación distinta para enviar, o que se active SMTP en la configuración de la cuenta.',
+
+'g.loopback_1'        => 'Esta página solo responde a peticiones desde el ordenador donde se ejecuta.',
+'g.loopback_2'        => 'Si el agente está en un host remoto, reenvía el puerto en lugar de esto:',
+'g.token_1'           => 'A este enlace le falta su llave de un solo uso, o la llave ha cambiado.',
+'g.token_2'           => 'Pide al agente que ejecute scripts/setup_web.sh otra vez y te mande el enlace nuevo.',
+'g.csrf'              => 'Ese formulario ha caducado. Recarga la página y rellénalo de nuevo.',
+];

--- a/webapp/i18n/es-ES.php
+++ b/webapp/i18n/es-ES.php
@@ -19,7 +19,6 @@ return [
 'saved.next_p2'     => 'Lo único que merece la pena hacer tú: mándale un correo al agente y pregúntale qué acaba de llegar. Si te contesta en un par de segundos, todo funciona.',
 'saved.forgot'      => 'Esta página ya ha olvidado la contraseña. Volver a abrirla no la muestra otra vez.',
 
-'warn.existing_p1'  => '<strong>Cuidado.</strong> Ya hay configuración de correo en <code>{path}</code>. Si terminas este formulario, la reemplaza.',
 
 'help.summary'      => '¿Dónde encuentro estos datos?',
 

--- a/webapp/i18n/es-ES.php
+++ b/webapp/i18n/es-ES.php
@@ -20,7 +20,6 @@ return [
 'saved.forgot'      => 'Esta página ya ha olvidado la contraseña. Volver a abrirla no la muestra otra vez.',
 
 'warn.existing_p1'  => '<strong>Cuidado.</strong> Ya hay configuración de correo en <code>{path}</code>. Si terminas este formulario, la reemplaza.',
-'warn.existing_p2'  => 'Si el agente ya está atendiendo correo, cierra esta página y confírmalo con quien lo configuró antes de seguir.',
 
 'help.summary'      => '¿Dónde encuentro estos datos?',
 
@@ -134,4 +133,10 @@ return [
 'g.token_1'           => 'A este enlace le falta su llave de un solo uso, o la llave ha cambiado.',
 'g.token_2'           => 'Pide al agente que ejecute scripts/setup_web.sh otra vez y te mande el enlace nuevo.',
 'g.csrf'              => 'Ese formulario ha caducado. Recarga la página y rellénalo de nuevo.',
+
+'f.mkdir_failed'        => 'No se ha podido crear {dir}.',
+'f.write_failed'        => 'No se ha podido escribir en {dir}.',
+'f.incomplete'          => 'El archivo no se ha podido escribir entero.',
+'f.symlink_failed'      => 'No se ha podido escribir a través del enlace simbólico hacia {target}.',
+'f.rename_failed'       => 'No se ha podido dejar el archivo en su sitio en {path}.',
 ];

--- a/webapp/i18n/es-MX.php
+++ b/webapp/i18n/es-MX.php
@@ -25,8 +25,7 @@ return [
 'saved.forgot'      => 'Esta página ya olvidó la contraseña. Volver a abrirla no la muestra otra vez.',
 
 // ── El aviso de configuración existente ──────────────────────────────────────
-'warn.existing_p1'  => '<strong>Aguas.</strong> Ya hay configuración de correo en <code>{path}</code>. Si terminas este formulario, la reemplaza.',
-'warn.existing_p2'  => 'Si el agente ya está atendiendo correo, cierra esta página y confirma con quien lo configuró antes de seguir.',
+'warn.existing_p1'  => '<strong>Cuidado.</strong> Ya hay configuración de correo en <code>{path}</code>. Si terminas este formulario, la reemplaza.',
 
 // ── La ayuda desplegable ─────────────────────────────────────────────────────
 'help.summary'      => '¿Dónde encuentro estos datos?',
@@ -138,6 +137,13 @@ return [
 'p.address_rejected'  => 'El servidor rechazó la dirección.',
 'p.send_auth_bad'     => 'El servidor rechazó esa dirección y contraseña para enviar.',
 'p.send_auth_bad_d'   => 'Si el inicio de sesión para leer sí funcionó, hay proveedores que además piden una contraseña de aplicación distinta para enviar, o que se active SMTP en la configuración de la cuenta.',
+
+// ── Al escribir el archivo ───────────────────────────────────────────────────
+'f.mkdir_failed'        => 'No se pudo crear {dir}.',
+'f.write_failed'        => 'No se pudo escribir en {dir}.',
+'f.incomplete'          => 'El archivo no se pudo escribir completo.',
+'f.symlink_failed'      => 'No se pudo escribir a través del enlace simbólico hacia {target}.',
+'f.rename_failed'       => 'No se pudo dejar el archivo en su lugar en {path}.',
 
 // ── Las pantallas de rechazo ─────────────────────────────────────────────────
 'g.loopback_1'        => 'Esta página solo responde a peticiones desde la computadora donde corre.',

--- a/webapp/i18n/es-MX.php
+++ b/webapp/i18n/es-MX.php
@@ -1,0 +1,148 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Español (MX). The source language: every other catalogue is translated from
+ * this one, and a key missing elsewhere falls back to here.
+ */
+
+return [
+
+// ── La página ────────────────────────────────────────────────────────────────
+'page.title'        => 'paynani: configuración del buzón',
+'page.h1'           => 'Dale un buzón al agente',
+'page.lead'         => 'Siete datos de tu proveedor de correo. Todo se queda en esta computadora. Esta página no es accesible desde internet.',
+'lang.label'        => 'Idioma',
+'lang.apply'        => 'Cambiar',
+
+// ── Cuando ya se guardó ──────────────────────────────────────────────────────
+'saved.h1'          => 'Listo',
+'saved.lead'        => 'Tu servidor de correo aceptó la cuenta y la configuración quedó guardada. Ya puedes cerrar esta página.',
+'saved.where'       => 'Se guardó en <code>{path}</code>, y solo esta cuenta puede leerlo.',
+'saved.next_h2'     => 'Qué sigue',
+'saved.next_p1'     => 'Avísale al agente que la configuración ya está. Él instala el resto y verifica que el correo llegue; esa parte es su trabajo, no el tuyo.',
+'saved.next_p2'     => 'Lo único que vale la pena hacer tú: mándale un correo al agente y pregúntale qué acaba de llegar. Si te contesta en un par de segundos, todo funciona.',
+'saved.forgot'      => 'Esta página ya olvidó la contraseña. Volver a abrirla no la muestra otra vez.',
+
+// ── El aviso de configuración existente ──────────────────────────────────────
+'warn.existing_p1'  => '<strong>Aguas.</strong> Ya hay configuración de correo en <code>{path}</code>. Si terminas este formulario, la reemplaza.',
+'warn.existing_p2'  => 'Si el agente ya está atendiendo correo, cierra esta página y confirma con quien lo configuró antes de seguir.',
+
+// ── La ayuda desplegable ─────────────────────────────────────────────────────
+'help.summary'      => '¿Dónde encuentro estos datos?',
+
+'help.cpanel_h3'    => 'Si tu correo vino con tu hosting web (cPanel)',
+'help.cpanel_p'     => 'Es el caso más común, y los datos ya están escritos ahí para ti.',
+'help.cpanel_li1'   => 'Entra a cPanel, normalmente <code>tudominio.example/cpanel</code>, o el enlace que te mandó tu proveedor.',
+'help.cpanel_li2'   => 'Abre <strong>Email Accounts</strong> (Cuentas de correo).',
+'help.cpanel_li3'   => 'Busca la dirección que va a usar el agente y haz clic en <strong>Connect Devices</strong> (en versiones viejas se llama <em>Set Up Mail Client</em>).',
+'help.cpanel_li4'   => 'Busca <strong>Mail Client Manual Settings</strong> y usa la columna <strong>Secure SSL/TLS Settings</strong>, no la que no lleva SSL.',
+'help.cpanel_after' => 'Copia <em>Incoming Server</em> y su puerto IMAP a la sección de lectura de abajo, y <em>Outgoing Server</em> con su puerto SMTP a la de envío. El usuario es la dirección de correo completa, y la contraseña es la que le pusiste a ese buzón cuando lo creaste. Si no la recuerdas, cPanel te deja cambiarla en esa misma página.',
+
+'help.gmail_h3'     => 'Gmail o Google Workspace',
+'help.gmail_p1'     => 'Los nombres de servidor siempre son los mismos: <code>imap.gmail.com</code> puerto <code>993</code> para leer, <code>smtp.gmail.com</code> puerto <code>465</code> para enviar.',
+'help.gmail_p2'     => 'La contraseña es donde se atora la gente. Google no acepta aquí la normal. Necesitas una <strong>contraseña de aplicación</strong>, que requiere tener activada primero la verificación en dos pasos. Créala en <code>myaccount.google.com</code> → Seguridad → Contraseñas de aplicaciones, y pega el código de 16 caracteres que te dé.',
+'help.gmail_p3'     => 'Revisa también que IMAP esté activado: Gmail → Configuración → Reenvío y correo POP/IMAP.',
+
+'help.ms_h3'        => 'Outlook.com, Hotmail o Microsoft 365',
+'help.ms_p1'        => '<code>outlook.office365.com</code> puerto <code>993</code> para leer, <code>smtp.office365.com</code> puerto <code>587</code> para enviar.',
+'help.ms_p2'        => 'Muchas cuentas empresariales de Microsoft ya bloquean por política los inicios de sesión como este. Si la verificación de abajo rechaza la contraseña aunque esté bien, normalmente es por eso, y tu administrador tiene que permitirlo.',
+
+'help.zoho_h3'      => 'Zoho',
+'help.zoho_p'       => '<code>imappro.zoho.com</code> puerto <code>993</code>, <code>smtp.zoho.com</code> puerto <code>465</code>. Zoho también pide una contraseña de aplicación, no la normal.',
+
+'help.fastmail_h3'  => 'Fastmail',
+'help.fastmail_p'   => '<code>imap.fastmail.com</code> puerto <code>993</code>, <code>smtp.fastmail.com</code> puerto <code>465</code>, con contraseña de aplicación.',
+
+'help.other_h3'     => 'Cualquier otro',
+'help.other_p1'     => 'Pregúntale a tu proveedor, o busca su nombre más <em>configuración IMAP y SMTP</em>. Buscas cuatro cosas: el nombre del servidor de entrada, el de salida, y un puerto para cada uno. Prefiere los puertos marcados como SSL o TLS.',
+'help.other_p2'     => 'Una advertencia que vale la pena repetir: no adivines el nombre del servidor poniéndole <code>mail.</code> enfrente a tu dominio. Seguido funciona lo suficiente para parecer correcto y luego falla en el certificado de seguridad, que es horrible de diagnosticar después. La verificación de abajo lo detecta y te lo dice claro.',
+
+// ── El formulario ────────────────────────────────────────────────────────────
+'form.account_legend' => 'La cuenta',
+'form.account_label'  => 'Dirección de correo',
+'form.account_ph'     => 'agente@tudominio.example',
+'form.account_hint'   => 'El buzón propio del agente, no el tuyo.',
+
+'form.password_label' => 'Contraseña',
+'form.password_kept'  => '••••••••  se conservó la anterior',
+'form.password_hint'  => 'Si tu proveedor ofrece <em>contraseñas de aplicación</em>, usa una de esas. Es el dato que más seguido termina rechazado si no.',
+
+'form.fromname_label' => 'Nombre visible',
+'form.optional'       => 'opcional',
+'form.fromname_ph'    => 'Atenea',
+'form.fromname_hint'  => 'El nombre que ve la gente cuando el agente les escribe.',
+
+'form.imap_legend'    => 'Lectura de correo (IMAP)',
+'form.smtp_legend'    => 'Envío de correo (SMTP)',
+'form.server'         => 'Servidor',
+'form.port'           => 'Puerto',
+'form.imap_host_ph'   => 'imap.tuproveedor.example',
+'form.smtp_host_ph'   => 'smtp.tuproveedor.example',
+'form.imap_hint'      => 'Pídele a tu proveedor el nombre exacto del servidor. Adivinarlo poniendo <code>imap.</code> enfrente de tu dominio seguido produce un nombre que funciona en todo menos en el certificado de seguridad, y ese falla es difícil de diagnosticar después.',
+'form.smtp_hint'      => '465 o 587. Los dos se verifican igual.',
+
+'form.submit'         => 'Verificar y guardar',
+'form.footnote'       => 'Esto entra a tu buzón y sale de inmediato; no lee, no envía ni cambia nada. La configuración se guarda solo si tu servidor de correo la acepta, así que no hay nada que deshacer si algo aquí está mal.',
+
+'report.h2'           => 'Todavía no se guarda: algo aquí no está bien',
+'report.imap_h3'      => 'Lectura de correo',
+'report.smtp_h3'      => 'Envío de correo',
+
+// ── Validación del formulario ────────────────────────────────────────────────
+'v.account_missing'   => 'El agente necesita una dirección de correo.',
+'v.account_bad'       => 'Eso no parece una dirección de correo.',
+'v.password_missing'  => 'Sin la contraseña el agente no puede abrir el buzón.',
+'v.fromname_oneline'  => 'El nombre visible tiene que caber en una sola línea.',
+'v.host_missing'      => 'Falta el nombre del servidor {proto}.',
+'v.host_is_port'      => 'Eso es un número de puerto, no un nombre de servidor. El nombre se ve así: imap.tuproveedor.example.',
+'v.host_has_junk'     => 'Aquí va solo el nombre del servidor: sin https://, sin espacios, sin dirección.',
+'v.host_bad_chars'    => 'Eso trae caracteres que un nombre de servidor no puede tener.',
+'v.port_missing'      => 'Falta el puerto {proto}.',
+'v.port_range'        => 'Un puerto es un número entre 1 y 65535.',
+
+// ── La verificación contra el servidor real ──────────────────────────────────
+'p.cert_mismatch'     => 'El servidor contestó, pero su certificado de seguridad no está emitido para “{host}”. Normalmente eso significa que el nombre del servidor está un poco mal; muchos proveedores quieren algo como imap.tuproveedor.example y no mail.tudominio.example. Pídele a tu proveedor el nombre exacto que publica.',
+'p.no_dns'            => '“{host}” no resuelve a ninguna máquina. Revisa cómo está escrito.',
+'p.refused'           => 'Se llega a “{host}” pero rechazó la conexión en ese puerto. Lo más probable es que el puerto esté mal.',
+'p.timed_out'         => '“{host}” no contestó en {seconds} segundos. O el nombre del servidor o el puerto están mal, o hay un firewall estorbando.',
+'p.failed_silent'     => 'La conexión falló sin decir por qué.',
+
+'p.imap143'           => 'El puerto 143 no sirve con esta herramienta.',
+'p.imap143_detail'    => 'El listener abre IMAP sobre TLS de inmediato (IMAP4_SSL), y el puerto 143 empieza sin cifrar. Usa el 993, que es el que ofrece casi cualquier proveedor.',
+'p.no_tls'            => 'No se pudo abrir una conexión cifrada a {host}:{port}.',
+'p.tls_ok'            => 'Conectado a {host}:{port} por TLS, y el certificado está correcto.',
+'p.not_imap'          => 'Ese puerto contestó, pero no está hablando IMAP.',
+'p.said'              => 'Dijo: {greeting}',
+'p.said_nothing'      => 'No dijo absolutamente nada.',
+'p.is_imap'           => 'El servidor se identificó como un servidor IMAP.',
+'p.auth_rejected'     => 'El servidor rechazó esa dirección y contraseña.',
+'p.auth_rejected_d'   => 'Muchos proveedores piden aquí una contraseña de aplicación en lugar de la que escribes en su sitio web. Si el tuyo ofrece verificación en dos pasos, casi seguro es el caso.',
+'p.signed_in'         => 'Sesión iniciada correctamente.',
+'p.signed_in_smtp'    => 'Sesión iniciada correctamente, así que el agente va a poder responder.',
+'p.idle_yes'          => 'El servidor soporta IDLE, así que el correo nuevo llega en más o menos un segundo.',
+'p.idle_no'           => 'Este servidor no ofrece IDLE.',
+'p.idle_no_detail'    => 'Sin eso no hay manera de enterarse del correo nuevo cuando llega, y esta herramienta no tiene nada a qué recurrir. Vale la pena preguntarle a tu proveedor antes de seguir.',
+
+'p.no_reach'          => 'No se pudo llegar a {host}:{port}.',
+'p.not_smtp'          => 'Ese puerto contestó, pero no está hablando SMTP.',
+'p.no_session'        => 'El servidor no quiso iniciar una sesión.',
+'p.tls_upgraded'      => 'Conectado a {host}:{port} y elevado a TLS; el certificado está correcto.',
+'p.no_encryption'     => 'Este servidor no cifra la conexión en ese puerto.',
+'p.no_encryption_d'   => 'Mandar una contraseña por un enlace sin cifrar no es algo que esta herramienta vaya a configurar. Prueba el puerto 465, o el 587 si tu proveedor soporta STARTTLS.',
+'p.starttls_refused'  => 'El servidor se negó a cambiar a una conexión cifrada.',
+'p.tls_failed'        => 'No se pudo establecer la conexión cifrada.',
+'p.no_auth_offered'   => 'El servidor no ofrece manera de iniciar sesión en ese puerto.',
+'p.no_auth_offered_d' => 'Normalmente eso significa que el puerto es para otra cosa. El 465 y el 587 son los dos que hay que probar.',
+'p.auth_method_bad'   => 'El servidor no aceptó esta forma de iniciar sesión.',
+'p.address_rejected'  => 'El servidor rechazó la dirección.',
+'p.send_auth_bad'     => 'El servidor rechazó esa dirección y contraseña para enviar.',
+'p.send_auth_bad_d'   => 'Si el inicio de sesión para leer sí funcionó, hay proveedores que además piden una contraseña de aplicación distinta para enviar, o que se active SMTP en la configuración de la cuenta.',
+
+// ── Las pantallas de rechazo ─────────────────────────────────────────────────
+'g.loopback_1'        => 'Esta página solo responde a peticiones desde la computadora donde corre.',
+'g.loopback_2'        => 'Si el agente está en un host remoto, reenvía el puerto en lugar de esto:',
+'g.token_1'           => 'A este enlace le falta su llave de un solo uso, o la llave cambió.',
+'g.token_2'           => 'Pídele al agente que corra scripts/setup_web.sh otra vez y te mande el enlace nuevo.',
+'g.csrf'              => 'Ese formulario expiró. Recarga la página y llénalo de nuevo.',
+];

--- a/webapp/i18n/es-MX.php
+++ b/webapp/i18n/es-MX.php
@@ -24,9 +24,6 @@ return [
 'saved.next_p2'     => 'Lo único que vale la pena hacer tú: mándale un correo al agente y pregúntale qué acaba de llegar. Si te contesta en un par de segundos, todo funciona.',
 'saved.forgot'      => 'Esta página ya olvidó la contraseña. Volver a abrirla no la muestra otra vez.',
 
-// ── El aviso de configuración existente ──────────────────────────────────────
-'warn.existing_p1'  => '<strong>Cuidado.</strong> Ya hay configuración de correo en <code>{path}</code>. Si terminas este formulario, la reemplaza.',
-
 // ── La ayuda desplegable ─────────────────────────────────────────────────────
 'help.summary'      => '¿Dónde encuentro estos datos?',
 

--- a/webapp/i18n/fr-FR.php
+++ b/webapp/i18n/fr-FR.php
@@ -20,7 +20,6 @@ return [
 'saved.forgot'      => 'Cette page a déjà oublié le mot de passe. La rouvrir ne l\'affichera pas de nouveau.',
 
 'warn.existing_p1'  => '<strong>Attention.</strong> Il y a déjà une configuration de messagerie dans <code>{path}</code>. Terminer ce formulaire la remplace.',
-'warn.existing_p2'  => 'Si l\'agent traite déjà du courrier, fermez cette page et vérifiez auprès de la personne qui l\'a configuré avant de continuer.',
 
 'help.summary'      => 'Où est-ce que je trouve ces informations ?',
 
@@ -134,4 +133,10 @@ return [
 'g.token_1'           => 'Il manque à ce lien sa clé à usage unique, ou la clé a changé.',
 'g.token_2'           => 'Demandez à l\'agent de relancer scripts/setup_web.sh et de vous envoyer le nouveau lien.',
 'g.csrf'              => 'Ce formulaire a expiré. Rechargez la page et remplissez-le de nouveau.',
+
+'f.mkdir_failed'        => 'Impossible de créer {dir}.',
+'f.write_failed'        => 'Impossible d\'écrire dans {dir}.',
+'f.incomplete'          => 'Le fichier n\'a pas pu être écrit en entier.',
+'f.symlink_failed'      => 'Impossible d\'écrire à travers le lien symbolique vers {target}.',
+'f.rename_failed'       => 'Impossible de mettre le fichier en place dans {path}.',
 ];

--- a/webapp/i18n/fr-FR.php
+++ b/webapp/i18n/fr-FR.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+/** Français (FR). Traduit depuis es-MX. */
+
+return [
+
+'page.title'        => 'paynani : configuration de la boîte mail',
+'page.h1'           => 'Donnez une boîte mail à l\'agent',
+'page.lead'         => 'Sept informations venant de votre fournisseur de messagerie. Tout reste sur cet ordinateur. Cette page n\'est pas accessible depuis internet.',
+'lang.label'        => 'Langue',
+'lang.apply'        => 'Changer',
+
+'saved.h1'          => 'C\'est fait',
+'saved.lead'        => 'Votre serveur de messagerie a accepté le compte et la configuration est enregistrée. Vous pouvez fermer cette page.',
+'saved.where'       => 'Enregistré dans <code>{path}</code>, et seul ce compte peut le lire.',
+'saved.next_h2'     => 'La suite',
+'saved.next_p1'     => 'Prévenez l\'agent que la configuration est en place. Il installe le reste et vérifie que le courrier arrive ; cette partie est son travail, pas le vôtre.',
+'saved.next_p2'     => 'La seule chose qui vaille la peine de votre côté : envoyez un courriel à l\'agent et demandez-lui ce qui vient d\'arriver. S\'il répond en deux secondes, tout fonctionne.',
+'saved.forgot'      => 'Cette page a déjà oublié le mot de passe. La rouvrir ne l\'affichera pas de nouveau.',
+
+'warn.existing_p1'  => '<strong>Attention.</strong> Il y a déjà une configuration de messagerie dans <code>{path}</code>. Terminer ce formulaire la remplace.',
+'warn.existing_p2'  => 'Si l\'agent traite déjà du courrier, fermez cette page et vérifiez auprès de la personne qui l\'a configuré avant de continuer.',
+
+'help.summary'      => 'Où est-ce que je trouve ces informations ?',
+
+'help.cpanel_h3'    => 'Si votre messagerie est venue avec votre hébergement web (cPanel)',
+'help.cpanel_p'     => 'C\'est le cas le plus courant, et les informations y sont déjà écrites pour vous.',
+'help.cpanel_li1'   => 'Connectez-vous à cPanel, en général <code>votredomaine.example/cpanel</code>, ou le lien que votre hébergeur vous a envoyé.',
+'help.cpanel_li2'   => 'Ouvrez <strong>Email Accounts</strong> (Comptes de messagerie).',
+'help.cpanel_li3'   => 'Trouvez l\'adresse que l\'agent va utiliser et cliquez sur <strong>Connect Devices</strong> (les anciennes versions l\'appellent <em>Set Up Mail Client</em>).',
+'help.cpanel_li4'   => 'Cherchez <strong>Mail Client Manual Settings</strong> et utilisez la colonne <strong>Secure SSL/TLS Settings</strong>, pas celle sans SSL.',
+'help.cpanel_after' => 'Copiez <em>Incoming Server</em> et son port IMAP dans la section de lecture ci-dessous, et <em>Outgoing Server</em> avec son port SMTP dans celle d\'envoi. L\'identifiant est l\'adresse électronique complète, et le mot de passe est celui que vous avez donné à cette boîte à sa création. Si vous ne vous en souvenez pas, cPanel vous laisse le changer sur cette même page.',
+
+'help.gmail_h3'     => 'Gmail ou Google Workspace',
+'help.gmail_p1'     => 'Les noms de serveur sont toujours les mêmes : <code>imap.gmail.com</code> port <code>993</code> pour lire, <code>smtp.gmail.com</code> port <code>465</code> pour envoyer.',
+'help.gmail_p2'     => 'C\'est le mot de passe qui bloque tout le monde. Google n\'accepte pas ici le mot de passe habituel. Il vous faut un <strong>mot de passe d\'application</strong>, ce qui exige d\'avoir d\'abord activé la validation en deux étapes. Créez-le sur <code>myaccount.google.com</code> → Sécurité → Mots de passe des applications, et collez le code de 16 caractères qu\'il vous donne.',
+'help.gmail_p3'     => 'Vérifiez aussi qu\'IMAP est activé : Gmail → Paramètres → Transfert et POP/IMAP.',
+
+'help.ms_h3'        => 'Outlook.com, Hotmail ou Microsoft 365',
+'help.ms_p1'        => '<code>outlook.office365.com</code> port <code>993</code> pour lire, <code>smtp.office365.com</code> port <code>587</code> pour envoyer.',
+'help.ms_p2'        => 'Beaucoup de comptes Microsoft d\'entreprise bloquent désormais par politique les connexions de ce type. Si la vérification ci-dessous refuse le mot de passe alors qu\'il est bon, c\'est généralement pour cette raison, et votre administrateur doit l\'autoriser.',
+
+'help.zoho_h3'      => 'Zoho',
+'help.zoho_p'       => '<code>imappro.zoho.com</code> port <code>993</code>, <code>smtp.zoho.com</code> port <code>465</code>. Zoho demande aussi un mot de passe d\'application, pas le mot de passe habituel.',
+
+'help.fastmail_h3'  => 'Fastmail',
+'help.fastmail_p'   => '<code>imap.fastmail.com</code> port <code>993</code>, <code>smtp.fastmail.com</code> port <code>465</code>, avec un mot de passe d\'application.',
+
+'help.other_h3'     => 'N\'importe quel autre',
+'help.other_p1'     => 'Demandez à votre fournisseur, ou cherchez son nom suivi de <em>configuration IMAP et SMTP</em>. Vous cherchez quatre choses : le nom du serveur entrant, celui du sortant, et un port pour chacun. Préférez les ports marqués SSL ou TLS.',
+'help.other_p2'     => 'Un avertissement qui mérite d\'être répété : ne devinez pas le nom du serveur en mettant <code>mail.</code> devant votre domaine. Cela marche souvent juste assez pour avoir l\'air correct, puis échoue sur le certificat de sécurité, ce qui est horrible à diagnostiquer ensuite. La vérification ci-dessous le détecte et vous le dit clairement.',
+
+'form.account_legend' => 'Le compte',
+'form.account_label'  => 'Adresse électronique',
+'form.account_ph'     => 'agent@votredomaine.example',
+'form.account_hint'   => 'La boîte propre à l\'agent, pas la vôtre.',
+
+'form.password_label' => 'Mot de passe',
+'form.password_kept'  => '••••••••  le précédent a été conservé',
+'form.password_hint'  => 'Si votre fournisseur propose des <em>mots de passe d\'application</em>, utilisez-en un. C\'est l\'information qui finit le plus souvent refusée sinon.',
+
+'form.fromname_label' => 'Nom affiché',
+'form.optional'       => 'facultatif',
+'form.fromname_ph'    => 'Atenea',
+'form.fromname_hint'  => 'Le nom que voient les gens quand l\'agent leur écrit.',
+
+'form.imap_legend'    => 'Lecture du courrier (IMAP)',
+'form.smtp_legend'    => 'Envoi du courrier (SMTP)',
+'form.server'         => 'Serveur',
+'form.port'           => 'Port',
+'form.imap_host_ph'   => 'imap.votrehebergeur.example',
+'form.smtp_host_ph'   => 'smtp.votrehebergeur.example',
+'form.imap_hint'      => 'Demandez à votre fournisseur le nom exact du serveur. Le deviner en mettant <code>imap.</code> devant votre domaine produit souvent un nom qui marche partout sauf sur le certificat de sécurité, et cette panne-là est difficile à diagnostiquer ensuite.',
+'form.smtp_hint'      => '465 ou 587. Les deux se vérifient de la même façon.',
+
+'form.submit'         => 'Vérifier et enregistrer',
+'form.footnote'       => 'Ceci entre dans votre boîte et en ressort aussitôt ; cela ne lit rien, n\'envoie rien et ne change rien. La configuration n\'est enregistrée que si votre serveur de messagerie l\'accepte, il n\'y a donc rien à défaire si quelque chose ici est faux.',
+
+'report.h2'           => 'Pas encore enregistré : quelque chose ne va pas ici',
+'report.imap_h3'      => 'Lecture du courrier',
+'report.smtp_h3'      => 'Envoi du courrier',
+
+'v.account_missing'   => 'L\'agent a besoin d\'une adresse électronique.',
+'v.account_bad'       => 'Cela ne ressemble pas à une adresse électronique.',
+'v.password_missing'  => 'Sans le mot de passe, l\'agent ne peut pas ouvrir la boîte.',
+'v.fromname_oneline'  => 'Le nom affiché doit tenir sur une seule ligne.',
+'v.host_missing'      => 'Le nom du serveur {proto} manque.',
+'v.host_is_port'      => 'C\'est un numéro de port, pas un nom de serveur. Un nom de serveur ressemble à ceci : imap.votrehebergeur.example.',
+'v.host_has_junk'     => 'Ici va uniquement le nom du serveur : sans https://, sans espaces, sans adresse.',
+'v.host_bad_chars'    => 'Cela contient des caractères qu\'un nom de serveur ne peut pas avoir.',
+'v.port_missing'      => 'Le port {proto} manque.',
+'v.port_range'        => 'Un port est un nombre entre 1 et 65535.',
+
+'p.cert_mismatch'     => 'Le serveur a répondu, mais son certificat de sécurité n\'est pas émis pour « {host} ». Cela signifie généralement que le nom du serveur est un peu faux ; beaucoup de fournisseurs veulent quelque chose comme imap.votrehebergeur.example et non mail.votredomaine.example. Demandez à votre fournisseur le nom exact qu\'il publie.',
+'p.no_dns'            => '« {host} » ne résout vers aucune machine. Vérifiez l\'orthographe.',
+'p.refused'           => 'On atteint « {host} » mais il a refusé la connexion sur ce port. Le plus probable est que le port soit faux.',
+'p.timed_out'         => '« {host} » n\'a pas répondu en {seconds} secondes. Soit le nom du serveur soit le port est faux, soit un pare-feu gêne.',
+'p.failed_silent'     => 'La connexion a échoué sans dire pourquoi.',
+
+'p.imap143'           => 'Le port 143 ne convient pas à cet outil.',
+'p.imap143_detail'    => 'Le listener ouvre IMAP sur TLS immédiatement (IMAP4_SSL), et le port 143 commence sans chiffrement. Utilisez le 993, que presque tous les fournisseurs proposent.',
+'p.no_tls'            => 'Impossible d\'ouvrir une connexion chiffrée vers {host}:{port}.',
+'p.tls_ok'            => 'Connecté à {host}:{port} en TLS, et le certificat est correct.',
+'p.not_imap'          => 'Ce port a répondu, mais il ne parle pas IMAP.',
+'p.said'              => 'Il a dit : {greeting}',
+'p.said_nothing'      => 'Il n\'a absolument rien dit.',
+'p.is_imap'           => 'Le serveur s\'est identifié comme un serveur IMAP.',
+'p.auth_rejected'     => 'Le serveur a refusé cette adresse et ce mot de passe.',
+'p.auth_rejected_d'   => 'Beaucoup de fournisseurs veulent ici un mot de passe d\'application plutôt que celui que vous tapez sur leur site. Si le vôtre propose la validation en deux étapes, c\'est presque certainement le cas.',
+'p.signed_in'         => 'Connexion réussie.',
+'p.signed_in_smtp'    => 'Connexion réussie, l\'agent pourra donc répondre.',
+'p.idle_yes'          => 'Le serveur prend en charge IDLE, le courrier nouveau arrive donc en une seconde environ.',
+'p.idle_no'           => 'Ce serveur ne propose pas IDLE.',
+'p.idle_no_detail'    => 'Sans cela, il n\'y a aucun moyen d\'apprendre l\'arrivée du courrier au moment où il arrive, et cet outil n\'a rien vers quoi se rabattre. Cela vaut la peine d\'interroger votre fournisseur avant de continuer.',
+
+'p.no_reach'          => 'Impossible d\'atteindre {host}:{port}.',
+'p.not_smtp'          => 'Ce port a répondu, mais il ne parle pas SMTP.',
+'p.no_session'        => 'Le serveur n\'a pas voulu ouvrir de session.',
+'p.tls_upgraded'      => 'Connecté à {host}:{port} puis élevé en TLS ; le certificat est correct.',
+'p.no_encryption'     => 'Ce serveur ne chiffre pas la connexion sur ce port.',
+'p.no_encryption_d'   => 'Envoyer un mot de passe sur un lien non chiffré n\'est pas quelque chose que cet outil va configurer. Essayez le port 465, ou le 587 si votre fournisseur prend en charge STARTTLS.',
+'p.starttls_refused'  => 'Le serveur a refusé de passer à une connexion chiffrée.',
+'p.tls_failed'        => 'La connexion chiffrée n\'a pas pu être établie.',
+'p.no_auth_offered'   => 'Le serveur n\'offre aucun moyen de se connecter sur ce port.',
+'p.no_auth_offered_d' => 'Cela signifie généralement que le port sert à autre chose. Le 465 et le 587 sont les deux à essayer.',
+'p.auth_method_bad'   => 'Le serveur n\'a pas accepté cette façon de se connecter.',
+'p.address_rejected'  => 'Le serveur a refusé l\'adresse.',
+'p.send_auth_bad'     => 'Le serveur a refusé cette adresse et ce mot de passe pour l\'envoi.',
+'p.send_auth_bad_d'   => 'Si la connexion pour la lecture a fonctionné, certains fournisseurs veulent malgré tout un mot de passe d\'application distinct pour l\'envoi, ou demandent que SMTP soit activé dans les réglages du compte.',
+
+'g.loopback_1'        => 'Cette page ne répond qu\'aux requêtes venant de l\'ordinateur où elle tourne.',
+'g.loopback_2'        => 'Si l\'agent est sur un hôte distant, redirigez le port au lieu de ceci :',
+'g.token_1'           => 'Il manque à ce lien sa clé à usage unique, ou la clé a changé.',
+'g.token_2'           => 'Demandez à l\'agent de relancer scripts/setup_web.sh et de vous envoyer le nouveau lien.',
+'g.csrf'              => 'Ce formulaire a expiré. Rechargez la page et remplissez-le de nouveau.',
+];

--- a/webapp/i18n/fr-FR.php
+++ b/webapp/i18n/fr-FR.php
@@ -19,7 +19,6 @@ return [
 'saved.next_p2'     => 'La seule chose qui vaille la peine de votre côté : envoyez un courriel à l\'agent et demandez-lui ce qui vient d\'arriver. S\'il répond en deux secondes, tout fonctionne.',
 'saved.forgot'      => 'Cette page a déjà oublié le mot de passe. La rouvrir ne l\'affichera pas de nouveau.',
 
-'warn.existing_p1'  => '<strong>Attention.</strong> Il y a déjà une configuration de messagerie dans <code>{path}</code>. Terminer ce formulaire la remplace.',
 
 'help.summary'      => 'Où est-ce que je trouve ces informations ?',
 

--- a/webapp/i18n/pt-BR.php
+++ b/webapp/i18n/pt-BR.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+/** Português (BR). Traduzido do es-MX. */
+
+return [
+
+'page.title'        => 'paynani: configuração da caixa de e-mail',
+'page.h1'           => 'Dê uma caixa de e-mail ao agente',
+'page.lead'         => 'Sete dados do seu provedor de e-mail. Tudo fica neste computador. Esta página não é acessível pela internet.',
+'lang.label'        => 'Idioma',
+'lang.apply'        => 'Trocar',
+
+'saved.h1'          => 'Pronto',
+'saved.lead'        => 'Seu servidor de e-mail aceitou a conta e a configuração ficou salva. Já pode fechar esta página.',
+'saved.where'       => 'Salvo em <code>{path}</code>, e só esta conta consegue ler.',
+'saved.next_h2'     => 'O que vem agora',
+'saved.next_p1'     => 'Avise o agente de que a configuração já está pronta. Ele instala o resto e confere que o e-mail chega; essa parte é trabalho dele, não seu.',
+'saved.next_p2'     => 'A única coisa que vale a pena fazer você: mande um e-mail para o agente e pergunte o que acabou de chegar. Se ele responder em uns dois segundos, está tudo funcionando.',
+'saved.forgot'      => 'Esta página já esqueceu a senha. Abrir de novo não mostra ela outra vez.',
+
+'warn.existing_p1'  => '<strong>Atenção.</strong> Já existe configuração de e-mail em <code>{path}</code>. Se você terminar este formulário, ela é substituída.',
+'warn.existing_p2'  => 'Se o agente já está atendendo e-mail, feche esta página e confirme com quem configurou antes de seguir.',
+
+'help.summary'      => 'Onde eu acho esses dados?',
+
+'help.cpanel_h3'    => 'Se o seu e-mail veio junto com a hospedagem do site (cPanel)',
+'help.cpanel_p'     => 'É o caso mais comum, e os dados já estão escritos lá para você.',
+'help.cpanel_li1'   => 'Entre no cPanel, normalmente <code>seudominio.example/cpanel</code>, ou o link que o seu provedor mandou.',
+'help.cpanel_li2'   => 'Abra <strong>Email Accounts</strong> (Contas de e-mail).',
+'help.cpanel_li3'   => 'Ache o endereço que o agente vai usar e clique em <strong>Connect Devices</strong> (em versões antigas se chama <em>Set Up Mail Client</em>).',
+'help.cpanel_li4'   => 'Procure <strong>Mail Client Manual Settings</strong> e use a coluna <strong>Secure SSL/TLS Settings</strong>, não a que não tem SSL.',
+'help.cpanel_after' => 'Copie <em>Incoming Server</em> e a porta IMAP para a seção de leitura abaixo, e <em>Outgoing Server</em> com a porta SMTP para a de envio. O usuário é o endereço de e-mail completo, e a senha é a que você colocou nessa caixa quando criou. Se não lembrar, o cPanel deixa trocar nessa mesma página.',
+
+'help.gmail_h3'     => 'Gmail ou Google Workspace',
+'help.gmail_p1'     => 'Os nomes de servidor são sempre os mesmos: <code>imap.gmail.com</code> porta <code>993</code> para ler, <code>smtp.gmail.com</code> porta <code>465</code> para enviar.',
+'help.gmail_p2'     => 'A senha é onde todo mundo trava. O Google não aceita aqui a senha normal. Você precisa de uma <strong>senha de app</strong>, que exige ter a verificação em duas etapas ligada antes. Crie em <code>myaccount.google.com</code> → Segurança → Senhas de app, e cole o código de 16 caracteres que ele der.',
+'help.gmail_p3'     => 'Confira também que o IMAP está ligado: Gmail → Configurações → Encaminhamento e POP/IMAP.',
+
+'help.ms_h3'        => 'Outlook.com, Hotmail ou Microsoft 365',
+'help.ms_p1'        => '<code>outlook.office365.com</code> porta <code>993</code> para ler, <code>smtp.office365.com</code> porta <code>587</code> para enviar.',
+'help.ms_p2'        => 'Muitas contas corporativas da Microsoft já bloqueiam por política logins como este. Se a verificação abaixo recusar a senha mesmo estando certa, normalmente é por isso, e o seu administrador precisa liberar.',
+
+'help.zoho_h3'      => 'Zoho',
+'help.zoho_p'       => '<code>imappro.zoho.com</code> porta <code>993</code>, <code>smtp.zoho.com</code> porta <code>465</code>. O Zoho também pede senha de app, não a normal.',
+
+'help.fastmail_h3'  => 'Fastmail',
+'help.fastmail_p'   => '<code>imap.fastmail.com</code> porta <code>993</code>, <code>smtp.fastmail.com</code> porta <code>465</code>, com senha de app.',
+
+'help.other_h3'     => 'Qualquer outro',
+'help.other_p1'     => 'Pergunte ao seu provedor, ou busque o nome dele mais <em>configuração IMAP e SMTP</em>. Você procura quatro coisas: o nome do servidor de entrada, o de saída, e uma porta para cada um. Prefira as portas marcadas como SSL ou TLS.',
+'help.other_p2'     => 'Um aviso que vale repetir: não adivinhe o nome do servidor colocando <code>mail.</code> na frente do seu domínio. Costuma funcionar o suficiente para parecer certo e depois falha no certificado de segurança, que é horrível de diagnosticar depois. A verificação abaixo detecta isso e te fala com todas as letras.',
+
+'form.account_legend' => 'A conta',
+'form.account_label'  => 'Endereço de e-mail',
+'form.account_ph'     => 'agente@seudominio.example',
+'form.account_hint'   => 'A caixa própria do agente, não a sua.',
+
+'form.password_label' => 'Senha',
+'form.password_kept'  => '••••••••  a anterior foi mantida',
+'form.password_hint'  => 'Se o seu provedor oferece <em>senhas de app</em>, use uma dessas. É o dado que mais acaba recusado quando não.',
+
+'form.fromname_label' => 'Nome visível',
+'form.optional'       => 'opcional',
+'form.fromname_ph'    => 'Atenea',
+'form.fromname_hint'  => 'O nome que as pessoas veem quando o agente escreve para elas.',
+
+'form.imap_legend'    => 'Leitura de e-mail (IMAP)',
+'form.smtp_legend'    => 'Envio de e-mail (SMTP)',
+'form.server'         => 'Servidor',
+'form.port'           => 'Porta',
+'form.imap_host_ph'   => 'imap.seuprovedor.example',
+'form.smtp_host_ph'   => 'smtp.seuprovedor.example',
+'form.imap_hint'      => 'Peça ao seu provedor o nome exato do servidor. Adivinhar colocando <code>imap.</code> na frente do seu domínio costuma produzir um nome que funciona em tudo menos no certificado de segurança, e essa falha é difícil de diagnosticar depois.',
+'form.smtp_hint'      => '465 ou 587. As duas se verificam igual.',
+
+'form.submit'         => 'Verificar e salvar',
+'form.footnote'       => 'Isto entra na sua caixa e sai na hora; não lê, não envia nem muda nada. A configuração só é salva se o seu servidor de e-mail aceitar, então não há nada a desfazer se algo aqui estiver errado.',
+
+'report.h2'           => 'Ainda não foi salvo: alguma coisa aqui está errada',
+'report.imap_h3'      => 'Leitura de e-mail',
+'report.smtp_h3'      => 'Envio de e-mail',
+
+'v.account_missing'   => 'O agente precisa de um endereço de e-mail.',
+'v.account_bad'       => 'Isso não parece um endereço de e-mail.',
+'v.password_missing'  => 'Sem a senha o agente não consegue abrir a caixa.',
+'v.fromname_oneline'  => 'O nome visível tem que caber numa única linha.',
+'v.host_missing'      => 'Falta o nome do servidor {proto}.',
+'v.host_is_port'      => 'Isso é um número de porta, não um nome de servidor. O nome se parece com isto: imap.seuprovedor.example.',
+'v.host_has_junk'     => 'Aqui vai só o nome do servidor: sem https://, sem espaços, sem endereço.',
+'v.host_bad_chars'    => 'Isso tem caracteres que um nome de servidor não pode ter.',
+'v.port_missing'      => 'Falta a porta {proto}.',
+'v.port_range'        => 'Uma porta é um número entre 1 e 65535.',
+
+'p.cert_mismatch'     => 'O servidor respondeu, mas o certificado de segurança dele não foi emitido para “{host}”. Normalmente isso quer dizer que o nome do servidor está um pouco errado; muitos provedores querem algo como imap.seuprovedor.example e não mail.seudominio.example. Peça ao seu provedor o nome exato que ele publica.',
+'p.no_dns'            => '“{host}” não resolve para nenhuma máquina. Confira como está escrito.',
+'p.refused'           => 'Chega-se a “{host}”, mas ele recusou a conexão nessa porta. O mais provável é que a porta esteja errada.',
+'p.timed_out'         => '“{host}” não respondeu em {seconds} segundos. Ou o nome do servidor ou a porta estão errados, ou tem um firewall atrapalhando.',
+'p.failed_silent'     => 'A conexão falhou sem dizer por quê.',
+
+'p.imap143'           => 'A porta 143 não serve com esta ferramenta.',
+'p.imap143_detail'    => 'O listener abre IMAP sobre TLS de imediato (IMAP4_SSL), e a porta 143 começa sem criptografia. Use a 993, que é a que quase todo provedor oferece.',
+'p.no_tls'            => 'Não foi possível abrir uma conexão criptografada com {host}:{port}.',
+'p.tls_ok'            => 'Conectado a {host}:{port} por TLS, e o certificado está correto.',
+'p.not_imap'          => 'Essa porta respondeu, mas não está falando IMAP.',
+'p.said'              => 'Disse: {greeting}',
+'p.said_nothing'      => 'Não disse absolutamente nada.',
+'p.is_imap'           => 'O servidor se identificou como um servidor IMAP.',
+'p.auth_rejected'     => 'O servidor recusou esse endereço e senha.',
+'p.auth_rejected_d'   => 'Muitos provedores pedem aqui uma senha de app em vez da que você digita no site deles. Se o seu oferece verificação em duas etapas, quase certamente é o caso.',
+'p.signed_in'         => 'Sessão iniciada com sucesso.',
+'p.signed_in_smtp'    => 'Sessão iniciada com sucesso, então o agente vai conseguir responder.',
+'p.idle_yes'          => 'O servidor suporta IDLE, então o e-mail novo chega em mais ou menos um segundo.',
+'p.idle_no'           => 'Este servidor não oferece IDLE.',
+'p.idle_no_detail'    => 'Sem isso não tem como saber do e-mail novo na hora em que ele chega, e esta ferramenta não tem a que recorrer. Vale perguntar ao seu provedor antes de seguir.',
+
+'p.no_reach'          => 'Não foi possível chegar a {host}:{port}.',
+'p.not_smtp'          => 'Essa porta respondeu, mas não está falando SMTP.',
+'p.no_session'        => 'O servidor não quis iniciar uma sessão.',
+'p.tls_upgraded'      => 'Conectado a {host}:{port} e elevado a TLS; o certificado está correto.',
+'p.no_encryption'     => 'Este servidor não criptografa a conexão nessa porta.',
+'p.no_encryption_d'   => 'Mandar uma senha por um enlace sem criptografia não é algo que esta ferramenta vá configurar. Tente a porta 465, ou a 587 se o seu provedor suportar STARTTLS.',
+'p.starttls_refused'  => 'O servidor se negou a mudar para uma conexão criptografada.',
+'p.tls_failed'        => 'Não foi possível estabelecer a conexão criptografada.',
+'p.no_auth_offered'   => 'O servidor não oferece jeito de iniciar sessão nessa porta.',
+'p.no_auth_offered_d' => 'Normalmente isso quer dizer que a porta é para outra coisa. A 465 e a 587 são as duas que vale testar.',
+'p.auth_method_bad'   => 'O servidor não aceitou esta forma de iniciar sessão.',
+'p.address_rejected'  => 'O servidor recusou o endereço.',
+'p.send_auth_bad'     => 'O servidor recusou esse endereço e senha para enviar.',
+'p.send_auth_bad_d'   => 'Se o login para leitura funcionou, tem provedor que ainda pede uma senha de app separada para enviar, ou que o SMTP seja ligado nas configurações da conta.',
+
+'g.loopback_1'        => 'Esta página só responde a requisições do computador onde ela roda.',
+'g.loopback_2'        => 'Se o agente está num host remoto, encaminhe a porta em vez disto:',
+'g.token_1'           => 'Falta a chave de uso único deste link, ou a chave mudou.',
+'g.token_2'           => 'Peça ao agente para rodar scripts/setup_web.sh de novo e te mandar o link novo.',
+'g.csrf'              => 'Esse formulário expirou. Recarregue a página e preencha de novo.',
+];

--- a/webapp/i18n/pt-BR.php
+++ b/webapp/i18n/pt-BR.php
@@ -19,7 +19,6 @@ return [
 'saved.next_p2'     => 'A única coisa que vale a pena fazer você: mande um e-mail para o agente e pergunte o que acabou de chegar. Se ele responder em uns dois segundos, está tudo funcionando.',
 'saved.forgot'      => 'Esta página já esqueceu a senha. Abrir de novo não mostra ela outra vez.',
 
-'warn.existing_p1'  => '<strong>Atenção.</strong> Já existe configuração de e-mail em <code>{path}</code>. Se você terminar este formulário, ela é substituída.',
 
 'help.summary'      => 'Onde eu acho esses dados?',
 

--- a/webapp/i18n/pt-BR.php
+++ b/webapp/i18n/pt-BR.php
@@ -20,7 +20,6 @@ return [
 'saved.forgot'      => 'Esta página já esqueceu a senha. Abrir de novo não mostra ela outra vez.',
 
 'warn.existing_p1'  => '<strong>Atenção.</strong> Já existe configuração de e-mail em <code>{path}</code>. Se você terminar este formulário, ela é substituída.',
-'warn.existing_p2'  => 'Se o agente já está atendendo e-mail, feche esta página e confirme com quem configurou antes de seguir.',
 
 'help.summary'      => 'Onde eu acho esses dados?',
 
@@ -134,4 +133,10 @@ return [
 'g.token_1'           => 'Falta a chave de uso único deste link, ou a chave mudou.',
 'g.token_2'           => 'Peça ao agente para rodar scripts/setup_web.sh de novo e te mandar o link novo.',
 'g.csrf'              => 'Esse formulário expirou. Recarregue a página e preencha de novo.',
+
+'f.mkdir_failed'        => 'Não foi possível criar {dir}.',
+'f.write_failed'        => 'Não foi possível escrever em {dir}.',
+'f.incomplete'          => 'O arquivo não pôde ser escrito por inteiro.',
+'f.symlink_failed'      => 'Não foi possível escrever através do link simbólico para {target}.',
+'f.rename_failed'       => 'Não foi possível deixar o arquivo no lugar em {path}.',
 ];

--- a/webapp/index.php
+++ b/webapp/index.php
@@ -52,7 +52,8 @@ $storedPassword = (string) ($stored['AGENT_EMAIL_PASSWORD'] ?? '');
 
 $values = $_SESSION['values'] ?? [];
 foreach (ENV_FIELDS as $key) {
-    if ($action !== '' && array_key_exists($key, $_POST)) {
+    $postedNow = $action !== '' && array_key_exists($key, $_POST);
+    if ($postedNow) {
         $posted = trim((string) $_POST[$key]);
         // The password box comes back empty on every render, because its value is
         // never written into the HTML. An empty box therefore means "unchanged",
@@ -62,12 +63,20 @@ foreach (ENV_FIELDS as $key) {
             $values[$key] = $posted;
         }
     }
+
+    // The file fills anything this request did not carry. Testing for empty and
+    // not merely for absent is the whole point: the language switch posts the
+    // form, so a switch on an untouched page used to store seven empty strings
+    // in the session, and those then shadowed the file on every later render.
+    // The fields came back blank for the rest of the session and nothing said
+    // why. A blank box that was not just typed means "whatever is on disk".
+    //
     // Never the stored password: it goes nowhere near anything this page renders.
-    if ($key !== 'AGENT_EMAIL_PASSWORD') {
-        $values[$key] ??= (string) ($stored[$key] ?? '');
-        if ($values[$key] === '') {
-            $values[$key] = PORT_HINTS[$key] ?? '';
-        }
+    if ($key !== 'AGENT_EMAIL_PASSWORD' && !$postedNow && ($values[$key] ?? '') === '') {
+        $values[$key] = (string) ($stored[$key] ?? '');
+    }
+    if (($values[$key] ?? '') === '') {
+        $values[$key] = $key === 'AGENT_EMAIL_PASSWORD' ? '' : (PORT_HINTS[$key] ?? '');
     }
     $values[$key] ??= '';
 }
@@ -123,7 +132,6 @@ if ($action === 'setup' && $errors === []) {
     }
 }
 
-$existing = existing_config();
 ?>
 <!doctype html>
 <html lang="<?= e(current_lang()) ?>">
@@ -210,12 +218,6 @@ $existing = existing_config();
   </div>
 
   <p class="lead"><?= th('page.lead') ?></p>
-
-  <?php if ($existing !== null): ?>
-    <div class="panel warn">
-      <p><?= th('warn.existing_p1', ['path' => $existing]) ?></p>
-    </div>
-  <?php endif; ?>
 
   <details class="help">
     <summary><?= th('help.summary') ?></summary>

--- a/webapp/index.php
+++ b/webapp/index.php
@@ -44,6 +44,12 @@ $notice      = null;
 // The password lives in the session between the test and the save, never in a
 // value attribute. Re-rendering it into the HTML would put it in the page
 // source, in the browser cache, and in any screenshot of this screen.
+// What is already on disk. The form is not only a first-time setup screen: the
+// fields arrive filled so that somebody can come back and change the password,
+// or fix a server name, without retyping the other six.
+$stored         = read_env();
+$storedPassword = (string) ($stored['AGENT_EMAIL_PASSWORD'] ?? '');
+
 $values = $_SESSION['values'] ?? [];
 foreach (ENV_FIELDS as $key) {
     if ($action !== '' && array_key_exists($key, $_POST)) {
@@ -56,8 +62,24 @@ foreach (ENV_FIELDS as $key) {
             $values[$key] = $posted;
         }
     }
-    $values[$key] ??= PORT_HINTS[$key] ?? '';
+    // Never the stored password: it goes nowhere near anything this page renders.
+    if ($key !== 'AGENT_EMAIL_PASSWORD') {
+        $values[$key] ??= (string) ($stored[$key] ?? '');
+        if ($values[$key] === '') {
+            $values[$key] = PORT_HINTS[$key] ?? '';
+        }
+    }
+    $values[$key] ??= '';
 }
+
+// The password actually used to sign in and to write the file. An empty box with
+// a password already on disk means "leave it alone", which is what makes it
+// possible to come here and change only the server name.
+$effective = $values;
+if ($effective['AGENT_EMAIL_PASSWORD'] === '') {
+    $effective['AGENT_EMAIL_PASSWORD'] = $storedPassword;
+}
+$hasPassword = $effective['AGENT_EMAIL_PASSWORD'] !== '';
 
 // A language change posts the whole form so that whatever has been typed
 // survives the switch. It is not an attempt to save, so it neither validates
@@ -65,7 +87,7 @@ foreach (ENV_FIELDS as $key) {
 if ($action !== '') {
     check_csrf();
     if ($action !== 'lang') {
-        $errors = validate($values);
+        $errors = validate($effective);
     }
     $_SESSION['values'] = $values;
 }
@@ -78,19 +100,19 @@ if ($action === 'setup' && $errors === []) {
     $imap = probe_imap(
         $values['AGENT_EMAIL_INCOMING_SERVER_IMAP_HOST'],
         (int) $values['AGENT_EMAIL_INCOMING_SERVER_IMAP_PORT'],
-        $values['AGENT_EMAIL_ACCOUNT'],
-        $values['AGENT_EMAIL_PASSWORD'],
+        $effective['AGENT_EMAIL_ACCOUNT'],
+        $effective['AGENT_EMAIL_PASSWORD'],
     );
     $smtp = probe_smtp(
         $values['AGENT_EMAIL_OUTGOING_SERVER_SMTP_HOST'],
         (int) $values['AGENT_EMAIL_OUTGOING_SERVER_SMTP_PORT'],
-        $values['AGENT_EMAIL_ACCOUNT'],
-        $values['AGENT_EMAIL_PASSWORD'],
+        $effective['AGENT_EMAIL_ACCOUNT'],
+        $effective['AGENT_EMAIL_PASSWORD'],
     );
     $report = ['imap' => $imap, 'smtp' => $smtp, 'ok' => $imap['ok'] && $smtp['ok']];
 
     if ($report['ok']) {
-        [$ok, $where] = write_env(render_env($values));
+        [$ok, $where] = write_env(render_env($effective));
         if ($ok) {
             $saved = $where;
             // Nothing keeps the password in memory once it is on disk.
@@ -192,7 +214,6 @@ $existing = existing_config();
   <?php if ($existing !== null): ?>
     <div class="panel warn">
       <p><?= th('warn.existing_p1', ['path' => $existing]) ?></p>
-      <p><?= th('warn.existing_p2') ?></p>
     </div>
   <?php endif; ?>
 
@@ -250,9 +271,9 @@ $existing = existing_config();
 
       <label for="password"><?= th('form.password_label') ?></label>
       <input type="password" id="password" name="AGENT_EMAIL_PASSWORD"
-             <?= $values['AGENT_EMAIL_PASSWORD'] === '' ? 'required' : '' ?>
+             <?= $hasPassword ? '' : 'required' ?>
              autocomplete="new-password"
-             placeholder="<?= $values['AGENT_EMAIL_PASSWORD'] !== '' ? th('form.password_kept') : '' ?>">
+             placeholder="<?= $hasPassword ? th('form.password_kept') : '' ?>">
       <?php if (isset($errors['AGENT_EMAIL_PASSWORD'])): ?>
         <p class="err"><?= e($errors['AGENT_EMAIL_PASSWORD']) ?></p>
       <?php endif; ?>

--- a/webapp/index.php
+++ b/webapp/index.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  * one-time link. See webapp/README.md.
  */
 
+require_once __DIR__ . '/lib/i18n.php';
 require_once __DIR__ . '/lib/guard.php';
 require_once __DIR__ . '/lib/validate.php';
 require_once __DIR__ . '/lib/probe.php';
@@ -58,9 +59,14 @@ foreach (ENV_FIELDS as $key) {
     $values[$key] ??= PORT_HINTS[$key] ?? '';
 }
 
+// A language change posts the whole form so that whatever has been typed
+// survives the switch. It is not an attempt to save, so it neither validates
+// nor touches the servers; it re-renders the same page in the other language.
 if ($action !== '') {
     check_csrf();
-    $errors = validate($values);
+    if ($action !== 'lang') {
+        $errors = validate($values);
+    }
     $_SESSION['values'] = $values;
 }
 
@@ -98,11 +104,11 @@ if ($action === 'setup' && $errors === []) {
 $existing = existing_config();
 ?>
 <!doctype html>
-<html lang="es-MX">
+<html lang="<?= e(current_lang()) ?>">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>paynani: configuración del buzón</title>
+<title><?= th('page.title') ?></title>
 <link rel="stylesheet" href="/assets/app.css">
 </head>
 <body>
@@ -110,139 +116,154 @@ $existing = existing_config();
 
 <?php if ($saved !== null): ?>
 
-  <h1>Listo</h1>
-  <p class="lead">Tu servidor de correo aceptó la cuenta y la configuración quedó
-     guardada. Ya puedes cerrar esta página.</p>
-
-  <div class="panel ok">
-    <p>Se guardó en <code><?= e($saved) ?></code>, y solo esta cuenta puede leerlo.</p>
+  <div class="topbar">
+    <h1><?= th('saved.h1') ?></h1>
+    <?php /* Nothing left to preserve on this screen, so a plain GET form is enough. */ ?>
+    <form method="get" action="/" class="langpick">
+      <label for="lang"><?= th('lang.label') ?></label>
+      <select id="lang" name="lang">
+        <?php foreach (LANGUAGES as $tag => $name): ?>
+          <option value="<?= e($tag) ?>"<?= $tag === current_lang() ? ' selected' : '' ?>><?= e($name) ?></option>
+        <?php endforeach; ?>
+      </select>
+      <button type="submit"><?= th('lang.apply') ?></button>
+    </form>
   </div>
 
-  <h2>Qué sigue</h2>
-  <p>Avísale al agente que la configuración ya está. Él instala el resto y verifica
-     que el correo llegue; esa parte es su trabajo, no el tuyo.</p>
-  <p>Lo único que vale la pena hacer tú: mándale un correo al agente y pregúntale qué
-     acaba de llegar. Si te contesta en un par de segundos, todo funciona.</p>
+  <p class="lead"><?= th('saved.lead') ?></p>
 
-  <p class="quiet">Esta página ya olvidó la contraseña. Volver a abrirla no la muestra otra vez.</p>
+  <div class="panel ok">
+    <p><?= th('saved.where', ['path' => $saved]) ?></p>
+  </div>
+
+  <h2><?= th('saved.next_h2') ?></h2>
+  <p><?= th('saved.next_p1') ?></p>
+  <p><?= th('saved.next_p2') ?></p>
+
+  <p class="quiet"><?= th('saved.forgot') ?></p>
 
 <?php else: ?>
 
-  <h1>Dale un buzón al agente</h1>
-  <p class="lead">Siete datos de tu proveedor de correo. Todo se queda en esta
-     computadora. Esta página no es accesible desde internet.</p>
+  <div class="topbar">
+    <h1><?= th('page.h1') ?></h1>
+    <?php /*
+      The select and its button belong to the form below through the form=
+      attribute, even though they sit up here. Switching language therefore
+      posts whatever has already been typed, and the fields come back filled in
+      the new language instead of empty.
+
+      No onchange, and no script anywhere: guard.php serves a
+      `default-src 'none'` policy with no script-src, so an inline handler would
+      be blocked and the switch would silently do nothing. A page that collects
+      a mail password is the wrong place to loosen that policy for the sake of
+      saving one click, so the button is real and always visible.
+    */ ?>
+    <div class="langpick">
+      <label for="lang"><?= th('lang.label') ?></label>
+      <select id="lang" name="lang" form="setup">
+        <?php foreach (LANGUAGES as $tag => $name): ?>
+          <option value="<?= e($tag) ?>"<?= $tag === current_lang() ? ' selected' : '' ?>><?= e($name) ?></option>
+        <?php endforeach; ?>
+      </select>
+      <?php /* formnovalidate: sin él, el navegador se niega a enviar mientras la
+           contraseña esté vacía, y cambiar de idioma se vuelve imposible hasta
+           haber llenado el formulario. Este envío no guarda nada, así que no
+           tiene nada que validar. */ ?>
+      <button type="submit" name="action" value="lang" form="setup" formnovalidate><?= th('lang.apply') ?></button>
+    </div>
+  </div>
+
+  <p class="lead"><?= th('page.lead') ?></p>
 
   <?php if ($existing !== null): ?>
     <div class="panel warn">
-      <p><strong>Aguas.</strong> Ya hay configuración de correo en
-         <code><?= e($existing) ?></code>. Si terminas este formulario, la reemplaza.</p>
-      <p>Si el agente ya está atendiendo correo, cierra esta página y confirma con quien
-         lo configuró antes de seguir.</p>
+      <p><?= th('warn.existing_p1', ['path' => $existing]) ?></p>
+      <p><?= th('warn.existing_p2') ?></p>
     </div>
   <?php endif; ?>
 
   <details class="help">
-    <summary>¿Dónde encuentro estos datos?</summary>
+    <summary><?= th('help.summary') ?></summary>
 
-    <h3>Si tu correo vino con tu hosting web (cPanel)</h3>
-    <p>Es el caso más común, y los datos ya están escritos ahí para ti.</p>
+    <h3><?= th('help.cpanel_h3') ?></h3>
+    <p><?= th('help.cpanel_p') ?></p>
     <ol>
-      <li>Entra a cPanel, normalmente <code>tudominio.com/cpanel</code>, o el enlace que te mandó tu proveedor.</li>
-      <li>Abre <strong>Email Accounts</strong> (Cuentas de correo).</li>
-      <li>Busca la dirección que va a usar el agente y haz clic en <strong>Connect Devices</strong>
-          (en versiones viejas se llama <em>Set Up Mail Client</em>).</li>
-      <li>Busca <strong>Mail Client Manual Settings</strong> y usa la columna
-          <strong>Secure SSL/TLS Settings</strong>, no la que no lleva SSL.</li>
+      <li><?= th('help.cpanel_li1') ?></li>
+      <li><?= th('help.cpanel_li2') ?></li>
+      <li><?= th('help.cpanel_li3') ?></li>
+      <li><?= th('help.cpanel_li4') ?></li>
     </ol>
-    <p>Copia <em>Incoming Server</em> y su puerto IMAP a la sección de lectura de abajo, y
-       <em>Outgoing Server</em> con su puerto SMTP a la de envío. El usuario es la dirección
-       de correo completa, y la contraseña es la que le pusiste a ese buzón cuando lo
-       creaste. Si no la recuerdas, cPanel te deja cambiarla en esa misma página.</p>
+    <p><?= th('help.cpanel_after') ?></p>
 
-    <h3>Gmail o Google Workspace</h3>
-    <p>Los nombres de servidor siempre son los mismos: <code>imap.gmail.com</code> puerto
-       <code>993</code> para leer, <code>smtp.gmail.com</code> puerto <code>465</code> para enviar.</p>
-    <p>La contraseña es donde se atora la gente. Google no acepta aquí la normal. Necesitas
-       una <strong>contraseña de aplicación</strong>, que requiere tener activada primero la
-       verificación en dos pasos. Créala en <code>myaccount.google.com</code> → Seguridad →
-       Contraseñas de aplicaciones, y pega el código de 16 caracteres que te dé.</p>
-    <p>Revisa también que IMAP esté activado: Gmail → Configuración → Reenvío y correo POP/IMAP.</p>
+    <h3><?= th('help.gmail_h3') ?></h3>
+    <p><?= th('help.gmail_p1') ?></p>
+    <p><?= th('help.gmail_p2') ?></p>
+    <p><?= th('help.gmail_p3') ?></p>
 
-    <h3>Outlook.com, Hotmail o Microsoft 365</h3>
-    <p><code>outlook.office365.com</code> puerto <code>993</code> para leer,
-       <code>smtp.office365.com</code> puerto <code>587</code> para enviar.</p>
-    <p>Muchas cuentas empresariales de Microsoft ya bloquean por política los inicios de
-       sesión como este. Si la verificación de abajo rechaza la contraseña aunque esté bien,
-       normalmente es por eso, y tu administrador tiene que permitirlo.</p>
+    <h3><?= th('help.ms_h3') ?></h3>
+    <p><?= th('help.ms_p1') ?></p>
+    <p><?= th('help.ms_p2') ?></p>
 
-    <h3>Zoho</h3>
-    <p><code>imappro.zoho.com</code> puerto <code>993</code>, <code>smtp.zoho.com</code>
-       puerto <code>465</code>. Zoho también pide una contraseña de aplicación, no la normal.</p>
+    <h3><?= th('help.zoho_h3') ?></h3>
+    <p><?= th('help.zoho_p') ?></p>
 
-    <h3>Fastmail</h3>
-    <p><code>imap.fastmail.com</code> puerto <code>993</code>,
-       <code>smtp.fastmail.com</code> puerto <code>465</code>, con contraseña de aplicación.</p>
+    <h3><?= th('help.fastmail_h3') ?></h3>
+    <p><?= th('help.fastmail_p') ?></p>
 
-    <h3>Cualquier otro</h3>
-    <p>Pregúntale a tu proveedor, o busca su nombre más <em>configuración IMAP y SMTP</em>.
-       Buscas cuatro cosas: el nombre del servidor de entrada, el de salida, y un puerto
-       para cada uno. Prefiere los puertos marcados como SSL o TLS.</p>
-    <p>Una advertencia que vale la pena repetir: no adivines el nombre del servidor
-       poniéndole <code>mail.</code> enfrente a tu dominio. Seguido funciona lo suficiente
-       para parecer correcto y luego falla en el certificado de seguridad, que es horrible
-       de diagnosticar después. La verificación de abajo lo detecta y te lo dice claro.</p>
+    <h3><?= th('help.other_h3') ?></h3>
+    <p><?= th('help.other_p1') ?></p>
+    <p><?= th('help.other_p2') ?></p>
   </details>
 
   <?php if ($notice !== null): ?>
     <div class="panel warn"><p><?= e($notice) ?></p></div>
   <?php endif; ?>
 
-  <form method="post" action="/" autocomplete="off">
+  <form method="post" action="/" id="setup" autocomplete="off">
     <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">
 
     <fieldset>
-      <legend>La cuenta</legend>
+      <legend><?= th('form.account_legend') ?></legend>
 
-      <label for="account">Dirección de correo</label>
+      <label for="account"><?= th('form.account_label') ?></label>
       <input type="email" id="account" name="AGENT_EMAIL_ACCOUNT" required
              value="<?= e($values['AGENT_EMAIL_ACCOUNT']) ?>"
-             placeholder="agente@tudominio.com">
+             placeholder="<?= th('form.account_ph') ?>">
       <?php if (isset($errors['AGENT_EMAIL_ACCOUNT'])): ?>
         <p class="err"><?= e($errors['AGENT_EMAIL_ACCOUNT']) ?></p>
       <?php endif; ?>
-      <p class="hint">El buzón propio del agente, no el tuyo.</p>
+      <p class="hint"><?= th('form.account_hint') ?></p>
 
-      <label for="password">Contraseña</label>
+      <label for="password"><?= th('form.password_label') ?></label>
       <input type="password" id="password" name="AGENT_EMAIL_PASSWORD"
              <?= $values['AGENT_EMAIL_PASSWORD'] === '' ? 'required' : '' ?>
              autocomplete="new-password"
-             placeholder="<?= $values['AGENT_EMAIL_PASSWORD'] !== '' ? '••••••••  se conservó la anterior' : '' ?>">
+             placeholder="<?= $values['AGENT_EMAIL_PASSWORD'] !== '' ? th('form.password_kept') : '' ?>">
       <?php if (isset($errors['AGENT_EMAIL_PASSWORD'])): ?>
         <p class="err"><?= e($errors['AGENT_EMAIL_PASSWORD']) ?></p>
       <?php endif; ?>
-      <p class="hint">Si tu proveedor ofrece <em>contraseñas de aplicación</em>, usa una de
-         esas. Es el dato que más seguido termina rechazado si no.</p>
+      <p class="hint"><?= th('form.password_hint') ?></p>
 
-      <label for="fromname">Nombre visible <span class="opt">opcional</span></label>
+      <label for="fromname"><?= th('form.fromname_label') ?> <span class="opt"><?= th('form.optional') ?></span></label>
       <input type="text" id="fromname" name="AGENT_EMAIL_FROM_NAME"
-             value="<?= e($values['AGENT_EMAIL_FROM_NAME']) ?>" placeholder="Atenea">
+             value="<?= e($values['AGENT_EMAIL_FROM_NAME']) ?>" placeholder="<?= th('form.fromname_ph') ?>">
       <?php if (isset($errors['AGENT_EMAIL_FROM_NAME'])): ?>
         <p class="err"><?= e($errors['AGENT_EMAIL_FROM_NAME']) ?></p>
       <?php endif; ?>
-      <p class="hint">El nombre que ve la gente cuando el agente les escribe.</p>
+      <p class="hint"><?= th('form.fromname_hint') ?></p>
     </fieldset>
 
     <fieldset>
-      <legend>Lectura de correo (IMAP)</legend>
+      <legend><?= th('form.imap_legend') ?></legend>
       <div class="row">
         <div class="grow">
-          <label for="imaphost">Servidor</label>
+          <label for="imaphost"><?= th('form.server') ?></label>
           <input type="text" id="imaphost" name="AGENT_EMAIL_INCOMING_SERVER_IMAP_HOST" required
                  value="<?= e($values['AGENT_EMAIL_INCOMING_SERVER_IMAP_HOST']) ?>"
-                 placeholder="imap.tuproveedor.com">
+                 placeholder="<?= th('form.imap_host_ph') ?>">
         </div>
         <div class="narrow">
-          <label for="imapport">Puerto</label>
+          <label for="imapport"><?= th('form.port') ?></label>
           <input type="text" id="imapport" name="AGENT_EMAIL_INCOMING_SERVER_IMAP_PORT" required
                  inputmode="numeric" value="<?= e($values['AGENT_EMAIL_INCOMING_SERVER_IMAP_PORT']) ?>">
         </div>
@@ -250,23 +271,20 @@ $existing = existing_config();
       <?php foreach (['AGENT_EMAIL_INCOMING_SERVER_IMAP_HOST', 'AGENT_EMAIL_INCOMING_SERVER_IMAP_PORT'] as $k): ?>
         <?php if (isset($errors[$k])): ?><p class="err"><?= e($errors[$k]) ?></p><?php endif; ?>
       <?php endforeach; ?>
-      <p class="hint">Pídele a tu proveedor el nombre exacto del servidor. Adivinarlo
-         poniendo <code>imap.</code> enfrente de tu dominio seguido produce un nombre que
-         funciona en todo menos en el certificado de seguridad, y ese falla es difícil de
-         diagnosticar después.</p>
+      <p class="hint"><?= th('form.imap_hint') ?></p>
     </fieldset>
 
     <fieldset>
-      <legend>Envío de correo (SMTP)</legend>
+      <legend><?= th('form.smtp_legend') ?></legend>
       <div class="row">
         <div class="grow">
-          <label for="smtphost">Servidor</label>
+          <label for="smtphost"><?= th('form.server') ?></label>
           <input type="text" id="smtphost" name="AGENT_EMAIL_OUTGOING_SERVER_SMTP_HOST" required
                  value="<?= e($values['AGENT_EMAIL_OUTGOING_SERVER_SMTP_HOST']) ?>"
-                 placeholder="smtp.tuproveedor.com">
+                 placeholder="<?= th('form.smtp_host_ph') ?>">
         </div>
         <div class="narrow">
-          <label for="smtpport">Puerto</label>
+          <label for="smtpport"><?= th('form.port') ?></label>
           <input type="text" id="smtpport" name="AGENT_EMAIL_OUTGOING_SERVER_SMTP_PORT" required
                  inputmode="numeric" value="<?= e($values['AGENT_EMAIL_OUTGOING_SERVER_SMTP_PORT']) ?>">
         </div>
@@ -274,14 +292,14 @@ $existing = existing_config();
       <?php foreach (['AGENT_EMAIL_OUTGOING_SERVER_SMTP_HOST', 'AGENT_EMAIL_OUTGOING_SERVER_SMTP_PORT'] as $k): ?>
         <?php if (isset($errors[$k])): ?><p class="err"><?= e($errors[$k]) ?></p><?php endif; ?>
       <?php endforeach; ?>
-      <p class="hint">465 o 587. Los dos se verifican igual.</p>
+      <p class="hint"><?= th('form.smtp_hint') ?></p>
     </fieldset>
 
     <?php if ($report !== null): ?>
       <div class="panel bad">
-        <h2>Todavía no se guarda: algo aquí no está bien</h2>
+        <h2><?= th('report.h2') ?></h2>
 
-        <h3>Lectura de correo</h3>
+        <h3><?= th('report.imap_h3') ?></h3>
         <ul class="steps">
           <?php foreach ($report['imap']['steps'] as $s): ?>
             <li class="<?= $s['ok'] ? 'good' : 'fail' ?>">
@@ -291,7 +309,7 @@ $existing = existing_config();
           <?php endforeach; ?>
         </ul>
 
-        <h3>Envío de correo</h3>
+        <h3><?= th('report.smtp_h3') ?></h3>
         <ul class="steps">
           <?php foreach ($report['smtp']['steps'] as $s): ?>
             <li class="<?= $s['ok'] ? 'good' : 'fail' ?>">
@@ -304,12 +322,10 @@ $existing = existing_config();
     <?php endif; ?>
 
     <div class="actions">
-      <button type="submit" name="action" value="setup" class="primary">Verificar y guardar</button>
+      <button type="submit" name="action" value="setup" class="primary"><?= th('form.submit') ?></button>
     </div>
 
-    <p class="quiet">Esto entra a tu buzón y sale de inmediato; no lee, no envía ni cambia
-       nada. La configuración se guarda solo si tu servidor de correo la acepta, así que no
-       hay nada que deshacer si algo aquí está mal.</p>
+    <p class="quiet"><?= th('form.footnote') ?></p>
   </form>
 
 <?php endif; ?>

--- a/webapp/index.php
+++ b/webapp/index.php
@@ -110,6 +110,7 @@ $existing = existing_config();
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?= th('page.title') ?></title>
 <link rel="stylesheet" href="/assets/app.css">
+<script src="/assets/lang.js" defer></script>
 </head>
 <body>
 <main>
@@ -120,13 +121,14 @@ $existing = existing_config();
     <h1><?= th('saved.h1') ?></h1>
     <?php /* Nothing left to preserve on this screen, so a plain GET form is enough. */ ?>
     <form method="get" action="/" class="langpick">
-      <label for="lang"><?= th('lang.label') ?></label>
-      <select id="lang" name="lang">
-        <?php foreach (LANGUAGES as $tag => $name): ?>
-          <option value="<?= e($tag) ?>"<?= $tag === current_lang() ? ' selected' : '' ?>><?= e($name) ?></option>
-        <?php endforeach; ?>
-      </select>
-      <button type="submit"><?= th('lang.apply') ?></button>
+      <span class="combo">
+        <select id="lang" name="lang" aria-label="<?= th('lang.label') ?>">
+          <?php foreach (LANGUAGES as $tag => $name): ?>
+            <option value="<?= e($tag) ?>"<?= $tag === current_lang() ? ' selected' : '' ?>><?= e($name) ?></option>
+          <?php endforeach; ?>
+        </select>
+      </span>
+      <button type="submit" id="langgo"><?= th('lang.apply') ?></button>
     </form>
   </div>
 
@@ -159,17 +161,29 @@ $existing = existing_config();
       saving one click, so the button is real and always visible.
     */ ?>
     <div class="langpick">
-      <label for="lang"><?= th('lang.label') ?></label>
-      <select id="lang" name="lang" form="setup">
-        <?php foreach (LANGUAGES as $tag => $name): ?>
-          <option value="<?= e($tag) ?>"<?= $tag === current_lang() ? ' selected' : '' ?>><?= e($name) ?></option>
-        <?php endforeach; ?>
-      </select>
-      <?php /* formnovalidate: sin él, el navegador se niega a enviar mientras la
-           contraseña esté vacía, y cambiar de idioma se vuelve imposible hasta
-           haber llenado el formulario. Este envío no guarda nada, así que no
-           tiene nada que validar. */ ?>
-      <button type="submit" name="action" value="lang" form="setup" formnovalidate><?= th('lang.apply') ?></button>
+      <?php /* La etiqueta visible se quitó a propósito; aria-label la conserva
+           para quien navega con lector de pantalla, que si no se encontraría un
+           combo sin nombre. */ ?>
+      <span class="combo">
+        <select id="lang" name="lang" form="setup" aria-label="<?= th('lang.label') ?>">
+          <?php foreach (LANGUAGES as $tag => $name): ?>
+            <option value="<?= e($tag) ?>"<?= $tag === current_lang() ? ' selected' : '' ?>><?= e($name) ?></option>
+          <?php endforeach; ?>
+        </select>
+      </span>
+      <?php /*
+        Este botón se queda en el HTML y assets/lang.js lo esconde al arrancar.
+        No es un noscript: un script bloqueado por la CSP cuenta como scripting
+        activo, así que un noscript no renderizaría nada y el combo quedaría
+        muerto. Así, si el script no corre, lo que queda en pantalla es un botón
+        que sí funciona.
+
+        formnovalidate: sin él, el navegador se niega a enviar mientras la
+        contraseña esté vacía, y cambiar de idioma se vuelve imposible hasta
+        haber llenado el formulario. Este envío no guarda nada, así que no tiene
+        nada que validar.
+      */ ?>
+      <button type="submit" name="action" value="lang" form="setup" formnovalidate id="langgo"><?= th('lang.apply') ?></button>
     </div>
   </div>
 

--- a/webapp/lib/envfile.php
+++ b/webapp/lib/envfile.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
  * convention.
  */
 
+require_once __DIR__ . '/i18n.php';
 require_once __DIR__ . '/guard.php';
 
 /**
@@ -159,25 +160,101 @@ function existing_config(): ?string
  * they strip one layer of matching quotes and nothing else. So a value must not
  * carry a newline, and a leading or trailing space would be silently lost.
  */
+/**
+ * Everything currently in the credentials file, as key => value.
+ *
+ * Quotes are stripped exactly one layer deep, which is what load_env() and
+ * send.sh do when they read the same file back. Anything that is not a
+ * KEY=value line is ignored here; render_env() is the half that preserves it.
+ *
+ * @return array<string, string>
+ */
+function read_env(): array
+{
+    $path = env_path();
+    if (!is_file($path)) {
+        return [];
+    }
+    $raw = @file_get_contents($path);
+    if (!is_string($raw)) {
+        return [];
+    }
+
+    $out = [];
+    foreach (preg_split("/\r\n|\n|\r/", $raw) as $line) {
+        if (preg_match('/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/', $line, $m) !== 1) {
+            continue;
+        }
+        $value = trim($m[2]);
+        $len   = strlen($value);
+        if ($len >= 2
+            && (($value[0] === '"' && $value[$len - 1] === '"')
+             || ($value[0] === "'" && $value[$len - 1] === "'"))) {
+            $value = substr($value, 1, -1);
+        }
+        $out[$m[1]] = $value;
+    }
+    return $out;
+}
+
 function sanitise_value(string $value): string
 {
     $value = str_replace(["\r", "\n"], '', $value);
     return trim($value);
 }
 
+/**
+ * The file to write.
+ *
+ * **Only the seven keys this form owns are touched.** A real installation keeps
+ * more than mail settings in here, tokens for other services among them, and
+ * this page has no idea what any of it is. Rewriting the file from scratch would
+ * delete all of it, which stayed harmless only while the form was something you
+ * ran once at install time. It is not that any more: the fields arrive filled so
+ * that a password can be changed later, and changing a password must not cost
+ * somebody every other secret in the file.
+ *
+ * So an existing file is edited in place, line by line. Comments, blank lines,
+ * key order and unknown keys all survive; a key the form owns but the file lacks
+ * is appended. Only an absent or empty file gets the generated header.
+ */
 function render_env(array $values): string
 {
-    $out  = "# Written by the paynani setup page.\n";
-    $out .= '# ' . date('Y-m-d H:i:s T') . "\n";
-    $out .= "#\n";
-    $out .= "# Key names follow the schema in .env.example. Ports live in their own\n";
-    $out .= "# keys: a port stored in a key named for a server is the one mistake\n";
-    $out .= "# this file format refuses to survive.\n\n";
+    $path     = env_path();
+    $existing = is_file($path) ? @file_get_contents($path) : false;
 
-    foreach (ENV_FIELDS as $key) {
-        $out .= $key . '=' . sanitise_value((string) ($values[$key] ?? '')) . "\n";
+    if (!is_string($existing) || trim($existing) === '') {
+        $out  = "# Written by the paynani setup page.\n";
+        $out .= '# ' . date('Y-m-d H:i:s T') . "\n";
+        $out .= "#\n";
+        $out .= "# Key names follow the schema in .env.example. Ports live in their own\n";
+        $out .= "# keys: a port stored in a key named for a server is the one mistake\n";
+        $out .= "# this file format refuses to survive.\n\n";
+
+        foreach (ENV_FIELDS as $key) {
+            $out .= $key . '=' . sanitise_value((string) ($values[$key] ?? '')) . "\n";
+        }
+        return $out;
     }
-    return $out;
+
+    $lines = preg_split("/\r\n|\n|\r/", rtrim($existing, "\r\n"));
+    $seen  = [];
+    foreach ($lines as $i => $line) {
+        if (preg_match('/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/', $line, $m) !== 1) {
+            continue;
+        }
+        if (!in_array($m[1], ENV_FIELDS, true)) {
+            continue;
+        }
+        $lines[$i] = $m[1] . '=' . sanitise_value((string) ($values[$m[1]] ?? ''));
+        $seen[$m[1]] = true;
+    }
+    foreach (ENV_FIELDS as $key) {
+        if (!isset($seen[$key])) {
+            $lines[] = $key . '=' . sanitise_value((string) ($values[$key] ?? ''));
+        }
+    }
+    return implode("\n", $lines) . "\n";
 }
 
 /**
@@ -189,7 +266,7 @@ function write_env(string $contents): array
     $dir  = dirname($path);
 
     if (!is_dir($dir) && !@mkdir($dir, 0700, true) && !is_dir($dir)) {
-        return [false, "No se pudo crear {$dir}."];
+        return [false, t('f.mkdir_failed', ['dir' => $dir])];
     }
     @chmod($dir, 0700);
 
@@ -199,7 +276,7 @@ function write_env(string $contents): array
     $tmp = $path . '.tmp';
     $fh  = @fopen($tmp, 'w');
     if ($fh === false) {
-        return [false, "No se pudo escribir en {$dir}."];
+        return [false, t('f.write_failed', ['dir' => $dir])];
     }
     @chmod($tmp, 0600);
 
@@ -208,7 +285,7 @@ function write_env(string $contents): array
 
     if ($written === false || $written !== strlen($contents)) {
         @unlink($tmp);
-        return [false, 'El archivo no se pudo escribir completo.'];
+        return [false, t('f.incomplete')];
     }
 
     // Follow a symlink rather than replacing it: on a host where this path is
@@ -224,7 +301,7 @@ function write_env(string $contents): array
     if ($target !== $path) {
         if (@file_put_contents($target, $contents) === false) {
             @unlink($tmp);
-            return [false, "No se pudo escribir a través del enlace simbólico hacia {$target}."];
+            return [false, t('f.symlink_failed', ['target' => $target])];
         }
         @chmod($target, 0600);
         @unlink($tmp);
@@ -233,7 +310,7 @@ function write_env(string $contents): array
 
     if (!@rename($tmp, $path)) {
         @unlink($tmp);
-        return [false, "No se pudo dejar el archivo en su lugar en {$path}."];
+        return [false, t('f.rename_failed', ['path' => $path])];
     }
     @chmod($path, 0600);
     return [true, $path];

--- a/webapp/lib/guard.php
+++ b/webapp/lib/guard.php
@@ -134,7 +134,12 @@ function send_security_headers(): void
     header('Cache-Control: no-store, no-cache, must-revalidate');
     // No external anything: the page is a form on a machine that may have no
     // route to the internet at all, and a CDN reference would silently break it.
-    header("Content-Security-Policy: default-src 'none'; style-src 'self'; form-action 'self'; base-uri 'none'");
+    // script-src 'self' and nothing more: same-origin files only, no
+    // 'unsafe-inline', no 'unsafe-eval', no remote origin. The one script this
+    // page loads is assets/lang.js, which switches language on change. Inline
+    // handlers stay forbidden, so a string injected into this page still cannot
+    // execute.
+    header("Content-Security-Policy: default-src 'none'; style-src 'self'; script-src 'self'; form-action 'self'; base-uri 'none'");
 }
 
 function start_session(): void

--- a/webapp/lib/guard.php
+++ b/webapp/lib/guard.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/i18n.php';
+
 /**
  * Access control for the setup form.
  *
@@ -49,8 +51,8 @@ function require_loopback(): void
     if (!in_array($remote, ['127.0.0.1', '::1'], true)) {
         http_response_code(403);
         header('Content-Type: text/plain; charset=UTF-8');
-        echo "Esta página solo responde a peticiones desde la computadora donde corre.\n\n";
-        echo "Si el agente está en un host remoto, reenvía el puerto en lugar de esto:\n";
+        echo t('g.loopback_1') . "\n\n";
+        echo t('g.loopback_2') . "\n";
         echo "  ssh -L 8765:127.0.0.1:8765 tu-usuario@ese-host\n";
         exit;
     }
@@ -98,8 +100,8 @@ function require_token(): void
 
     http_response_code(403);
     header('Content-Type: text/plain; charset=UTF-8');
-    echo "A este enlace le falta su llave de un solo uso, o la llave cambió.\n\n";
-    echo "Pídele al agente que corra scripts/setup_web.sh otra vez y te mande el enlace nuevo.\n";
+    echo t('g.token_1') . "\n\n";
+    echo t('g.token_2') . "\n";
     exit;
 }
 
@@ -117,7 +119,7 @@ function check_csrf(): void
     if (!isset($_SESSION['csrf']) || !hash_equals((string) $_SESSION['csrf'], $given)) {
         http_response_code(400);
         header('Content-Type: text/plain; charset=UTF-8');
-        echo "Ese formulario expiró. Recarga la página y llénalo de nuevo.\n";
+        echo t('g.csrf') . "\n";
         exit;
     }
 }

--- a/webapp/lib/i18n.php
+++ b/webapp/lib/i18n.php
@@ -1,0 +1,115 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Language for the setup page.
+ *
+ * The person filling this form is not always the person who runs the agent, and
+ * is not always the person who chose the language the rest of the install speaks.
+ * They are handing over a mailbox password, so they get to read what they are
+ * agreeing to in their own language.
+ *
+ * The catalogues live in webapp/i18n/<tag>.php and are plain arrays. A key that
+ * a translation is missing falls back to es-MX rather than rendering blank, so a
+ * half-finished catalogue degrades to a mixed page instead of an empty one.
+ */
+
+const LANG_DEFAULT = 'es-MX';
+
+/** Tag => the name that tag calls itself. Never translated; each is in its own language. */
+const LANGUAGES = [
+    'es-MX' => 'Español (MX)',
+    'en-US' => 'English (US)',
+    'es-ES' => 'Español (ES)',
+    'fr-FR' => 'Français (FR)',
+    'pt-BR' => 'Português (BR)',
+];
+
+/** @var array<string, string>|null */
+$GLOBALS['paynani_strings'] = null;
+/** @var array<string, string>|null */
+$GLOBALS['paynani_fallback'] = null;
+
+function lang_is_known(string $tag): bool
+{
+    return array_key_exists($tag, LANGUAGES);
+}
+
+/**
+ * The language this request renders in.
+ *
+ * A ?lang= or a posted lang wins and is remembered for the session, so the
+ * choice survives the validation round-trips without riding in every URL.
+ */
+function current_lang(): string
+{
+    static $lang = null;
+    if ($lang !== null) {
+        return $lang;
+    }
+
+    $asked = trim((string) ($_POST['lang'] ?? $_GET['lang'] ?? ''));
+    if ($asked !== '' && lang_is_known($asked)) {
+        $_SESSION['lang'] = $asked;
+        return $lang = $asked;
+    }
+
+    $held = (string) ($_SESSION['lang'] ?? '');
+    if ($held !== '' && lang_is_known($held)) {
+        return $lang = $held;
+    }
+
+    return $lang = LANG_DEFAULT;
+}
+
+function load_catalogue(string $tag): array
+{
+    $file = __DIR__ . '/../i18n/' . $tag . '.php';
+    if (!is_file($file)) {
+        return [];
+    }
+    $strings = require $file;
+    return is_array($strings) ? $strings : [];
+}
+
+/**
+ * One string, with {placeholders} replaced.
+ *
+ * Returns the key itself when nothing has it. That is deliberately ugly: a
+ * missing string should be obvious on the page rather than silently empty.
+ */
+function t(string $key, array $vars = []): string
+{
+    if ($GLOBALS['paynani_strings'] === null) {
+        $GLOBALS['paynani_strings']  = load_catalogue(current_lang());
+        $GLOBALS['paynani_fallback'] = current_lang() === LANG_DEFAULT
+            ? $GLOBALS['paynani_strings']
+            : load_catalogue(LANG_DEFAULT);
+    }
+
+    $text = $GLOBALS['paynani_strings'][$key]
+        ?? $GLOBALS['paynani_fallback'][$key]
+        ?? $key;
+
+    foreach ($vars as $name => $value) {
+        $text = str_replace('{' . $name . '}', (string) $value, $text);
+    }
+    return $text;
+}
+
+/**
+ * The same string, for a template.
+ *
+ * Catalogue text may carry light markup, so this is echoed raw; the values
+ * substituted into it are escaped here, which is the half that comes from
+ * outside. Use t() where the caller escapes the whole thing itself, which is
+ * what the validator and the prober do.
+ */
+function th(string $key, array $vars = []): string
+{
+    $escaped = [];
+    foreach ($vars as $name => $value) {
+        $escaped[$name] = htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+    return t($key, $escaped);
+}

--- a/webapp/lib/probe.php
+++ b/webapp/lib/probe.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/i18n.php';
+
 /**
  * Live checks against the mail server, before anything is written to disk.
  *
@@ -37,23 +39,19 @@ function explain_connect_error(string $raw, string $host): string
 
     if (str_contains($lower, 'did not match') || str_contains($lower, 'certificate verify failed')
         || str_contains($lower, 'certificate_verify_failed')) {
-        return "El servidor contestó, pero su certificado de seguridad no está emitido para “{$host}”. "
-             . "Normalmente eso significa que el nombre del servidor está un poco mal; muchos proveedores "
-             . "quieren algo como imap.tuproveedor.com y no mail.tudominio.com. Pídele a tu proveedor el "
-             . "nombre exacto que publica.";
+        return t('p.cert_mismatch', ['host' => $host]);
     }
     if (str_contains($lower, 'getaddrinfo') || str_contains($lower, 'name or service not known')
         || str_contains($lower, 'no such host')) {
-        return "“{$host}” no resuelve a ninguna máquina. Revisa cómo está escrito.";
+        return t('p.no_dns', ['host' => $host]);
     }
     if (str_contains($lower, 'connection refused')) {
-        return "Se llega a “{$host}” pero rechazó la conexión en ese puerto. Lo más probable es que el puerto esté mal.";
+        return t('p.refused', ['host' => $host]);
     }
     if (str_contains($lower, 'timed out') || str_contains($lower, 'timeout')) {
-        return "“{$host}” no contestó en " . PROBE_TIMEOUT . " segundos. O el nombre del servidor o el "
-             . "puerto están mal, o hay un firewall estorbando.";
+        return t('p.timed_out', ['host' => $host, 'seconds' => PROBE_TIMEOUT]);
     }
-    return $raw !== '' ? $raw : 'La conexión falló sin decir por qué.';
+    return $raw !== '' ? $raw : t('p.failed_silent');
 }
 
 function tls_context(): mixed
@@ -159,52 +157,49 @@ function probe_imap(string $host, int $port, string $user, string $pass): array
     $steps = [];
 
     if ($port === 143) {
-        $steps[] = step(false, 'El puerto 143 no sirve con esta herramienta.',
-            'El listener abre IMAP sobre TLS de inmediato (IMAP4_SSL), y el puerto 143 empieza sin cifrar. '
-          . 'Usa el 993, que es el que ofrece casi cualquier proveedor.');
+        $steps[] = step(false, t('p.imap143'),
+            t('p.imap143_detail'));
         return ['ok' => false, 'steps' => $steps];
     }
 
     [$stream, $error] = open_stream('ssl', $host, $port);
     if ($stream === null) {
-        $steps[] = step(false, "No se pudo abrir una conexión cifrada a {$host}:{$port}.", $error);
+        $steps[] = step(false, t('p.no_tls', ['host' => $host, 'port' => $port]), $error);
         return ['ok' => false, 'steps' => $steps];
     }
-    $steps[] = step(true, "Conectado a {$host}:{$port} por TLS, y el certificado está correcto.");
+    $steps[] = step(true, t('p.tls_ok', ['host' => $host, 'port' => $port]));
 
     $greeting = read_line($stream);
     if (!str_starts_with($greeting, '* OK') && !str_starts_with($greeting, '* PREAUTH')) {
-        $steps[] = step(false, 'Ese puerto contestó, pero no está hablando IMAP.',
-            $greeting !== '' ? "Dijo: {$greeting}" : 'No dijo absolutamente nada.');
+        $steps[] = step(false, t('p.not_imap'),
+            $greeting !== '' ? t('p.said', ['greeting' => $greeting]) : t('p.said_nothing'));
         fclose($stream);
         return ['ok' => false, 'steps' => $steps];
     }
-    $steps[] = step(true, 'El servidor se identificó como un servidor IMAP.');
+    $steps[] = step(true, t('p.is_imap'));
 
     fwrite($stream, "a1 LOGIN " . imap_quote($user) . ' ' . imap_quote($pass) . "\r\n");
     $lines  = imap_read_until($stream, 'a1');
     $result = end($lines) ?: '';
 
     if (!str_starts_with($result, 'a1 OK')) {
-        $steps[] = step(false, 'El servidor rechazó esa dirección y contraseña.',
-            'Muchos proveedores piden aquí una contraseña de aplicación en lugar de la que escribes en su sitio web. '
-          . 'Si el tuyo ofrece verificación en dos pasos, casi seguro es el caso.');
+        $steps[] = step(false, t('p.auth_rejected'),
+            t('p.auth_rejected_d'));
         fwrite($stream, "a9 LOGOUT\r\n");
         fclose($stream);
         return ['ok' => false, 'steps' => $steps];
     }
-    $steps[] = step(true, 'Sesión iniciada correctamente.');
+    $steps[] = step(true, t('p.signed_in'));
 
     // IDLE is the whole design. Ask after logging in; plenty of servers only
     // advertise it to an authenticated session.
     fwrite($stream, "a2 CAPABILITY\r\n");
     $caps = strtoupper(implode(' ', imap_read_until($stream, 'a2')));
     if (str_contains($caps, 'IDLE')) {
-        $steps[] = step(true, 'El servidor soporta IDLE, así que el correo nuevo llega en más o menos un segundo.');
+        $steps[] = step(true, t('p.idle_yes'));
     } else {
-        $steps[] = step(false, 'Este servidor no ofrece IDLE.',
-            'Sin eso no hay manera de enterarse del correo nuevo cuando llega, y esta herramienta no tiene '
-          . 'nada a qué recurrir. Vale la pena preguntarle a tu proveedor antes de seguir.');
+        $steps[] = step(false, t('p.idle_no'),
+            t('p.idle_no_detail'));
         fwrite($stream, "a9 LOGOUT\r\n");
         fclose($stream);
         return ['ok' => false, 'steps' => $steps];
@@ -277,38 +272,37 @@ function probe_smtp_mode(string $host, int $port, string $user, string $pass, bo
 
     [$stream, $error] = open_stream($implicit ? 'ssl' : 'tcp', $host, $port);
     if ($stream === null) {
-        $steps[] = step(false, "No se pudo llegar a {$host}:{$port}.", $error);
+        $steps[] = step(false, t('p.no_reach', ['host' => $host, 'port' => $port]), $error);
         return ['ok' => false, 'authenticated' => false, 'steps' => $steps];
     }
 
     $greeting = smtp_read_reply($stream);
     if (smtp_code($greeting) !== 220) {
-        $steps[] = step(false, 'Ese puerto contestó, pero no está hablando SMTP.',
-            trim($greeting) !== '' ? 'Dijo: ' . trim($greeting) : 'No dijo absolutamente nada.');
+        $steps[] = step(false, t('p.not_smtp'),
+            trim($greeting) !== '' ? t('p.said', ['greeting' => trim($greeting)]) : t('p.said_nothing'));
         fclose($stream);
         return ['ok' => false, 'authenticated' => false, 'steps' => $steps];
     }
 
     $ehlo = smtp_command($stream, 'EHLO localhost');
     if (smtp_code($ehlo) !== 250) {
-        $steps[] = step(false, 'El servidor no quiso iniciar una sesión.', trim($ehlo));
+        $steps[] = step(false, t('p.no_session'), trim($ehlo));
         fclose($stream);
         return ['ok' => false, 'authenticated' => false, 'steps' => $steps];
     }
 
     if ($implicit) {
-        $steps[] = step(true, "Conectado a {$host}:{$port} por TLS, y el certificado está correcto.");
+        $steps[] = step(true, t('p.tls_ok', ['host' => $host, 'port' => $port]));
     } else {
         if (!str_contains(strtoupper($ehlo), 'STARTTLS')) {
-            $steps[] = step(false, 'Este servidor no cifra la conexión en ese puerto.',
-                'Mandar una contraseña por un enlace sin cifrar no es algo que esta herramienta vaya a configurar. '
-              . 'Prueba el puerto 465, o el 587 si tu proveedor soporta STARTTLS.');
+            $steps[] = step(false, t('p.no_encryption'),
+                t('p.no_encryption_d'));
             fclose($stream);
             return ['ok' => false, 'authenticated' => false, 'steps' => $steps];
         }
         $start = smtp_command($stream, 'STARTTLS');
         if (smtp_code($start) !== 220) {
-            $steps[] = step(false, 'El servidor se negó a cambiar a una conexión cifrada.', trim($start));
+            $steps[] = step(false, t('p.starttls_refused'), trim($start));
             fclose($stream);
             return ['ok' => false, 'authenticated' => false, 'steps' => $steps];
         }
@@ -318,18 +312,18 @@ function probe_smtp_mode(string $host, int $port, string $user, string $pass, bo
         if ($crypto !== true) {
             // Same trap as the implicit-TLS path: the certificate complaint is in
             // a warning, not in the return value.
-            $steps[] = step(false, 'No se pudo establecer la conexión cifrada.',
+            $steps[] = step(false, t('p.tls_failed'),
                 explain_connect_error($warnings, $host));
             fclose($stream);
             return ['ok' => false, 'authenticated' => false, 'steps' => $steps];
         }
-        $steps[] = step(true, "Conectado a {$host}:{$port} y elevado a TLS; el certificado está correcto.");
+        $steps[] = step(true, t('p.tls_upgraded', ['host' => $host, 'port' => $port]));
         $ehlo = smtp_command($stream, 'EHLO localhost');
     }
 
     if (!str_contains(strtoupper($ehlo), 'AUTH')) {
-        $steps[] = step(false, 'El servidor no ofrece manera de iniciar sesión en ese puerto.',
-            'Normalmente eso significa que el puerto es para otra cosa. El 465 y el 587 son los dos que hay que probar.');
+        $steps[] = step(false, t('p.no_auth_offered'),
+            t('p.no_auth_offered_d'));
         smtp_command($stream, 'QUIT');
         fclose($stream);
         return ['ok' => false, 'authenticated' => false, 'steps' => $steps];
@@ -337,7 +331,7 @@ function probe_smtp_mode(string $host, int $port, string $user, string $pass, bo
 
     $auth = smtp_command($stream, 'AUTH LOGIN');
     if (smtp_code($auth) !== 334) {
-        $steps[] = step(false, 'El servidor no aceptó esta forma de iniciar sesión.', trim($auth));
+        $steps[] = step(false, t('p.auth_method_bad'), trim($auth));
         smtp_command($stream, 'QUIT');
         fclose($stream);
         return ['ok' => false, 'authenticated' => false, 'steps' => $steps];
@@ -345,7 +339,7 @@ function probe_smtp_mode(string $host, int $port, string $user, string $pass, bo
 
     $sentUser = smtp_command($stream, base64_encode($user));
     if (smtp_code($sentUser) !== 334) {
-        $steps[] = step(false, 'El servidor rechazó la dirección.', trim($sentUser));
+        $steps[] = step(false, t('p.address_rejected'), trim($sentUser));
         smtp_command($stream, 'QUIT');
         fclose($stream);
         return ['ok' => false, 'authenticated' => false, 'steps' => $steps];
@@ -353,14 +347,13 @@ function probe_smtp_mode(string $host, int $port, string $user, string $pass, bo
 
     $sentPass = smtp_command($stream, base64_encode($pass));
     if (smtp_code($sentPass) !== 235) {
-        $steps[] = step(false, 'El servidor rechazó esa dirección y contraseña para enviar.',
-            'If signing in for reading worked, some providers still want a separate app password for '
-          . 'sending, or need SMTP switched on in your account settings.');
+        $steps[] = step(false, t('p.send_auth_bad'),
+            t('p.send_auth_bad_d'));
         smtp_command($stream, 'QUIT');
         fclose($stream);
         return ['ok' => false, 'authenticated' => false, 'steps' => $steps];
     }
-    $steps[] = step(true, 'Sesión iniciada correctamente, así que el agente va a poder responder.');
+    $steps[] = step(true, t('p.signed_in_smtp'));
 
     smtp_command($stream, 'QUIT');
     fclose($stream);

--- a/webapp/lib/validate.php
+++ b/webapp/lib/validate.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/i18n.php';
+
 /**
  * Form validation.
  *
@@ -18,18 +20,18 @@ function validate(array $in): array
 
     $account = trim((string) ($in['AGENT_EMAIL_ACCOUNT'] ?? ''));
     if ($account === '') {
-        $errors['AGENT_EMAIL_ACCOUNT'] = 'El agente necesita una dirección de correo.';
+        $errors['AGENT_EMAIL_ACCOUNT'] = t('v.account_missing');
     } elseif (filter_var($account, FILTER_VALIDATE_EMAIL) === false) {
-        $errors['AGENT_EMAIL_ACCOUNT'] = 'Eso no parece una dirección de correo.';
+        $errors['AGENT_EMAIL_ACCOUNT'] = t('v.account_bad');
     }
 
     if ((string) ($in['AGENT_EMAIL_PASSWORD'] ?? '') === '') {
-        $errors['AGENT_EMAIL_PASSWORD'] = 'Sin la contraseña el agente no puede abrir el buzón.';
+        $errors['AGENT_EMAIL_PASSWORD'] = t('v.password_missing');
     }
 
     $name = (string) ($in['AGENT_EMAIL_FROM_NAME'] ?? '');
     if (str_contains($name, "\n") || str_contains($name, "\r")) {
-        $errors['AGENT_EMAIL_FROM_NAME'] = 'El nombre visible tiene que caber en una sola línea.';
+        $errors['AGENT_EMAIL_FROM_NAME'] = t('v.fromname_oneline');
     }
 
     foreach ([
@@ -38,23 +40,22 @@ function validate(array $in): array
     ] as $key => $label) {
         $host = trim((string) ($in[$key] ?? ''));
         if ($host === '') {
-            $errors[$key] = "Falta el nombre del servidor {$label}.";
+            $errors[$key] = t('v.host_missing', ['proto' => $label]);
             continue;
         }
         // The trap this repo documents: a field named for a server holding a
         // port. Read literally it sends the listener somewhere that does not
         // exist, and the error arrives as a connection failure.
         if (ctype_digit($host)) {
-            $errors[$key] = 'Eso es un número de puerto, no un nombre de servidor. El nombre se ve así: '
-                          . 'imap.tuproveedor.com.';
+            $errors[$key] = t('v.host_is_port');
             continue;
         }
         if (str_contains($host, '/') || str_contains($host, ' ') || str_contains($host, '@')) {
-            $errors[$key] = 'Aquí va solo el nombre del servidor: sin https://, sin espacios, sin dirección.';
+            $errors[$key] = t('v.host_has_junk');
             continue;
         }
         if (preg_match('/^[A-Za-z0-9.\-]+$/', $host) !== 1) {
-            $errors[$key] = 'Eso trae caracteres que un nombre de servidor no puede tener.';
+            $errors[$key] = t('v.host_bad_chars');
         }
     }
 
@@ -64,11 +65,11 @@ function validate(array $in): array
     ] as $key => $label) {
         $port = trim((string) ($in[$key] ?? ''));
         if ($port === '') {
-            $errors[$key] = "Falta el puerto {$label}.";
+            $errors[$key] = t('v.port_missing', ['proto' => $label]);
             continue;
         }
         if (!ctype_digit($port) || (int) $port < 1 || (int) $port > 65535) {
-            $errors[$key] = 'Un puerto es un número entre 1 y 65535.';
+            $errors[$key] = t('v.port_range');
         }
     }
 


### PR DESCRIPTION
Quien llena este formulario no siempre es quien opera el agente, ni quien eligió el idioma en que habla el resto de la instalación. Está entregando la contraseña de un buzón, así que le toca leer en su idioma lo que está aceptando.

El selector va **junto al título**, con las mismas cinco lenguas a las que está traducida la documentación y **Español (MX)** preseleccionado.

## Qué se traduce

Todo lo que la página puede decir, no solo el formulario:

| | |
| --- | --- |
| `index.php` | título, encabezados, campos, ayuda por proveedor, pantalla de éxito |
| `validate.php` | los diez mensajes de validación de campo |
| `probe.php` | el reporte paso a paso de la verificación en vivo contra IMAP y SMTP |
| `guard.php` | las tres pantallas de rechazo: loopback, llave y CSRF |

**109 cadenas por idioma, y los cinco catálogos tienen exactamente las mismas claves.** Una clave que a una traducción le falte cae a `es-MX` en lugar de renderizar vacío, así que un catálogo a medias degrada a una página mezclada y no a una en blanco.

## Tres decisiones que el código no explica solo

**Cambiar de idioma no pierde lo escrito.** El selector y su botón pertenecen al formulario principal por el atributo `form=`, aunque estén arriba de él, así que el cambio envía todo y los campos regresan llenos.

**Ese envío lleva `formnovalidate`.** Sin él el navegador se niega a enviar mientras la contraseña esté vacía, y nadie podría cambiar de idioma antes de terminar el formulario. Esto se encontró probando la página, no leyéndola: el primer intento simplemente no hacía nada al pulsar el botón.

**No lleva JavaScript.** `guard.php` sirve `default-src 'none'` sin `script-src`, así que un `onchange` quedaría bloqueado y el selector no haría nada, en silencio. Por eso el botón es real y visible: una página que recibe una contraseña de correo no es el lugar para aflojar esa política a cambio de ahorrarse un clic. El `README` de la webapp ya presumía «no JavaScript» y eso se respeta.

## De paso

Quedan traducidas dos frases que estaban **en inglés dentro de la app en español**, en el detalle del rechazo de autenticación de SMTP (`probe.php`).

## Verificación

Con Playwright contra la página realmente servida por `scripts/setup_web.sh`:

- Los cinco idiomas renderizan, y `html[lang]` y el valor del selector coinciden con el pedido.
- Los mensajes de validación salen traducidos, comprobado en `en-US` y `fr-FR` forzando tres errores distintos.
- Un cambio de idioma con seis campos llenos los conserva **todos** y no dispara errores.
- `php -l` limpio en los doce archivos.

## Nota sobre el orden de merge

Esta rama sale de `main`. Los PRs #24 y #25 tocan `webapp/index.php`, `validate.php`, `probe.php` y `app.css`, así que si se mergean primero, esta necesita un rebase y yo lo hago. Los placeholders ya usan dominios `.example` aquí, de modo que el resultado final coincide con #24 sea cual sea el orden.