### PR TITLE
Aísla el resolutor de rutas de PHP en webapp/lib/paths.php

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -355,7 +355,7 @@ and this project does not.
 
 Adding a runtime means adding its root to `HARNESS_ROOTS`, in
 [`harness/paths.py`](harness/paths.py), [`scripts/envpath.sh`](scripts/envpath.sh)
-and [`webapp/lib/envfile.php`](webapp/lib/envfile.php) together —
+and [`webapp/lib/paths.php`](webapp/lib/paths.php) together —
 `scripts/test_paths.sh` asserts the three agree.
 
 If two harnesses on one host each have credentials, neither is adopted and the

--- a/scripts/envpath.sh
+++ b/scripts/envpath.sh
@@ -16,7 +16,7 @@ paynani_root() {
 # own installation directory. One pattern, not a list of special cases: a new
 # runtime is a new root here and nothing else. Keep in step with HARNESS_ROOTS /
 # HARNESS_ENV_RELATIVE in harness/paths.py and the same pair in
-# webapp/lib/envfile.php; scripts/test_paths.sh asserts all three agree.
+# webapp/lib/paths.php; scripts/test_paths.sh asserts all three agree.
 #
 # The OpenClaw root is listed because it is an instance of the rule rather than
 # an exception to it.
@@ -29,7 +29,7 @@ paynani_config_dir() {
 
 # One value out of the installer-generated runtime.env, or nothing. Kept
 # deliberately identical to recorded_env() in harness/paths.py and to
-# recorded_env() in webapp/lib/envfile.php: three implementations of one rule,
+# recorded_env() in webapp/lib/paths.php: three implementations of one rule,
 # and scripts/test_paths.sh exists because they have drifted before.
 paynani_recorded_env() {
     local file line value

--- a/scripts/test_paths.sh
+++ b/scripts/test_paths.sh
@@ -27,13 +27,10 @@ trap 'rm -rf "$CLONE"' EXIT
 mkdir -p "$CLONE/harness" "$CLONE/scripts" "$CLONE/webapp/lib"
 cp "$SOURCE_ROOT/harness/paths.py" "$CLONE/harness/"
 cp "$SOURCE_ROOT/scripts/envpath.sh" "$CLONE/scripts/"
-# envfile.php requiere guard.php e i18n.php. Copiar de menos no da un fallo
-# legible: el require muere, php no imprime nada, y la comparación de abajo
-# lee ese vacío como un desacuerdo de rutas. i18n.php no necesita catálogos
-# aquí — load_catalogue() devuelve [] si el archivo no está, y ni env_path()
-# ni state_dir() llaman a t().
-cp "$SOURCE_ROOT/webapp/lib/envfile.php" "$SOURCE_ROOT/webapp/lib/guard.php" \
-   "$SOURCE_ROOT/webapp/lib/i18n.php" "$CLONE/webapp/lib/"
+# paths.php es la tercera implementación de la regla y no requiere nada, así que
+# un solo archivo basta y la lista de arriba no vuelve a quedarse corta cuando
+# alguien agregue un require en otro lado.
+cp "$SOURCE_ROOT/webapp/lib/paths.php" "$CLONE/webapp/lib/"
 ROOT="$CLONE"
 
 pass=0
@@ -89,7 +86,7 @@ php_() {
     command -v php >/dev/null 2>&1 || { echo SKIP_NOPHP; return; }
     local out
     out=$(HOME="$1" PAYNANI_ENV="${2:-}" php -r '
-        require "'"$ROOT"'/webapp/lib/envfile.php";
+        require "'"$ROOT"'/webapp/lib/paths.php";
         echo "'"${3:-env}"'" === "env" ? env_path() : state_dir();
     ' 2>&1)
     # Un fatal de php sale por stderr y deja stdout vacío. Descartarlo con

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -191,6 +191,7 @@ documents it as the schema trap it is.
 
 ```
 webapp/index.php        the form, the report, and the confirmation
+webapp/lib/paths.php    where the credentials and the state live; requires nothing
 webapp/lib/guard.php    loopback check, one-time key, CSRF, headers
 webapp/lib/validate.php field checks, each one a mistake seen in the wild
 webapp/lib/probe.php    live IMAP and SMTP sign-in

--- a/webapp/lib/envfile.php
+++ b/webapp/lib/envfile.php
@@ -23,23 +23,8 @@ declare(strict_types=1);
  * convention.
  */
 
+require_once __DIR__ . '/paths.php';
 require_once __DIR__ . '/i18n.php';
-require_once __DIR__ . '/guard.php';
-
-/**
- * Every harness keeps its agent's mail credentials in the workspace folder of
- * its own installation directory. One pattern rather than a list of special
- * cases: a new runtime is a new root here and nothing else. Keep in step with
- * HARNESS_ROOTS / HARNESS_ENV_RELATIVE in harness/paths.py and the same pair in
- * scripts/envpath.sh; scripts/test_paths.sh asserts all three agree.
- *
- * The OpenClaw root is listed because it is an instance of the rule rather than
- * an exception to it.
- */
-const HARNESS_ROOTS         = ['.openclaw', '.hermes', '.claude'];
-const HARNESS_ENV_RELATIVE  = 'workspace/.env';
-
-const ENV_BASENAME = '.env';
 
 /** The keys this form owns, in the order they are written. */
 const ENV_FIELDS = [
@@ -51,65 +36,6 @@ const ENV_FIELDS = [
     'AGENT_EMAIL_OUTGOING_SERVER_SMTP_HOST',
     'AGENT_EMAIL_OUTGOING_SERVER_SMTP_PORT',
 ];
-
-/**
- * The credentials file the installer recorded in runtime.env, or null.
- *
- * Kept deliberately identical to recorded_env() in harness/paths.py and
- * paynani_recorded_env() in scripts/envpath.sh. Three implementations of one
- * rule; scripts/test_paths.sh cross-checks them because they have drifted before.
- */
-function recorded_env(): ?string
-{
-    $file = install_root() . '/runtime.env';
-    clearstatcache(true, $file);
-    if (!is_file($file)) {
-        return null;
-    }
-    $text = @file_get_contents($file);
-    if ($text === false) {
-        return null;
-    }
-    foreach (preg_split('/\r\n|\r|\n/', $text) as $line) {
-        $line = trim($line);
-        if (strpos($line, 'PAYNANI_ENV=') === 0) {
-            $value = trim(substr($line, strlen('PAYNANI_ENV=')), " \t\"'");
-            return $value !== '' ? $value : null;
-        }
-    }
-    return null;
-}
-
-function env_path(): string
-{
-    $override = getenv('PAYNANI_ENV');
-    if (is_string($override) && trim($override) !== '') {
-        return trim($override);
-    }
-
-    $recorded = recorded_env();
-    if ($recorded !== null) {
-        return $recorded;
-    }
-
-    // Read the harness's file where it lies. Everything else still hangs off
-    // the clone; that split is deliberate and is explained in harness/paths.py.
-    // Two harness files means two agents share this host, either could be the
-    // wrong mailbox, and a listener on the wrong mailbox is indistinguishable
-    // from a quiet one — so neither is adopted.
-    $harness = [];
-    foreach (HARNESS_ROOTS as $root) {
-        $candidate = rtrim(home_dir(), '/') . '/' . $root . '/' . HARNESS_ENV_RELATIVE;
-        clearstatcache(true, $candidate);
-        if (is_file($candidate) || is_link($candidate)) {
-            $harness[] = $candidate;
-        }
-    }
-    if (count($harness) === 1) {
-        return $harness[0];
-    }
-    return install_root() . '/' . ENV_BASENAME;
-}
 
 function env_is_symlink(): bool
 {

--- a/webapp/lib/guard.php
+++ b/webapp/lib/guard.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/paths.php';
 require_once __DIR__ . '/i18n.php';
 
 /**
@@ -21,29 +22,6 @@ require_once __DIR__ . '/i18n.php';
 
 const TOKEN_BASENAME = 'setup.token';
 
-/**
- * The clone, which is also the install root.
- *
- * Found from this file, not from $PWD or $HOME, so serving this directory from
- * anywhere still resolves to the install it belongs to. The rule is written
- * down in harness/paths.py and the three languages are asserted to agree in
- * scripts/test_paths.sh; change all of them or none.
- */
-function install_root(): string
-{
-    return dirname(__DIR__, 2);
-}
-
-/** The queue state, cursors and logs. */
-function state_dir(): string
-{
-    $override = getenv('PAYNANI_STATE');
-    if (is_string($override) && trim($override) !== '') {
-        return rtrim(trim($override), '/');
-    }
-    return install_root() . '/state';
-}
-
 /** Loopback only. A password form has no business answering the network. */
 function require_loopback(): void
 {
@@ -61,16 +39,6 @@ function require_loopback(): void
 function token_path(): string
 {
     return state_dir() . '/' . TOKEN_BASENAME;
-}
-
-function home_dir(): string
-{
-    $home = getenv('HOME');
-    if (is_string($home) && $home !== '') {
-        return $home;
-    }
-    $info = posix_getpwuid(posix_geteuid());
-    return is_array($info) && isset($info['dir']) ? (string) $info['dir'] : '/tmp';
 }
 
 /**

--- a/webapp/lib/paths.php
+++ b/webapp/lib/paths.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Where everything lives, for PHP.
+ *
+ * One rule, three implementations: harness/paths.py, scripts/envpath.sh and
+ * this file. scripts/test_paths.sh asserts they answer identically, because
+ * they have drifted before and the drift is invisible until it matters — the
+ * form writes credentials to one path while the listener reads another, which
+ * looks exactly like a mailbox that never gets mail.
+ *
+ * This file requires nothing. That is the point, not an accident: it is the
+ * third of a cross-language contract, so it has to be comparable on its own,
+ * and anything it pulled in could break underneath it. It carries resolution
+ * and only resolution — reading and writing the credentials file is
+ * envfile.php's job, and guarding the form is guard.php's.
+ */
+
+/**
+ * Every harness keeps its agent's mail credentials in the workspace folder of
+ * its own installation directory. One pattern rather than a list of special
+ * cases: a new runtime is a new root here and nothing else. Keep in step with
+ * HARNESS_ROOTS / HARNESS_ENV_RELATIVE in harness/paths.py and the same pair in
+ * scripts/envpath.sh; scripts/test_paths.sh asserts all three agree.
+ *
+ * The OpenClaw root is listed because it is an instance of the rule rather than
+ * an exception to it.
+ */
+const HARNESS_ROOTS         = ['.openclaw', '.hermes', '.claude'];
+const HARNESS_ENV_RELATIVE  = 'workspace/.env';
+
+const ENV_BASENAME = '.env';
+
+/**
+ * The clone, which is also the install root.
+ *
+ * Found from this file, not from $PWD or $HOME, so serving this directory from
+ * anywhere still resolves to the install it belongs to. The rule is written
+ * down in harness/paths.py and the three languages are asserted to agree in
+ * scripts/test_paths.sh; change all of them or none.
+ */
+function install_root(): string
+{
+    return dirname(__DIR__, 2);
+}
+
+/** The queue state, cursors and logs. */
+function state_dir(): string
+{
+    $override = getenv('PAYNANI_STATE');
+    if (is_string($override) && trim($override) !== '') {
+        return rtrim(trim($override), '/');
+    }
+    return install_root() . '/state';
+}
+
+function home_dir(): string
+{
+    $home = getenv('HOME');
+    if (is_string($home) && $home !== '') {
+        return $home;
+    }
+    $info = posix_getpwuid(posix_geteuid());
+    return is_array($info) && isset($info['dir']) ? (string) $info['dir'] : '/tmp';
+}
+
+/**
+ * The credentials file the installer recorded in runtime.env, or null.
+ *
+ * Kept deliberately identical to recorded_env() in harness/paths.py and
+ * paynani_recorded_env() in scripts/envpath.sh. Three implementations of one
+ * rule; scripts/test_paths.sh cross-checks them because they have drifted before.
+ */
+function recorded_env(): ?string
+{
+    $file = install_root() . '/runtime.env';
+    clearstatcache(true, $file);
+    if (!is_file($file)) {
+        return null;
+    }
+    $text = @file_get_contents($file);
+    if ($text === false) {
+        return null;
+    }
+    foreach (preg_split('/\r\n|\r|\n/', $text) as $line) {
+        $line = trim($line);
+        if (strpos($line, 'PAYNANI_ENV=') === 0) {
+            $value = trim(substr($line, strlen('PAYNANI_ENV=')), " \t\"'");
+            return $value !== '' ? $value : null;
+        }
+    }
+    return null;
+}
+
+function env_path(): string
+{
+    $override = getenv('PAYNANI_ENV');
+    if (is_string($override) && trim($override) !== '') {
+        return trim($override);
+    }
+
+    $recorded = recorded_env();
+    if ($recorded !== null) {
+        return $recorded;
+    }
+
+    // Read the harness's file where it lies. Everything else still hangs off
+    // the clone; that split is deliberate and is explained in harness/paths.py.
+    // Two harness files means two agents share this host, either could be the
+    // wrong mailbox, and a listener on the wrong mailbox is indistinguishable
+    // from a quiet one — so neither is adopted.
+    $harness = [];
+    foreach (HARNESS_ROOTS as $root) {
+        $candidate = rtrim(home_dir(), '/') . '/' . $root . '/' . HARNESS_ENV_RELATIVE;
+        clearstatcache(true, $candidate);
+        if (is_file($candidate) || is_link($candidate)) {
+            $harness[] = $candidate;
+        }
+    }
+    if (count($harness) === 1) {
+        return $harness[0];
+    }
+    return install_root() . '/' . ENV_BASENAME;
+}


### PR DESCRIPTION
Cierra #33.

## El problema

Para preguntar en PHP *«¿dónde vive el `.env`?»* había que cargar el catálogo de
idiomas, el control de acceso del formulario, la sesión y el CSRF: `envfile.php` y
`guard.php` requerían `i18n.php`, y las funciones de resolución estaban repartidas
entre esos dos archivos. En Python basta `harness/paths.py`; en shell,
`scripts/envpath.sh`. La tercera implementación de la misma regla era la única que
arrastraba media aplicación.

Ya había cobrado una pieza: en #31, un `require` que no encontraba su archivo mató
a PHP, y las veinte comparaciones leyeron la cadena vacía **como una ruta que no
coincide**.

## Qué hace este PR

**Nuevo `webapp/lib/paths.php`**, con las cinco funciones juntas —`home_dir()`,
`install_root()`, `state_dir()`, `recorded_env()`, `env_path()`— más
`HARNESS_ROOTS`, `HARNESS_ENV_RELATIVE` y `ENV_BASENAME`. **No requiere nada.**
Eso no es higiene: es lo que le permite ser comparable por sí solo con las otras
dos implementaciones, que es exactamente lo que `test_paths.sh` afirma 151 veces.

Queda como contraparte simétrica de `harness/paths.py` y `scripts/envpath.sh`, y
el nombre lo dice.

**`guard.php`** se queda con lo suyo: loopback, llave de un solo uso, CSRF,
cabeceras, sesión.
**`envfile.php`** se queda con lo suyo: leer, sanear, renderizar y escribir.
Los dos requieren `paths.php`.

**Ninguno pierde su `require` de `i18n.php`**, y eso es deliberado:
`require_loopback()` y `write_env()` sí traducen sus mensajes, y los lee alguien
que está entregando la contraseña de su buzón. La dependencia legítima se queda
donde es legítima; lo que se corta es que el resolutor la heredara.

`envfile.php` además deja de requerir `guard.php`: no usaba nada de ahí salvo las
funciones que se movieron.

**`test_paths.sh` copia un solo archivo** a su clon de prueba. La lista que en #31
se había quedado corta deja de ser una lista.

## Prosa actualizada

`scripts/envpath.sh` (dos comentarios que nombraban `envfile.php`), `INSTALL.md`
y la tabla de archivos de `webapp/README.md`, donde `paths.php` entra con su
propia línea. **Las entradas del `CHANGELOG` no se tocan**: describen lo que era
cierto cuando se escribieron.

## Verificación

- Las **dieciséis suites** pasan, sin fallos. `test_paths.sh` sigue en 151 de 151.
- `php -l` limpio en los catorce archivos PHP.
- La página se sirve y devuelve **403 con su mensaje traducido** —es decir,
  `paths.php`, `guard.php` e `i18n.php` cargan bien y `t()` resuelve—, sin un solo
  fatal en el log del servidor.
