### PR TITLE
Acorta el prompt del Paso 2 para que quepa en un teléfono

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,25 @@ contraseña no debe pasar por un chat.
 Pégale esto a tu agente:
 
 ```text
-Revisa la configuración de tu cuenta de correo electrónico; está en la
-carpeta workspace del directorio de instalación de tu Harness.
+Revisa la configuración de tu
+cuenta de correo electrónico;
+está en la carpeta workspace del
+directorio de instalación de tu
+Harness.
 
 ../workspace/.env
 
-Después, instala este repositorio para poder usarla:
+Después, instala este
+repositorio para poder usarla:
 https://github.com/iaaorgmx/paynani
 
-Sigue las instrucciones del archivo AGENTS.md del repositorio.
+Sigue las instrucciones del
+archivo AGENTS.md del
+repositorio.
 
-Vas a necesitar mi nombre y mi dirección de correo electrónico para el archivo
-roster.md.
+Vas a necesitar mi nombre y mi
+dirección de correo electrónico
+para el archivo roster.md.
 
 Pregúntame lo que necesites.
 ```

--- a/i18n/README.en-US.md
+++ b/i18n/README.en-US.md
@@ -45,17 +45,23 @@ password should not travel through a chat.
 Paste this to your agent:
 
 ```text
-Check your email account settings; they are in the workspace folder of your
-Harness installation directory.
+Check your email account
+settings; they are in the
+workspace folder of your Harness
+installation directory.
 
 ../workspace/.env
 
-Then install this repository so you can use it:
+Then install this repository so
+you can use it:
 https://github.com/iaaorgmx/paynani
 
-Follow the instructions in the repository's AGENTS.md file.
+Follow the instructions in the
+repository's AGENTS.md file.
 
-You will need my name and my email address for the roster.md file.
+You will need my name and my
+email address for the roster.md
+file.
 
 Ask me anything you need.
 ```
@@ -64,18 +70,25 @@ Ask me anything you need.
 <summary>En español</summary>
 
 ```text
-Revisa la configuración de tu cuenta de correo electrónico; está en la
-carpeta workspace del directorio de instalación de tu Harness.
+Revisa la configuración de tu
+cuenta de correo electrónico;
+está en la carpeta workspace del
+directorio de instalación de tu
+Harness.
 
 ../workspace/.env
 
-Después, instala este repositorio para poder usarla:
+Después, instala este
+repositorio para poder usarla:
 https://github.com/iaaorgmx/paynani
 
-Sigue las instrucciones del archivo AGENTS.md del repositorio.
+Sigue las instrucciones del
+archivo AGENTS.md del
+repositorio.
 
-Vas a necesitar mi nombre y mi dirección de correo electrónico para el archivo
-roster.md.
+Vas a necesitar mi nombre y mi
+dirección de correo electrónico
+para el archivo roster.md.
 
 Pregúntame lo que necesites.
 ```

--- a/i18n/README.es-ES.md
+++ b/i18n/README.es-ES.md
@@ -45,18 +45,25 @@ debe pasar por un chat.
 Pégale esto a tu agente:
 
 ```text
-Revisa la configuración de tu cuenta de correo electrónico; está en la
-carpeta workspace del directorio de instalación de tu Harness.
+Revisa la configuración de tu
+cuenta de correo electrónico;
+está en la carpeta workspace del
+directorio de instalación de tu
+Harness.
 
 ../workspace/.env
 
-Después, instala este repositorio para poder usarla:
+Después, instala este
+repositorio para poder usarla:
 https://github.com/iaaorgmx/paynani
 
-Sigue las instrucciones del archivo AGENTS.md del repositorio.
+Sigue las instrucciones del
+archivo AGENTS.md del
+repositorio.
 
-Vas a necesitar mi nombre y mi dirección de correo electrónico para el archivo
-roster.md.
+Vas a necesitar mi nombre y mi
+dirección de correo electrónico
+para el archivo roster.md.
 
 Pregúntame lo que necesites.
 ```

--- a/i18n/README.fr-FR.md
+++ b/i18n/README.fr-FR.md
@@ -47,20 +47,27 @@ et un mot de passe ne doit pas transiter par une conversation.
 Collez ceci à votre agent :
 
 ```text
-Vérifiez les paramètres de votre compte de messagerie ; ils se trouvent dans
-le dossier workspace du répertoire d'installation de votre Harness.
+Vérifiez les paramètres de votre
+compte de messagerie ; ils se
+trouvent dans le dossier
+workspace du répertoire
+d'installation de votre Harness.
 
 ../workspace/.env
 
-Installez ensuite ce dépôt pour pouvoir l'utiliser :
+Installez ensuite ce dépôt pour
+pouvoir l'utiliser :
 https://github.com/iaaorgmx/paynani
 
-Suivez les instructions du fichier AGENTS.md du dépôt.
+Suivez les instructions du
+fichier AGENTS.md du dépôt.
 
-Vous aurez besoin de mon nom et de mon adresse e-mail pour le fichier
-roster.md.
+Vous aurez besoin de mon nom et
+de mon adresse e-mail pour le
+fichier roster.md.
 
-Demandez-moi tout ce dont vous avez besoin.
+Demandez-moi tout ce dont vous
+avez besoin.
 ```
 
 Tout le reste dont l'agent a besoin se trouve dans le dépôt : le texte n'a donc

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -45,18 +45,23 @@ passar por um chat.
 Cole isto para o seu agente:
 
 ```text
-Verifique as configurações da sua conta de e-mail; elas estão na pasta
-workspace do diretório de instalação do seu Harness.
+Verifique as configurações da
+sua conta de e-mail; elas estão
+na pasta workspace do diretório
+de instalação do seu Harness.
 
 ../workspace/.env
 
-Depois, instale este repositório para poder usá-la:
+Depois, instale este repositório
+para poder usá-la:
 https://github.com/iaaorgmx/paynani
 
-Siga as instruções do arquivo AGENTS.md do repositório.
+Siga as instruções do arquivo
+AGENTS.md do repositório.
 
-Você vai precisar do meu nome e do meu endereço de e-mail para o arquivo
-roster.md.
+Você vai precisar do meu nome e
+do meu endereço de e-mail para o
+arquivo roster.md.
 
 Pergunte o que precisar.
 ```


### PR DESCRIPTION
En GitHub móvil el bloque del Paso 2 sale cortado a media palabra.

## Por qué

Las vallas de código **no envuelven líneas**, nunca. Una línea de 78 caracteres
se corta donde termina la pantalla y el resto queda detrás de un desplazamiento
horizontal que casi nadie descubre. En un teléfono caben unos 32 caracteres, y el
botón de copiar se come parte de la primera línea.

Justo el texto que el README pide copiar entero era el que no se podía leer
entero.

## Qué cambia

El prompt se reenvuelve a **32 columnas** en los cinco idiomas. **No cambia una
sola palabra**: es el mismo texto con otros saltos de línea, y como se pega en un
chat, dónde parta la línea no significa nada.

**Se conserva la valla de código a propósito.** Un `>` blockquote envolvería
solo, pero perdería el botón de copiar — y en un texto cuyo único uso es copiarse,
eso es lo que más sirve.

La única línea que sigue midiendo 35 es la URL del repositorio, que no se puede
partir. A 360 px entra completa de todos modos.

## Verificación

No es una estimación: se renderizó el bloque a 360 px de ancho con la tipografía
y el tamaño con que GitHub pinta el código (`font-size: 85%`, monoespaciada,
`padding: 16px`), con el botón de copiar en su sitio. Entra entero, sin
desplazamiento horizontal, y el botón no tapa texto.

`scripts/test_docs.py` pasa.
