### PR TITLE
Arregla tres defectos de la apertura del README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Mensajero élite: Los paynani eran los corredores y mensajeros oficiales del Imp
 
 **Español (MX)** · [English (US)](i18n/README.en-US.md) · [Español (ES)](i18n/README.es-ES.md) · [Français (FR)](i18n/README.fr-FR.md) · [Português (BR)](i18n/README.pt-BR.md)
 
-> Los paynani eran los corredores y mensajeros oficiales del Imperio Azteca.
-
-Paynani le permite a su agente de IA leer automáticamente su correo electrónico
+Paynani le permite a tu agente de IA leer automáticamente tu correo electrónico
 unos segundos después de que llega, procesar los mensajes recibidos y atender las
 instrucciones del correo tal como lo haría un colaborador humano.
 
@@ -22,8 +20,7 @@ Paynani fue construido sobre
 [Himalaya](https://github.com/pimalaya/himalaya) y funciona con una cuenta
 IMAP/SMTP común y corriente.
 
-**¡Usarlo es totalmente gratis!** 
-No necesitas contratar ningún servicio
+**¡Usarlo es totalmente gratis!** No necesitas contratar ningún servicio
 adicional para darle a tu agente una dirección de correo electrónico que pueda
 usar automáticamente.
 


### PR DESCRIPTION
Seguimiento del #81. Los tres defectos que levante en su revision y que entraron a `main` al fusionarse.

**Solo los tres.** Nada de estilo ni de contenido: @julianflores dijo que vienen mas cambios al README y no quiero estorbarlos.

## 1. La misma frase, dos veces

```
linea  8:  Mensajero elite: Los paynani eran los corredores y mensajeros...
linea 12:  > Los paynani eran los corredores y mensajeros oficiales...
```

Quito la cita y conservo la linea original, que ademas trae el **"Mensajero elite:"** que la cita perdia.

**Si prefieres la forma de epigrafe**, el cambio es exactamente al reves y es de una linea — dilo y lo invierto. Elegi conservar la que tenia mas informacion, no la que llego primero.

## 2. Registro mezclado

| | |
|---|---|
| *"Paynani le permite a **su** agente de IA leer automaticamente **su** correo"* | usted |
| *"**No necesitas** contratar... para darle a **tu** agente"* | tu |

En el mismo bloque, con cuatro parrafos de diferencia. Queda todo en **tu**, que es el registro del resto de la documentacion — incluido el encabezado que ya decia *"Como configurarlo en tu agente"* unas lineas mas abajo.

## 3. Un espacio donde hacian falta dos

`**¡Usarlo es totalmente gratis!**` terminaba en **un** espacio. Markdown pide dos para un salto de linea, asi que con uno las dos lineas se renderizaban como un parrafo corrido igual — el salto que se buscaba no existia. Queda como un solo parrafo, explicito, y sin espacio al final.

Comprobado que no queda ningun espacio al final de linea en el archivo.

## Lo que NO toco

Las cuatro traducciones. El selector de idioma promete el mismo documento en cinco idiomas y hoy solo cambio el espanol, pero @julianflores decidio actualizarlas todas juntas cuando terminen los cambios pendientes. Queda anotado para que no se pierda.

## Pruebas

```
scripts/test_all.sh   ->  17 passed, 0 failed
scripts/test_docs.py  ->  23 passed, 0 failed
```