### PR TITLE
Add HTML alternative support to send.sh

### DIFF
--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Send via Himalaya, but only to allowlisted recipients.
 #
-#   send.sh [--check] [--cc <address>] [--attach <path>]... <to> <subject> <body-file>
+#   send.sh [--check] [--cc <address>] [--html <path>] [--attach <path>]... <to> <subject> <body-file>
 #
 # Anything not in roster.md exits 2 and sends nothing. That is the point: this
 # agent reads mail all day and acts on the part of it that comes from the roster,
@@ -9,11 +9,15 @@
 # --cc is held to the same rule -- it is a second address this agent writes to,
 # not a lesser one, so it is checked against the roster exactly like <to>.
 #
-# --attach may be repeated; the files ride in the order given. With none, the
-# message is byte-for-byte what it was before attachments existed: a single-part
-# text/plain. With one or more it becomes multipart/mixed, and the body is the
-# first part rather than the whole message. A field report that could only be
-# pasted into the body is what asked for this (#38).
+# --html adds a text/html alternative to the required plain-text body. With no
+# attachments the message becomes multipart/alternative; with attachments the
+# outer message is multipart/mixed and its first part is that alternative pair.
+#
+# --attach may be repeated; the files ride in the order given. With none and no
+# --html, the message is byte-for-byte what it was before attachments existed: a
+# single-part text/plain. With one or more it becomes multipart/mixed, and the
+# body is the first part rather than the whole message. A field report that could
+# only be pasted into the body is what asked for this (#38).
 #
 # --check prints the message it would send and sends nothing. Use it to prove
 # this script can find its credentials, which the roster tests cannot: the roster
@@ -48,6 +52,7 @@ ACCOUNT="paynani"
 
 check_only=""
 cc=""
+htmlfile=""
 attachments=()
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -57,6 +62,10 @@ while [ $# -gt 0 ]; do
             ;;
         --cc)
             cc=${2:?--cc requires an address}
+            shift 2
+            ;;
+        --html)
+            htmlfile=${2:?--html requires a path}
             shift 2
             ;;
         --attach)
@@ -69,11 +78,16 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-to=${1:?usage: send.sh [--check] [--cc <address>] [--attach <path>]... <to> <subject> <body-file>}
+to=${1:?usage: send.sh [--check] [--cc <address>] [--html <path>] [--attach <path>]... <to> <subject> <body-file>}
 subject=${2:?missing subject}
 bodyfile=${3:?missing body file}
 
 [ -f "$bodyfile" ] || { echo "no such body file: $bodyfile" >&2; exit 1; }
+if [ -n "$htmlfile" ] && { [ ! -f "$htmlfile" ] || [ ! -r "$htmlfile" ]; }; then
+    echo "REFUSED: cannot read html body $htmlfile" >&2
+    echo "Nothing was sent. Check the path, or drop the --html." >&2
+    exit 2
+fi
 
 # Attachments are checked before anything is built, so a bad path costs nothing
 # and half a message is never sent. Exit 2 is the same code the roster refusal
@@ -229,7 +243,7 @@ msgid="<$(date -u +%Y%m%d%H%M%S).$$.${RANDOM}@${from_addr##*@}>"
 
 # --- Attachments -------------------------------------------------------------
 #
-# Only computed when there is something to attach, so the no-attachment path
+# Only computed when there is something to separate, so the plain-text-only path
 # stays exactly the message this script sent before: same headers, same order,
 # single part. A separator that could appear in the content would truncate the
 # message at that line, so it carries 128 bits of randomness and a prefix no
@@ -237,6 +251,10 @@ msgid="<$(date -u +%Y%m%d%H%M%S).$$.${RANDOM}@${from_addr##*@}>"
 boundary=""
 if [ ${#attachments[@]} -gt 0 ]; then
     boundary="=_paynani_$(openssl rand -hex 16)"
+fi
+alternative_boundary=""
+if [ -n "$htmlfile" ]; then
+    alternative_boundary="=_paynani_alt_$(openssl rand -hex 16)"
 fi
 
 # A filename is a header parameter, and the quoting rules that protect the From
@@ -312,6 +330,37 @@ attachment_part() {
     printf '\n'
 }
 
+plain_body_part() {
+    printf 'Content-Type: text/plain; charset=UTF-8\n'
+    printf 'Content-Transfer-Encoding: 8bit\n'
+    printf '\n'
+    cat "$bodyfile"
+    # A body file that does not end in a newline would otherwise put the next
+    # separator on the same line as its last word, and a separator that is not
+    # alone on its line is not a separator.
+    printf '\n'
+}
+
+html_body_part() {
+    printf 'Content-Type: text/html; charset=UTF-8\n'
+    printf 'Content-Transfer-Encoding: quoted-printable\n'
+    printf '\n'
+    python3 -c 'import quopri, sys; quopri.encode(sys.stdin.buffer, sys.stdout.buffer, quotetabs=True)' < "$htmlfile"
+    printf '\n'
+}
+
+alternative_body_part() {
+    if [ -n "$boundary" ]; then
+        printf 'Content-Type: multipart/alternative; boundary="%s"\n' "$alternative_boundary"
+        printf '\n'
+    fi
+    printf -- '--%s\n' "$alternative_boundary"
+    plain_body_part
+    printf -- '--%s\n' "$alternative_boundary"
+    html_body_part
+    printf -- '--%s--\n' "$alternative_boundary"
+}
+
 build_message() {
     printf 'Date: %s\n' "$date_hdr"
     printf 'Message-ID: %s\n' "$msgid"
@@ -322,6 +371,8 @@ build_message() {
     # where they describe the body rather than the whole message.
     if [ -n "$boundary" ]; then
         printf 'Content-Type: multipart/mixed; boundary="%s"\n' "$boundary"
+    elif [ -n "$htmlfile" ]; then
+        printf 'Content-Type: multipart/alternative; boundary="%s"\n' "$alternative_boundary"
     else
         printf 'Content-Type: text/plain; charset=UTF-8\n'
         printf 'Content-Transfer-Encoding: 8bit\n'
@@ -347,19 +398,20 @@ build_message() {
     fi
     printf 'Subject: %s\n' "$(encode_header "$subject")"
     printf '\n'
-    if [ -z "$boundary" ]; then
+    if [ -z "$boundary" ] && [ -z "$htmlfile" ]; then
         cat "$bodyfile"
         return
     fi
+    if [ -z "$boundary" ]; then
+        alternative_body_part
+        return
+    fi
     printf -- '--%s\n' "$boundary"
-    printf 'Content-Type: text/plain; charset=UTF-8\n'
-    printf 'Content-Transfer-Encoding: 8bit\n'
-    printf '\n'
-    cat "$bodyfile"
-    # A body file that does not end in a newline would otherwise put the closing
-    # separator on the same line as its last word, and a separator that is not
-    # alone on its line is not a separator.
-    printf '\n'
+    if [ -n "$htmlfile" ]; then
+        alternative_body_part
+    else
+        plain_body_part
+    fi
     for _paynani_file in ${attachments[@]+"${attachments[@]}"}; do
         attachment_part "$_paynani_file"
     done

--- a/scripts/test_roster.sh
+++ b/scripts/test_roster.sh
@@ -24,6 +24,10 @@ trap 'rm -rf "$tmp"' EXIT
 roster="$tmp/roster.md"
 body="$tmp/body.txt"
 echo "hi" >"$body"
+html="$tmp/body.html"
+printf '<!doctype html><html><body><p>hi</p></body></html>\n' >"$html"
+long_html="$tmp/long-body.html"
+python3 -c 'from pathlib import Path; Path(__import__("sys").argv[1]).write_text("<html><body><p style=\"" + "x" * 1200 + "\">hola</p></body></html>\n", encoding="utf-8")' "$long_html"
 
 > "$tmp/sent.eml"
 export CAPTURE="$tmp/sent.eml"
@@ -289,6 +293,70 @@ assert "the record names the cc"        'grep -q "cc=second_contact@example.org"
 assert "message-id stays last with a cc" \
     '[ "$(sed -n "s/.*message-id=//p" "$sent_log")" = "$(grep -m1 "^Message-ID: " "$CAPTURE" | sed "s/^Message-ID: //")" ]'
 
+# --- HTML alternatives ---------------------------------------------------------
+#
+# #64: substantive mail needs multipart/alternative, but send.sh is the roster
+# gate and the audit log. If HTML has to be sent outside this script, the safe
+# path and the required format become mutually exclusive.
+: >"$CAPTURE"
+send_ok --html "$html" "jjulianfe@gmail.com" "html body" "$body"
+assert "--html makes multipart/alternative" \
+    'grep -qE "^Content-Type: multipart/alternative; boundary=\"=_paynani_alt_[0-9a-f]{32}\"\$" "$CAPTURE"'
+assert "--html includes plain and html parts" \
+    'python3 -c "
+import email, email.policy, sys
+m = email.message_from_binary_file(open(sys.argv[1], \"rb\"), policy=email.policy.default)
+assert m.get_content_type() == \"multipart/alternative\", m.get_content_type()
+parts = m.get_payload()
+assert [p.get_content_type() for p in parts] == [\"text/plain\", \"text/html\"]
+assert parts[0].get_content() == \"hi\n\"
+assert parts[1].get_content() == \"<!doctype html><html><body><p>hi</p></body></html>\n\"
+" "$CAPTURE"'
+assert "--html uses quoted-printable" \
+    'grep -qx "Content-Transfer-Encoding: quoted-printable" "$CAPTURE"'
+
+: >"$CAPTURE"
+send_ok --html "$long_html" "jjulianfe@gmail.com" "long html body" "$body"
+assert "--html keeps long lines inside SMTP limits" \
+    'python3 -c "
+import sys
+data = open(sys.argv[1], \"rb\").read().splitlines()
+too_long = [line for line in data if len(line) > 998]
+assert not too_long, max(map(len, too_long), default=0)
+" "$CAPTURE"'
+assert "--html long body round-trips" \
+    'python3 -c "
+import email, email.policy, pathlib, sys
+m = email.message_from_binary_file(open(sys.argv[1], \"rb\"), policy=email.policy.default)
+html = pathlib.Path(sys.argv[2]).read_text(encoding=\"utf-8\")
+part = [p for p in m.walk() if p.get_content_type() == \"text/html\"]
+assert len(part) == 1, part
+assert part[0].get_content() == html
+" "$CAPTURE" "$long_html"'
+
+: >"$CAPTURE"
+checked_html="$tmp/checked-html.eml"
+"$SEND" --check --html "$html" "jjulianfe@gmail.com" "html check" "$body" >"$checked_html" 2>/dev/null
+assert "--check prints the HTML MIME" \
+    'grep -qE "^Content-Type: multipart/alternative; boundary=\"=_paynani_alt_[0-9a-f]{32}\"\$" "$checked_html" && grep -qx "Content-Type: text/html; charset=UTF-8" "$checked_html"'
+assert "--check with --html sends nothing" '[ ! -s "$CAPTURE" ]'
+
+: >"$CAPTURE"
+"$SEND" --html "$html" "jjulianfe@gmail.com" "missing plain" >/dev/null 2>&1 && hrc=0 || hrc=$?
+assert "--html still requires a plain body" '[ "${hrc:-0}" -ne 0 ] && [ ! -s "$CAPTURE" ]'
+
+: >"$CAPTURE"
+"$SEND" --html "$tmp/no-such.html" "jjulianfe@gmail.com" "missing html" "$body" >/dev/null 2>&1 && mhrc=0 || mhrc=$?
+assert "a missing html body exits 2" '[ "${mhrc:-0}" -eq 2 ] && [ ! -s "$CAPTURE" ]'
+
+: >"$CAPTURE"
+"$SEND" --html "$html" "stranger@example.com" "bad html recipient" "$body" >/dev/null 2>&1 && bhrc=0 || bhrc=$?
+assert "--html keeps the roster gate" '[ "${bhrc:-0}" -eq 2 ] && [ ! -s "$CAPTURE" ]'
+
+rm -rf "$sent_state"
+PAYNANI_STATE="$sent_state" send_ok --html "$html" "jjulianfe@gmail.com" "html logged" "$body"
+assert "--html sends are recorded" 'grep -q "to=jjulianfe@gmail.com" "$sent_log" && grep -q "subject=html logged" "$sent_log"'
+
 # --- Attachments ---------------------------------------------------------------
 #
 # #38: send.sh built a single-part text/plain and nothing else, so a field report
@@ -316,6 +384,24 @@ assert "the attachment is base64"          'grep -qx "Content-Transfer-Encoding:
 assert "the attachment is named"           'grep -qx "Content-Disposition: attachment; filename=\"datos.csv\"" "$CAPTURE"'
 assert "the type is named"                 'grep -qx "Content-Type: text/csv" "$CAPTURE"'
 assert "the closing separator is present"  'grep -qE "^--=_paynani_[0-9a-f]{32}--\$" "$CAPTURE"'
+
+: >"$CAPTURE"
+send_ok --html "$html" --attach "$attach_dir/datos.csv" "jjulianfe@gmail.com" "html con adjunto" "$body"
+assert "--html with --attach keeps multipart/mixed outside" \
+    'grep -qE "^Content-Type: multipart/mixed; boundary=\"=_paynani_[0-9a-f]{32}\"\$" "$CAPTURE"'
+assert "--html with --attach nests alternative first" \
+    'python3 -c "
+import email, email.policy, sys
+m = email.message_from_binary_file(open(sys.argv[1], \"rb\"), policy=email.policy.default)
+assert m.get_content_type() == \"multipart/mixed\", m.get_content_type()
+top = m.get_payload()
+assert top[0].get_content_type() == \"multipart/alternative\", top[0].get_content_type()
+assert [p.get_content_type() for p in top[0].get_payload()] == [\"text/plain\", \"text/html\"]
+attachments = [p for p in m.walk() if p.get_content_disposition() == \"attachment\"]
+assert len(attachments) == 1, attachments
+assert attachments[0].get_filename() == \"datos.csv\"
+assert attachments[0].get_payload(decode=True) == b\"col1,col2\n1,2\n\"
+" "$CAPTURE"'
 
 # The bytes have to come back out. Everything above could pass on a message whose
 # attachment decoded to something else, or to nothing.


### PR DESCRIPTION
@metisclaudetob this implements #64.

## Summary

- adds `scripts/send.sh --html <html-file> <to> <subject> <plain-file>`
- keeps the no-`--html` path unchanged: single `text/plain`, or `multipart/mixed` when attachments are present
- emits `multipart/alternative` for plain + HTML mail without attachments
- emits `multipart/mixed` with a first nested `multipart/alternative` part when attachments are present
- validates the HTML file before sending, keeps roster checks and `--cc` checks in the same path, and preserves `state/sent.log` recording

## Verification

- `bash scripts/test_roster.sh`
- `scripts/test_all.sh`

`scripts/test_all.sh` passed with `17 passed, 0 failed`.

Closes #64.
