### PR TITLE
Degrada sin timeout(1) en vez de fallar siempre en macOS

### DIFF
--- a/scripts/test_version.sh
+++ b/scripts/test_version.sh
@@ -194,6 +194,49 @@ printf '%s 1.9.0\n' "$(date +%s)" >"$state/version.check"
 run 1.10.0 --line
 assert "a legacy two-field cache is refreshed" 'grep -q "paynani 1.10.0 (latest)" <<<"$out"'
 
+# ---- a host without timeout(1) (#68) --------------------------------------
+#
+# `timeout` is GNU coreutils and macOS does not ship it. Wrapping the remote
+# call in a command that is not there made latest_version() fail on every macOS
+# install, permanently -- and "could not find out" reads like a passing network
+# glitch, so nobody investigates. Found by Ximena on the first macOS install,
+# after three of my four predictions about that host turned out to be wrong.
+#
+# Simulated with a PATH that has everything except timeout and gtimeout: a
+# symlink farm, because a trimmed literal PATH loses tools the script needs for
+# unrelated reasons and would pass for the wrong reason.
+notimeout="$tmp/notimeout-bin"
+mkdir -p "$notimeout"
+_old_ifs=$IFS; IFS=:
+for _d in $PATH; do
+    [ -d "$_d" ] || continue
+    for _f in "$_d"/*; do
+        [ -x "$_f" ] || continue
+        _b=${_f##*/}
+        case "$_b" in timeout|gtimeout) continue ;; esac
+        [ -e "$notimeout/$_b" ] || ln -s "$_f" "$notimeout/$_b" 2>/dev/null
+    done
+done
+IFS=$_old_ifs
+
+if PATH="$notimeout" command -v timeout >/dev/null 2>&1; then
+    # The farm did not actually hide it, so anything below would pass for the
+    # wrong reason. Say so instead of reporting a green that means nothing.
+    assert "the no-timeout farm really hides timeout" 'false'
+else
+    fresh
+    printf '%s\n' "1.10.0" >"$clone/VERSION"
+    out=$(PATH="$notimeout" "$clone/scripts/version.sh" 2>&1); rc=$?
+    assert "the report resolves latest without timeout" '[ "$rc" -eq 0 ]'
+    assert "without timeout it does not give up"  '! grep -q "could not find out" <<<"$out"'
+    assert "without timeout it names the tag"     'grep -q "latest:    1.10.0" <<<"$out"'
+
+    fresh
+    out=$(PATH="$notimeout" "$clone/scripts/version.sh" --line 2>&1); rc=$?
+    assert "--line resolves latest without timeout" '[ "$rc" -eq 0 ]'
+    assert "--line without timeout says latest"     'grep -q "paynani 1.10.0 (latest)" <<<"$out"'
+fi
+
 fresh; run 1.0.0 --line
 assert "--line behind exits 2"           '[ "$rc" -eq 2 ]'
 assert "--line behind says OUT OF DATE"  'grep -q "OUT OF DATE" <<<"$out"'

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -43,7 +43,26 @@ latest_version() {
     # that has gone private asks for a username on a terminal nobody is watching
     # and blocks until something kills it.
     local out
-    out=$(GIT_TERMINAL_PROMPT=0 timeout "$REMOTE_TIMEOUT" \
+    # `timeout` is GNU coreutils and macOS does not ship it. Wrapping the remote
+    # call in a command that is not there made every macOS install fail this
+    # check permanently and silently -- `could not find out` reads like a passing
+    # network glitch, so nobody investigates, and the version check is dead for
+    # the life of the host (#68, found by Ximena on the first macOS install).
+    #
+    # Homebrew's coreutils installs the GNU tools under a g prefix, so gtimeout
+    # is the same program when it exists.
+    #
+    # Degrading without the ceiling is the right trade, and the comment above
+    # says why: GIT_TERMINAL_PROMPT=0 is the protection that matters, and it
+    # survives here. A check that works without an upper bound beats one that
+    # always fails.
+    local -a limit=()
+    if command -v timeout >/dev/null 2>&1; then
+        limit=(timeout "$REMOTE_TIMEOUT")
+    elif command -v gtimeout >/dev/null 2>&1; then
+        limit=(gtimeout "$REMOTE_TIMEOUT")
+    fi
+    out=$(GIT_TERMINAL_PROMPT=0 ${limit[@]+"${limit[@]}"} \
               git -C "$REPO" ls-remote --tags --refs origin 'v*' 2>/dev/null) || return 1
     printf '%s\n' "$out" \
         | sed -n 's#.*refs/tags/v##p' \


### PR DESCRIPTION
Cierra el #68, encontrado por @ximenasalazartob en la primera instalacion de paynani sobre macOS.

**Va apilado sobre el #78** (base `invalida-el-cache-de-version`), no sobre `main`, porque los dos tocan `scripts/version.sh`. Fusionar el #78 primero.

## El problema

`timeout` es de GNU coreutils y **macOS no lo trae**. `latest_version()` envolvia la consulta al remoto en ese comando, asi que en su host:

```text
$ command -v timeout || echo AUSENTE
AUSENTE

$ scripts/version.sh; echo exit=$?
installed: 0.3.0
latest:    could not find out
exit=1
```

Y el remoto contestaba perfectamente cuando se le preguntaba sin el envoltorio.

**Lo peor no es el fallo, es su forma.** `could not find out` se lee como un problema de red pasajero. Nadie investiga un fallo intermitente, asi que la comprobacion de version queda muerta durante toda la vida del host — y se cruza con el #61: donde `latest` nunca se resuelve, el reporte de version pierde su unica defensa contra quedarse en una release vieja.

## El arreglo

`timeout` si existe, `gtimeout` si esta el coreutils de Homebrew, y si no hay ninguno, consultar **sin cota superior**.

Es el arreglo que el issue propone, y el propio comentario de la funcion ya decia por que es aceptable:

> `GIT_TERMINAL_PROMPT=0` matters more than the timeout: without it, a remote that has gone private asks for a username on a terminal nobody is watching and blocks until something kills it.

Esa proteccion sobrevive. Se pierde el techo de tiempo; se gana una comprobacion que funciona. Una consulta sin cota es mejor que uno que siempre falla.

## Verificado antes y despues, mismo PATH sin `timeout`

```text
ANTES (main)          DESPUES (esta rama)
installed: 0.3.0      installed: 0.3.0
latest: could not     latest:    0.3.0
        find out
exit=1                Up to date.
```

## La prueba

Simula el host con una **granja de symlinks** que replica el `PATH` real menos `timeout` y `gtimeout`.

Empece con un `PATH` recortado a mano y **pasaba por el motivo equivocado**: perdia `dirname`, el script moria antes de llegar a la parte que se estaba probando, y el resultado se veia igual. Por eso la prueba **primero verifica que la granja de verdad esconde `timeout`** y falla ruidosamente si no lo hace. Una prueba que puede pasar sin ejercitar su rama no es una prueba.

```
scripts/test_version.sh  ->  51 passed, 0 failed
scripts/test_all.sh      ->  17 passed, 0 failed
```

## Lo que este PR NO puede cerrar por si mismo

**El primer criterio de cierre dice que `version.sh` resuelve `latest` en un host sin `timeout`.** Aqui esta simulado, y la simulacion es fiel — pero es una simulacion, en Linux.

Lo que no puedo hacer desde este host es correrlo en macOS de verdad. **@ximenasalazartob tiene el unico Mac del equipo**, y la verificacion real le toca a ella. Le mando las instrucciones por correo.

Hasta que llegue esa confirmacion, este PR se puede fusionar pero **el issue no lo cierro**: seria registrar una simulacion como si fuera la verificacion que el criterio pide.
