### PR TITLE
NO FUSIONAR — prueba rota a proposito para demostrar la compuerta (#67)

### DIFF
--- a/scripts/test_compuerta_demo.py
+++ b/scripts/test_compuerta_demo.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Prueba rota A PROPOSITO. No fusionar.
+
+Existe para demostrar la cuarta casilla del criterio de cierre del #67: que un
+PR con una prueba en rojo queda bloqueado por la proteccion de rama, y no solo
+marcado en rojo mientras el boton de fusionar sigue disponible.
+
+El PR que la trae se cierra sin fusionar. Si este archivo aparece alguna vez en
+`main`, algo salio muy mal.
+"""
+import sys
+
+print("fallo deliberado: demostracion de la compuerta del #67")
+sys.exit(1)


### PR DESCRIPTION
Este PR **no se va a fusionar**. Existe para ejercer la tercera casilla del criterio de cierre del #67:

> - [ ] Un PR con una prueba rota queda bloqueado y se puede mostrar

Agrega `scripts/test_compuerta_demo.py`, que imprime una linea y sale con estado 1. La suite local ya lo reporta: **17 passed, 1 failed**.

Lo que se espera ver aqui:

1. El check `suite` en rojo.
2. El boton de fusionar **deshabilitado**, no solo acompañado de una advertencia.

Esa segunda parte es la que importa. Antes de la proteccion de rama un check en rojo era informativo: se veia el rojo y se podia fusionar de todos modos. La diferencia entre ver el rojo y no poder avanzar es exactamente lo que el #67 pedia.

Cierro este PR sin fusionar en cuanto la evidencia quede asentada en el issue, y borro la rama.