### PR TITLE
Repara test_paths.sh, que desde #26 comparaba rutas contra un php muerto

### DIFF
--- a/scripts/test_paths.sh
+++ b/scripts/test_paths.sh
@@ -27,7 +27,13 @@ trap 'rm -rf "$CLONE"' EXIT
 mkdir -p "$CLONE/harness" "$CLONE/scripts" "$CLONE/webapp/lib"
 cp "$SOURCE_ROOT/harness/paths.py" "$CLONE/harness/"
 cp "$SOURCE_ROOT/scripts/envpath.sh" "$CLONE/scripts/"
-cp "$SOURCE_ROOT/webapp/lib/envfile.php" "$SOURCE_ROOT/webapp/lib/guard.php" "$CLONE/webapp/lib/"
+# envfile.php requiere guard.php e i18n.php. Copiar de menos no da un fallo
+# legible: el require muere, php no imprime nada, y la comparación de abajo
+# lee ese vacío como un desacuerdo de rutas. i18n.php no necesita catálogos
+# aquí — load_catalogue() devuelve [] si el archivo no está, y ni env_path()
+# ni state_dir() llaman a t().
+cp "$SOURCE_ROOT/webapp/lib/envfile.php" "$SOURCE_ROOT/webapp/lib/guard.php" \
+   "$SOURCE_ROOT/webapp/lib/i18n.php" "$CLONE/webapp/lib/"
 ROOT="$CLONE"
 
 pass=0
@@ -81,10 +87,20 @@ php_() {
         *) echo SKIP_NA; return ;;
     esac
     command -v php >/dev/null 2>&1 || { echo SKIP_NOPHP; return; }
-    HOME="$1" PAYNANI_ENV="${2:-}" php -r '
+    local out
+    out=$(HOME="$1" PAYNANI_ENV="${2:-}" php -r '
         require "'"$ROOT"'/webapp/lib/envfile.php";
         echo "'"${3:-env}"'" === "env" ? env_path() : state_dir();
-    ' 2>/dev/null
+    ' 2>&1)
+    # Un fatal de php sale por stderr y deja stdout vacío. Descartarlo con
+    # 2>/dev/null convertía «este archivo no carga» en «este archivo resuelve la
+    # cadena vacía», y el fallo se leía como un desacuerdo de rutas que no era.
+    # Una ruta siempre es absoluta; cualquier otra cosa es el error, y se
+    # devuelve para que aparezca en la línea «actual».
+    case "$out" in
+        /*) printf '%s\n' "$out" ;;
+        *)  printf 'PHP_ERROR: %s\n' "$(printf '%s' "$out" | tr '\n' ' ' | cut -c1-140)" ;;
+    esac
 }
 
 # Sets RESOLVED rather than printing it: this also prints check results, and a


### PR DESCRIPTION
**`main` está en 131 de 151.** Los veinte fallos son todos `php agrees with
python`, con la ruta esperada de un lado y **la cadena vacía** del otro.

## No es un desacuerdo de rutas

#26 le agregó a `webapp/lib/envfile.php` un `require_once` de `i18n.php`. La
dependencia es legítima: `envfile.php` usa `t()` en cinco mensajes de error al
escribir el archivo de credenciales.

Pero esta suite arma un clon de prueba desechable y copia dentro **sólo**
`envfile.php` y `guard.php`. El `require_once` no encuentra `i18n.php`, php
muere, stdout queda vacío, y `check` lee ese vacío como una ruta que no coincide.

Bisecado: `cb4b2a9` (#25), `0e3b32c` (#28), `f71351f` (#29) y `7e01dc7` (#30)
pasan 151 de 151. `cff6583` (#26) cae a 131. La rama de #26 ya fallaba en su
punta anterior, `958a42c`, antes de que se integrara `main` en ella.

## Dos arreglos, y el segundo importa más

**1. Se copia también `i18n.php`.** No hacen falta los catálogos:
`load_catalogue()` devuelve `[]` si el archivo no está, y ni `env_path()` ni
`state_dir()` llaman a `t()`.

**2. La invocación de php dejaba de silenciar stderr con `2>/dev/null`.** Ese
descarte convertía *«este archivo no carga»* en *«este archivo resuelve la cadena
vacía»* — un fallo distinto, que manda a buscar el problema al lado equivocado.
Ahora, si la salida no es una ruta absoluta, se devuelve el error para que
aparezca en la línea `actual:`.

Sin el punto 2 este mismo fallo se vuelve a esconder la próxima vez que alguien
agregue un `require`. Comprobado quitando `i18n.php` a mano:

```
PHP_ERROR: PHP Warning:  require_once(.../webapp/lib/i18n.php): Failed to open
stream: No such file or directory in ...
```

en vez de no decir nada.

La suite queda en **151 pasan, 0 fallan**.
