### PR TITLE
session_watch.sh: el aviso de lock ocupado va a stdout

### DIFF
--- a/harness/session_start.py
+++ b/harness/session_start.py
@@ -509,13 +509,15 @@ def main():
             "ARM THE MAIL WATCH NOW, before doing anything else, with a persistent "
             "Monitor running exactly:\n\n"
             f"    bash {SESSION_WATCH} {STATE_DIR} {spool_through}\n\n"
-            "Each stdout line is one new mail notification. The byte offset is not "
-            "optional and must not be rounded: this hook has replayed the spool "
-            "through exactly that byte, so starting anywhere else either repeats "
-            "messages or steps over ones nobody has seen. Arming is also what "
-            "acknowledges the replay above — if you skip it, the next session "
-            "shows these same messages again, and no new mail reaches you for the "
-            "rest of this one."
+            "Each stdout line is one new mail notification, except a line saying "
+            "the watch could not be armed because another session already holds "
+            "it — that one is not mail. The byte offset is not optional and must "
+            "not be rounded: this hook has replayed the spool through exactly "
+            "that byte, so starting anywhere else either repeats messages or "
+            "steps over ones nobody has seen. Arming is also what acknowledges "
+            "the replay above — if you skip it, the next session shows these "
+            "same messages again, and no new mail reaches you for the rest of "
+            "this one."
         )
     elif runtime == "codex":
         if spool_lines:

--- a/harness/session_watch.sh
+++ b/harness/session_watch.sh
@@ -31,7 +31,12 @@ mkdir -p "$STATE_DIR"
 # accuracy of both.
 exec 9>"$LOCK"
 if ! flock -n 9; then
-	echo "[watch] another session is already watching this spool; not arming a second." >&2
+	# stdout, not stderr (#62). From Claude Code's side, stderr on this command
+	# goes to a file nothing reads; the session sees "Monitor ended without
+	# producing output (exit 0)", which is indistinguishable from a quiet
+	# mailbox. A stdout line is a notification and actually reaches the session
+	# that just found out it is not armed.
+	echo "[watch] another session is already watching this spool; not arming a second."
 	exit 0
 fi
 

--- a/scripts/test_claudecode.py
+++ b/scripts/test_claudecode.py
@@ -352,7 +352,11 @@ class Watcher(unittest.TestCase):
         second = sp.run(["bash", str(self.WATCH), str(self.state), "0"],
                         capture_output=True, text=True, timeout=10)
         self.assertEqual(second.returncode, 0)
-        self.assertIn("already watching", second.stderr)
+        # stdout, not stderr (#62): a Monitor only turns stdout into a
+        # notification, so the second session must see this line to know it
+        # is not armed rather than mistaking silence for a quiet mailbox.
+        self.assertIn("already watching", second.stdout)
+        self.assertEqual(second.stderr, "")
 
     def test_arming_records_the_offset_it_was_given(self):
         """Arming is the acknowledgement; it must land before any mail does."""


### PR DESCRIPTION
## Qué arregla

Issue #62, **pieza 1** (obligatoria): al chocar con el `flock`, la línea
salía por stderr con `exit 0`. Desde Claude Code, stderr de un Monitor va a
un archivo que nadie abre; la sesión ve `Monitor ended without producing
output (exit 0)`, indistinguible de un buzón tranquilo. Cree que armó el
watch y no lo armó.

## Cómo

Un cambio de una línea: la línea del choque de lock ahora sale por stdout.
El código de salida se deja igual, tal como pide el issue.

## Pruebas

Actualicé `test_a_second_watcher_refuses_rather_than_racing` en
`scripts/test_claudecode.py` para leer `stdout` en vez de `stderr` (y
confirmar que `stderr` queda vacío) — el test antes afirmaba exactamente el
comportamiento roto.

`scripts/test_all.sh` en verde (17 passed, 0 failed).

## Pieza 2, deliberadamente fuera de este PR

El issue también pide verificar que el tenedor del lock siga vivo (no solo
`kill -0`, también estado `T`) y tomar el relevo si no. Empecé a
implementarlo y encontré un problema de fondo antes de escribir el PR:

`tail -F ... | while read ...; done` son dos procesos hijos que heredan el
fd 9 (el del `flock`) porque `exec 9>"$LOCK"` ocurre antes del pipeline y
bash no cierra descriptores heredados por defecto. El `flock` está atado a
esa *open file description*, compartida por herencia — no solo al PID
principal. Mientras esos hijos sigan vivos, matar solo el PID registrado
(el del proceso principal) no libera el lock: quedan huérfanos, re-parentados
a init, sin nadie que los mate, y el "relevo" nunca ocurre.

La forma correcta de matarlos a los tres exige señalizar el *grupo de
procesos*, no un PID suelto — y no puedo confirmar desde aquí si
`session_watch.sh`, cuando lo arranca Monitor, corre en su propio grupo de
procesos o comparte el de otra cosa. Si comparte grupo con un proceso que
no debería tocar, `kill -TERM -$pgid` manda la señal más lejos de lo
pensado. Dado ese riesgo y que el propio issue autoriza mandar la pieza 1
sola, la dejo fuera y lo explico en un comentario en el issue para que se
decida el diseño con más cuidado del que le puedo dar en un parche rápido.

No cierra #62 — la pieza 1 va aquí, la pieza 2 queda abierta en el issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyHkR7fUKZw9cbAt2sMTA7