### PR TITLE
Sondea la conexión IMAP con keepalive, para que una conexión muerta se note

### DIFF
--- a/scripts/idle_listener.py
+++ b/scripts/idle_listener.py
@@ -33,8 +33,11 @@ DEFAULT_ENV   = None   # resolved by harness/paths.py, see main()
 DEFAULT_STATE = str(state_dir() / "idle.json")
 DEFAULT_JOURNAL = str(state_dir() / "events.jsonl")
 
-# RFC 2177: a client must re-issue IDLE at least every 29 minutes.
-IDLE_REFRESH = 25 * 60
+# RFC 2177: a client must re-issue IDLE at least every 29 minutes. We stay well
+# under the ceiling on purpose: this interval is also the longest a dead
+# connection can sit unnoticed, so 25 minutes bought nothing and cost a
+# 25-minute blind window. See keepalive() for the primary defence.
+IDLE_REFRESH = 5 * 60
 BACKOFF_MIN, BACKOFF_MAX = 5, 300
 
 # Optional: collapse GitHub notification subjects into something scannable.
@@ -270,6 +273,33 @@ def lookup(env, field, default=None):
     sys.exit(1)
 
 
+def keepalive(sock):
+    """Make a dead connection announce itself.
+
+    Behind NAT — WSL2, or most home routers — an idle connection is dropped
+    without a FIN, and from this side the socket still reads ESTAB until
+    something tries to write. The listener sits in select() waiting for an
+    EXISTS that can no longer arrive, and the mailbox looks exactly like a quiet
+    one. Keepalive probes turn that into a read error, which the retry loop
+    already handles: recovery was never the missing piece, noticing was.
+    """
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except OSError as exc:
+        log(f"could not enable SO_KEEPALIVE: {exc}")
+        return
+    # macOS does not expose TCP_KEEPIDLE, so every tunable is asked for by name
+    # before it is set. A missing one costs sensitivity, not correctness.
+    for name, value in (("TCP_KEEPIDLE", 60), ("TCP_KEEPINTVL", 20), ("TCP_KEEPCNT", 3)):
+        option = getattr(socket, name, None)
+        if option is None:
+            continue
+        try:
+            sock.setsockopt(socket.IPPROTO_TCP, option, value)
+        except OSError as exc:
+            log(f"could not set {name}={value}: {exc}")
+
+
 def connect(env):
     # The old schema is a trap rather than an inconvenience: the key is named for
     # a server and holds a port, so a literal reading sends you somewhere else.
@@ -292,6 +322,7 @@ def connect(env):
     password = lookup(env, "password")
 
     conn = imaplib.IMAP4_SSL(host, port, ssl_context=ssl.create_default_context(), timeout=30)
+    keepalive(conn.sock)
     try:
         conn.login(user, password)
     except imaplib.IMAP4.error as exc:


### PR DESCRIPTION
Cierra #37.

## El problema

Detrás de un NAT —WSL2, o casi cualquier router doméstico— una conexión IMAP inactiva se descarta sin FIN. Desde este lado el socket se sigue viendo `ESTAB` hasta que alguien intenta escribir, así que `idle_listener.py` se queda bloqueado en `select()` esperando un `EXISTS` que ya no puede llegar.

El resultado es el peor tipo de fallo: **el correo deja de llegar en silencio**. Proceso vivo, socket sano, cero errores en el log. Un buzón tranquilo y un listener ciego producen exactamente la misma señal.

Nada probaba la conexión, por dos razones que se combinaban:

- `connect()` abría el socket sin `SO_KEEPALIVE`, así que el kernel nunca sondeaba al otro extremo.
- `IDLE_REFRESH` estaba en 25 minutos, y ese número no es solo cada cuánto se reemite IDLE: es cuánto puede durar una conexión muerta sin que nadie se entere.

## Los cambios

**`keepalive(sock)` nueva**, invocada en `connect()` después de abrir el socket y antes del `login()`. Activa `SO_KEEPALIVE` y, cuando el kernel las expone, `TCP_KEEPIDLE=60`, `TCP_KEEPINTVL=20` y `TCP_KEEPCNT=3`. Cada opción se consulta con `getattr(socket, name, None)` porque **macOS no expone `TCP_KEEPIDLE`**; si un `setsockopt` falla se registra con `log()` y se sigue, porque una opción faltante cuesta sensibilidad, no corrección.

Con esto una conexión muerta se vuelve un error de lectura, que el bucle de reintentos **ya sabía manejar**. Lo que faltaba nunca fue la recuperación, era darse cuenta.

**`IDLE_REFRESH` de 25 a 5 minutos**, como respaldo si el keepalive no alcanza. El costo es un viaje `DONE`/`IDLE` extra cada 5 minutos.

## Verificación

`scripts/test_listener.py` pasa.

Aplicado y reiniciado en la instalación de Metis (WSL2). El socket nuevo trae el temporizador que antes no existía:

```
ESTAB  172.19.50.109:36704  173.194.208.108:993  users:(("python3",pid=1845,fd=3))  timer:(keepalive,56sec,0)
```

En la instalación de Esteban, con el mismo parche, el correo pasó de no llegar a llegar en **21 segundos**.

## Cómo probarlo

**No sirve enviar en ráfaga.** El bug necesita reposo para aparecer: las tres pruebas de la primera ronda del reporte pasaron porque ninguna dejó la conexión quieta lo suficiente. Deja el listener **30 minutos en reposo** y luego envía.

## Consecuencia que hereda el arreglo

Las reconexiones ahora son más frecuentes, y cada una puede entregar backlog **ya atendido**. Una notificación atrasada no es un mensaje nuevo, y hay que distinguirla por asunto y fecha. Está descrito en #37; documentarlo en `AGENTS.md` queda fuera de este PR.

## Crédito

Diagnosticado y reportado por **Zeus Claude-Tob**, el agente Claude Code de Esteban Rodríguez, al instalar paynani en el workspace de Esteban. La evidencia de `ss` que prueba la causa raíz es suya: al reiniciar el servicio capturó la conexión vieja en `FIN-WAIT-1` con 65 bytes atorados en la cola de envío y 7 reintentos de retransmisión — el otro extremo llevaba rato sin devolver un solo ACK.
