### PR TITLE
Pide el temporizador de keepalive también por su nombre de macOS

### DIFF
--- a/scripts/idle_listener.py
+++ b/scripts/idle_listener.py
@@ -273,6 +273,25 @@ def lookup(env, field, default=None):
     sys.exit(1)
 
 
+# How long a connection may sit idle before the kernel probes it, how far apart
+# the probes go, and how many go unanswered before the socket is declared dead.
+#
+# The idle timer has two names. Linux calls it TCP_KEEPIDLE; macOS calls it
+# TCP_KEEPALIVE, and each platform exposes only its own -- so listing both and
+# asking for each by name costs one skipped lookup either way and covers both.
+# Naming only TCP_KEEPIDLE, as this did at first, does not fail on macOS: it
+# leaves SO_KEEPALIVE on with the system default of two hours, so no probe fires
+# inside any window that matters and the protection quietly falls back to
+# IDLE_REFRESH. A silent downgrade is the exact failure this whole function
+# exists to remove, so the macOS name is not an optional extra.
+KEEPALIVE_OPTIONS = (
+    ("TCP_KEEPIDLE", 60),     # Linux
+    ("TCP_KEEPALIVE", 60),    # macOS, same knob
+    ("TCP_KEEPINTVL", 20),
+    ("TCP_KEEPCNT", 3),
+)
+
+
 def keepalive(sock):
     """Make a dead connection announce itself.
 
@@ -288,9 +307,11 @@ def keepalive(sock):
     except OSError as exc:
         log(f"could not enable SO_KEEPALIVE: {exc}")
         return
-    # macOS does not expose TCP_KEEPIDLE, so every tunable is asked for by name
-    # before it is set. A missing one costs sensitivity, not correctness.
-    for name, value in (("TCP_KEEPIDLE", 60), ("TCP_KEEPINTVL", 20), ("TCP_KEEPCNT", 3)):
+    # Every tunable is asked for by name before it is set, because which ones
+    # exist depends on the platform. A missing one costs sensitivity, not
+    # correctness -- see KEEPALIVE_OPTIONS for why both idle-timer names are
+    # listed rather than only Linux's.
+    for name, value in KEEPALIVE_OPTIONS:
         option = getattr(socket, name, None)
         if option is None:
             continue

--- a/scripts/test_listener.py
+++ b/scripts/test_listener.py
@@ -8,12 +8,13 @@ instructions, so most of these tests are about what must *not* be tagged.
 
 import email
 import pathlib
+import socket
 import sys
 import tempfile
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
-from idle_listener import describe, decode_hdr
+from idle_listener import KEEPALIVE_OPTIONS, describe, decode_hdr, keepalive
 from roster import (notifier_headers, notifiers, roster_addresses,
                     roster_entries, sender_is_listed)
 
@@ -196,6 +197,41 @@ def main():
         check(encoded == "Prueba de correo — ñ, á, ¿qué tal?", f"decoded to {encoded!r}")
         check("\n" not in describe("a@b.c", encoded, "", trusted=True),
               "one message is always one line")
+
+    # --- keepalive, the thing that makes a dead connection announce itself ----
+    #
+    # Behind NAT an idle connection is dropped without a FIN and the socket still
+    # reads ESTAB, so nothing notices until something writes. These probes are
+    # what write. The failure this guards is not a crash: naming only Linux's
+    # TCP_KEEPIDLE leaves macOS with SO_KEEPALIVE on and the system default of
+    # two hours, so no probe fires inside any useful window and the protection
+    # silently falls back to IDLE_REFRESH. Silence is the failure mode the whole
+    # feature exists to remove, so it has to be asserted, not assumed.
+    names = [name for name, _ in KEEPALIVE_OPTIONS]
+    check("TCP_KEEPIDLE" in names, "the Linux idle-timer name is asked for")
+    check("TCP_KEEPALIVE" in names, "the macOS idle-timer name is asked for too")
+    check(len(names) == len(set(names)), f"no option is set twice: {names}")
+
+    # Whichever platform this is, one of the two idle names must resolve. If
+    # neither does, keepalive() runs, logs nothing, and protects nothing.
+    idle_names = [n for n in ("TCP_KEEPIDLE", "TCP_KEEPALIVE") if hasattr(socket, n)]
+    check(idle_names, "this platform exposes an idle timer under one of the two names")
+
+    # And it has to reach the socket. Asserting on the table alone would pass on
+    # a keepalive() that never called setsockopt.
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        keepalive(probe)
+        check(probe.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) == 1,
+              "SO_KEEPALIVE is on after keepalive()")
+        for name, value in KEEPALIVE_OPTIONS:
+            option = getattr(socket, name, None)
+            if option is None:
+                continue
+            got = probe.getsockopt(socket.IPPROTO_TCP, option)
+            check(got == value, f"{name} is {value} after keepalive(), got {got}")
+    finally:
+        probe.close()
 
     print("listener tests passed")
     return 0


### PR DESCRIPTION
Seguimiento de #37. No hay issue aparte porque el arreglo va aquí mismo.

## El hueco

`keepalive()` consultaba `TCP_KEEPIDLE`, `TCP_KEEPINTVL` y `TCP_KEEPCNT`. Su comentario decía que se consultan por nombre *"porque macOS no expone `TCP_KEEPIDLE`"*.

El diagnóstico era correcto. Lo incompleto era el arreglo: **macOS sí tiene ese temporizador, se llama `TCP_KEEPALIVE`**, y nunca se pedía. El código evitaba morir en un Mac; no hacía que el keepalive funcionara ahí.

## Por qué importa aunque no rompa nada visible

En un Mac queda `SO_KEEPALIVE` encendido con el ocioso por omisión del sistema: **dos horas**. Ninguna sonda dispara dentro de una ventana útil, y la protección se cae al `IDLE_REFRESH` de 5 minutos.

No es catastrófico —5 minutos de ceguera en vez de los 25 originales— pero es **silencioso**, y un degradado silencioso es exactamente la falla que esta función existe para eliminar. `scripts/install_macos.py` son 328 líneas: macOS es un objetivo de instalación soportado, no hipotético.

## El cambio

La tabla sale a `KEEPALIVE_OPTIONS`, constante del módulo, con los dos nombres del mismo temporizador:

```python
KEEPALIVE_OPTIONS = (
    ("TCP_KEEPIDLE", 60),     # Linux
    ("TCP_KEEPALIVE", 60),    # macOS, same knob
    ("TCP_KEEPINTVL", 20),
    ("TCP_KEEPCNT", 3),
)
```

Cada plataforma expone solo el suyo, así que el par cuesta una consulta que se salta y cubre las dos. Sacarla a constante es lo que permite que la suite afirme sobre ella.

## Pruebas

`test_listener.py` gana seis aserciones:

- los dos nombres del temporizador están en la tabla
- ninguna opción se repite
- esta plataforma resuelve al menos uno de los dos nombres — si no resolviera ninguno, `keepalive()` correría, no registraría nada y no protegería nada
- `keepalive()` **llega al socket**: `SO_KEEPALIVE` en 1, y cada opción existente con su valor

Lo último importa porque afirmar solo sobre la tabla pasaría con un `keepalive()` que nunca llama a `setsockopt`.

**La aserción muerde.** Quitando la línea de `TCP_KEEPALIVE`, la suite falla:

```
AssertionError: the macOS idle-timer name is asked for too
```

Suite completa del repo en verde.

## Lo que este PR no prueba

Que funcione en un Mac. Nadie de la flota corre macOS que yo sepa, así que esto se apoya en que `TCP_KEEPALIVE` es el nombre correcto ahí, no en una medición. Si algún día hay un host macOS, la prueba de campo de #37 —30 minutos de conexión quieta— es la que lo confirmaría.
