### PR TITLE
Estrena la cabecera de marca en el README y sus cuatro traducciones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# paynani
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="brand/paynani-horizontal-claro.svg">
+    <img src="brand/paynani-horizontal.svg" alt="paynani" height="52">
+  </picture>
+</h1>
+
 Mensajero élite: Los paynani eran los corredores y mensajeros oficiales del Imperio Azteca.
 
 **Español (MX)** · [English (US)](i18n/README.en-US.md) · [Español (ES)](i18n/README.es-ES.md) · [Français (FR)](i18n/README.fr-FR.md) · [Português (BR)](i18n/README.pt-BR.md)

--- a/i18n/README.en-US.md
+++ b/i18n/README.en-US.md
@@ -1,4 +1,10 @@
-# paynani
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../brand/paynani-horizontal-claro.svg">
+    <img src="../brand/paynani-horizontal.svg" alt="paynani" height="52">
+  </picture>
+</h1>
+
 Elite messenger: the paynani were the official runners and messengers of the Aztec Empire.
 
 [Español (MX)](../README.md) · **English (US)** · [Español (ES)](README.es-ES.md) · [Français (FR)](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)

--- a/i18n/README.es-ES.md
+++ b/i18n/README.es-ES.md
@@ -1,4 +1,10 @@
-# paynani
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../brand/paynani-horizontal-claro.svg">
+    <img src="../brand/paynani-horizontal.svg" alt="paynani" height="52">
+  </picture>
+</h1>
+
 Mensajero de élite: los paynani eran los corredores y mensajeros oficiales del Imperio Azteca.
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · **Español (ES)** · [Français (FR)](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)

--- a/i18n/README.fr-FR.md
+++ b/i18n/README.fr-FR.md
@@ -1,4 +1,10 @@
-# paynani
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../brand/paynani-horizontal-claro.svg">
+    <img src="../brand/paynani-horizontal.svg" alt="paynani" height="52">
+  </picture>
+</h1>
+
 Messager d'élite : les paynani étaient les coureurs et messagers officiels de l'Empire aztèque.
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · [Español (ES)](README.es-ES.md) · **Français (FR)** · [Português (BR)](README.pt-BR.md)

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -1,4 +1,10 @@
-# paynani
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../brand/paynani-horizontal-claro.svg">
+    <img src="../brand/paynani-horizontal.svg" alt="paynani" height="52">
+  </picture>
+</h1>
+
 Mensageiro de elite: os paynani eram os corredores e mensageiros oficiais do Império Asteca.
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · [Español (ES)](README.es-ES.md) · [Français (FR)](README.fr-FR.md) · **Português (BR)**


### PR DESCRIPTION
Cambia el `# paynani` de texto por el logotipo, en `README.md` y en los cuatro
archivos de `i18n/`.

**Este PR va apilado sobre #28**, que es donde entran los archivos de `brand/`.
Su base es `agrega-marca-y-manual`, no `main`: fusionar #28 primero deja este
apuntando a `main` con un diff de cinco archivos.

## Dos decisiones que no son cosméticas

**El logotipo va dentro de un `<h1>`.** La portada conserva su encabezado de
primer nivel y la imagen lleva `alt="paynani"`, así que quien la lea con lector
de pantalla oye el nombre y no un hueco. Sustituir un `#` por una imagen suelta
habría costado las dos cosas.

**Va envuelto en `<picture>` con `prefers-color-scheme`.** El logotipo normal
tiene el texto en tinta `#1c1c1a`, que sobre el tema oscuro de GitHub
prácticamente no se ve. La variante clara se sirve en su lugar — es justo para
esto que `brand/` trae los `-claro`.

## Verificación

No es una suposición sobre cómo renderiza GitHub: se pasó el archivo por su
propio renderizador (`POST /markdown`, modo `gfm`) y devuelve

```html
<h1 dir="auto">
  <themed-picture data-catalyst-inline="true"><picture>
    <source media="(prefers-color-scheme: dark)" srcset="brand/paynani-horizontal-claro.svg">
    <img src="brand/paynani-horizontal.svg" alt="paynani" height="52">
  </picture></themed-picture>
</h1>
<p dir="auto">Mensajero élite: Los paynani eran los corredores…</p>
```

`<themed-picture>` es la envoltura que GitHub agrega cuando reconoce el par
claro/oscuro, y el resto del documento sigue parseándose como Markdown.

`scripts/test_docs.py` pasa: 22 de 22.

La línea de idiomas no se toca.
