### PR TITLE
Alinea el acento de la webapp con la grana de la marca

### DIFF
--- a/webapp/assets/app.css
+++ b/webapp/assets/app.css
@@ -8,7 +8,7 @@
   --ink:     #1c1c1a;
   --quiet:   #66655f;
   --line:    #dedcd6;
-  --accent:  #2f5d50;
+  --accent:  #8f2d2b;
   --ok-bg:   #edf6f0;  --ok-line:   #b6d8c4;  --ok-ink:   #1d5334;
   --bad-bg:  #fdf0ee;  --bad-line:  #eebcb3;  --bad-ink:  #8a2c1c;
   --warn-bg: #fdf6e8;  --warn-line: #e8d5a3;  --warn-ink: #7a5a12;
@@ -21,7 +21,7 @@
     --ink:     #e8e6e1;
     --quiet:   #9c9a94;
     --line:    #33363c;
-    --accent:  #7cc0a8;
+    --accent:  #d8887f;
     --ok-bg:   #16261d;  --ok-line:   #2e5741;  --ok-ink:   #9adcb6;
     --bad-bg:  #2a1a17;  --bad-line:  #5e3229;  --bad-ink:  #f0a898;
     --warn-bg: #262015;  --warn-line: #574a2b;  --warn-ink: #e2c583;
@@ -163,7 +163,11 @@ button {
   border: 1px solid var(--accent);
   cursor: pointer;
 }
-button.primary   { background: var(--accent); color: var(--card); }
+/* El primario va en tinta, no en el acento: desde que la marca es grana, un
+   botón del color del acento y el panel de error son el mismo rojo, y la
+   alarma deja de leerse como alarma. El acento sigue en enlaces, foco,
+   botón secundario y resumen. */
+button.primary   { background: var(--ink); border-color: var(--ink); color: var(--card); }
 button.secondary { background: transparent;   color: var(--accent); }
 button:hover     { filter: brightness(1.08); }
 button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }


### PR DESCRIPTION
Julian decidió que el jade se retira y la marca es grana cochinilla. `--accent`
en `webapp/assets/app.css` era el único lugar del repositorio donde el color
viejo seguía vivo.

## Por qué el cambio no es de una línea

Sustituir `--accent` a secas rompe la señal de error.

| | Acento vs rojo de error | |
|---|---|---|
| Con jade (hoy) | dE76 **65.4** en claro, **53.3** en oscuro | inconfundibles |
| Con grana, cambiando sólo el acento | dE76 **7.7** en claro, **11.8** en oscuro | casi el mismo color |

Y en pantalla se ve peor que en el número: el botón «Verificar y guardar» y el
panel «No se pudo conectar» quedan del mismo rojo. En tema oscuro el botón
(`#d8887f`) y el encabezado del error (`#f0a898`) son prácticamente el mismo
salmón.

**Mover el rojo de error hacia el naranja tampoco sirve.** Lo aleja de la grana
pero lo acerca al ámbar de aviso: en oscuro la separación error/aviso cae de
dE 29.8 a entre 9.8 y 20.8 según el tono. Es cambiar un choque por uno peor.

## Lo que hace este PR

Dos cosas:

1. `--accent` pasa a `#8f2d2b` en claro y `#d8887f` en oscuro.
2. `button.primary` deja de usar el acento y pasa a `var(--ink)`.

Con eso el único rojo saturado de la página vuelve a ser el error, y el acento
sigue presente donde no compite: enlaces, anillo de foco, botón secundario y el
`<summary>` de la ayuda. **Las familias `--ok`, `--bad` y `--warn` quedan
intactas.**

Contraste del botón primario tras el cambio: **15.91:1** en claro y **14.37:1**
en oscuro.

## Verificación

Las dos vistas se revisaron renderizadas, en claro y en oscuro, con la hoja de
estilos real. El formulario en vivo no se levantó a propósito: está detrás de una
llave de un solo uso y escribe `.env`.

Los archivos de la marca van aparte, en #28. El manual completo: #27
