### PR TITLE
Fix Codex SessionEnd hook timeout

### DIFF
--- a/scripts/codex_hook.py
+++ b/scripts/codex_hook.py
@@ -26,7 +26,8 @@ START_EVENT = "SessionStart"
 END_EVENT = "SessionEnd"
 START_MATCHER = "startup|resume|clear|compact"
 END_MATCHER = ".*"
-TIMEOUT = 15
+START_TIMEOUT = 15
+END_TIMEOUT = 3
 ADDITIONAL_CONTEXT_LIMIT = 5000
 
 
@@ -42,7 +43,7 @@ def start_fragment():
     return {
         "type": "command",
         "command": start_command(),
-        "timeout": TIMEOUT,
+        "timeout": START_TIMEOUT,
         "statusMessage": "Checking paynani",
         "additionalContextLimit": ADDITIONAL_CONTEXT_LIMIT,
     }
@@ -52,7 +53,7 @@ def end_fragment():
     return {
         "type": "command",
         "command": end_command(),
-        "timeout": TIMEOUT,
+        "timeout": END_TIMEOUT,
         "statusMessage": "Clearing paynani session",
     }
 
@@ -75,27 +76,41 @@ def load(path):
         )
 
 
-def _event_has_command(settings, event, command_text):
+def _event_has_fragment(settings, event, matcher, fragment):
     for entry in settings.get("hooks", {}).get(event, []) or []:
+        if entry.get("matcher") != matcher:
+            continue
         for hook in entry.get("hooks", []) or []:
-            if (hook.get("command") or "") == command_text:
+            if hook == fragment:
                 return True
     return False
 
 
 def already_registered(settings):
-    return (_event_has_command(settings, START_EVENT, start_command())
-            and _event_has_command(settings, END_EVENT, end_command()))
+    return (_event_has_fragment(settings, START_EVENT, START_MATCHER, start_fragment())
+            and _event_has_fragment(settings, END_EVENT, END_MATCHER, end_fragment()))
+
+
+def _merge_event(hooks, event, matcher, fragment):
+    entries = hooks.setdefault(event, [])
+    command_text = fragment["command"]
+    for entry in entries:
+        hook_list = entry.get("hooks", []) or []
+        for index, hook in enumerate(hook_list):
+            if (hook.get("command") or "") == command_text:
+                hook_list[index] = fragment
+                if len(hook_list) == 1:
+                    entry["matcher"] = matcher
+                return
+    entries.append({"matcher": matcher, "hooks": [fragment]})
 
 
 def merge(settings):
     hooks = settings.setdefault("hooks", {})
-    if not _event_has_command(settings, START_EVENT, start_command()):
-        hooks.setdefault(START_EVENT, []).append(
-            {"matcher": START_MATCHER, "hooks": [start_fragment()]})
-    if not _event_has_command(settings, END_EVENT, end_command()):
-        hooks.setdefault(END_EVENT, []).append(
-            {"matcher": END_MATCHER, "hooks": [end_fragment()]})
+    if not _event_has_fragment(settings, START_EVENT, START_MATCHER, start_fragment()):
+        _merge_event(hooks, START_EVENT, START_MATCHER, start_fragment())
+    if not _event_has_fragment(settings, END_EVENT, END_MATCHER, end_fragment()):
+        _merge_event(hooks, END_EVENT, END_MATCHER, end_fragment())
     return settings
 
 

--- a/scripts/test_codex.py
+++ b/scripts/test_codex.py
@@ -524,15 +524,35 @@ class HookRegistration(unittest.TestCase):
         self.assertEqual(self.commands("SessionStart"), [self.hook.start_command()])
         self.assertEqual(self.commands("SessionEnd"), [self.hook.end_command()])
 
+    def test_existing_codex_hooks_are_converged(self):
+        import json
+        old_end = self.hook.end_fragment()
+        old_end["timeout"] = 15
+        self.settings.write_text(json.dumps({
+            "hooks": {
+                "SessionStart": [{"matcher": self.hook.START_MATCHER, "hooks": [self.hook.start_fragment()]}],
+                "SessionEnd": [{"matcher": self.hook.END_MATCHER, "hooks": [old_end]}],
+            },
+        }), encoding="utf-8")
+        self.assertFalse(self.hook.already_registered(self.load()))
+        self.run_install()
+        after = self.load()
+        self.assertTrue(self.hook.already_registered(after))
+        self.assertEqual(self.commands("SessionStart"), [self.hook.start_command()])
+        self.assertEqual(self.commands("SessionEnd"), [self.hook.end_command()])
+        self.assertEqual(after["hooks"]["SessionEnd"][0]["hooks"][0]["timeout"], 3)
+
     def test_fragments_use_codex_hook_shapes(self):
         self.run_install()
         entry = self.load()["hooks"]["SessionStart"][0]
         hook = entry["hooks"][0]
         self.assertEqual(entry["matcher"], self.hook.START_MATCHER)
+        self.assertEqual(hook["timeout"], 15)
         self.assertEqual(hook["additionalContextLimit"], self.hook.ADDITIONAL_CONTEXT_LIMIT)
         end_entry = self.load()["hooks"]["SessionEnd"][0]
         end_hook = end_entry["hooks"][0]
         self.assertEqual(end_entry["matcher"], self.hook.END_MATCHER)
+        self.assertEqual(end_hook["timeout"], 3)
         self.assertNotIn("additionalContextLimit", end_hook)
         self.assertIn("--session-end", end_hook["command"])
 


### PR DESCRIPTION
@metisclaudetob this addresses #58.

## Summary

- split the Codex hook timeout into `START_TIMEOUT = 15` and `END_TIMEOUT = 3`
- made `codex_hook.py --check` require the full expected hook fragment, not just the command
- made `codex_hook.py --install` converge existing paynani hooks in place, so an installed `SessionEnd` hook with timeout 15 is updated without duplicating it
- added tests for the explicit timeout values and stale-hook convergence

## Verification

- `python3 scripts/test_codex.py`
- `python3 scripts/test_env_secret.py`
- `python3 scripts/test_listener.py` (outside sandbox; local sockets required)
- `python3 scripts/test_dispatch.py`
- `python3 scripts/test_healthcheck.py`
- `python3 scripts/test_rotate_logs.py`
- `python3 scripts/test_docs.py`
- `python3 scripts/test_hermes_adapter.py` (outside sandbox; local HTTP server required)
- `python3 scripts/test_claudecode.py`
- `python3 scripts/test_hermes_install.py` (outside sandbox; local HTTP server required)
- `python3 scripts/test_hermes_examples.py`
- `bash scripts/test_paths.sh`
- `bash scripts/test_roster.sh`
- `bash scripts/test_roster_agree.sh`
- `bash scripts/test_version.sh`
- `bash scripts/test_preflight.sh`
- `bash scripts/test_install.sh` (outside sandbox; systemd user session required)
- `scripts/codex_hook.py --install`
- `timeout 60 codex exec -s read-only --ephemeral -C /home/julianflores/.codex/workspace/paynani 'Reply exactly: hook-start-ok'`

The Codex smoke start printed `hook: SessionStart` / `hook: SessionStart Completed` and did not print `clamping SessionEnd hook timeout`.

Closes #58.
