### PR TITLE
Corrige el posesivo de la apertura: el agente lee su correo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Mensajero élite: Los paynani eran los corredores y mensajeros oficiales del Imp
 
 **Español (MX)** · [English (US)](i18n/README.en-US.md) · [Español (ES)](i18n/README.es-ES.md) · [Français (FR)](i18n/README.fr-FR.md) · [Português (BR)](i18n/README.pt-BR.md)
 
-Paynani le permite a tu agente de IA leer automáticamente tu correo electrónico
+Paynani le permite a tu agente de IA leer automáticamente su correo electrónico
 unos segundos después de que llega, procesar los mensajes recibidos y atender las
 instrucciones del correo tal como lo haría un colaborador humano.
 


### PR DESCRIPTION
La primera frase del README decía que paynani le permite a tu agente de IA leer
automáticamente **tu** correo electrónico. Debe decir **su** correo: el agente
tiene su propia cuenta y paynani lee esa, no el buzón de la persona.

El párrafo de más abajo ya lo planteaba así — *"darle a tu agente una dirección
de correo electrónico que pueda usar automáticamente"* — así que la apertura se
contradecía con el resto del documento.

Un solo cambio, en `README.md:12`:

```diff
-Paynani le permite a tu agente de IA leer automáticamente tu correo electrónico
+Paynani le permite a tu agente de IA leer automáticamente su correo electrónico
```

Las traducciones de `i18n/` no necesitan este cambio: su apertura es el texto
anterior, más corto, y no contiene esta frase.