### PR TITLE
Pone las cuatro traducciones al día con la apertura en español

### DIFF
--- a/i18n/README.en-US.md
+++ b/i18n/README.en-US.md
@@ -9,13 +9,25 @@ Elite messenger: the paynani were the official runners and messengers of the Azt
 
 [Español (MX)](../README.md) · **English (US)** · [Español (ES)](README.es-ES.md) · [Français (FR)](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)
 
-Push-style email for an AI agent. It finds out about new mail within about a
-second, without polling, and can read and send under a recipient allowlist.
+Paynani lets your AI agent automatically read its own email a few seconds after
+it arrives, process the messages it receives, and act on their instructions just
+as a human colleague would.
 
-Built around [Himalaya](https://github.com/pimalaya/himalaya) for a plain
-IMAP/SMTP account, running on Ubuntu 24.04 under the OpenClaw, Hermes Agent,
-Claude Code or OpenAI Codex harness. OpenClaw and Codex on macOS are supported
-through per-user launchd LaunchAgents.
+Every incoming email is read, but instructions are only followed when they come
+from a list of authorized contacts.
+
+Paynani is built on [Himalaya](https://github.com/pimalaya/himalaya) and works
+with an ordinary IMAP/SMTP account.
+
+**It is completely free to use!** You don't need to pay for any extra service to
+give your agent an email address it can use on its own.
+
+It is currently used by AI agents such as OpenClaw, Hermes Agent, Claude Code and
+OpenAI Codex.
+
+Developed and tested on Linux (Ubuntu 24.04) and macOS (26.4.1).
+
+Made with love by humans and AI agents, from Mexico to the world.
 
 ---
 

--- a/i18n/README.es-ES.md
+++ b/i18n/README.es-ES.md
@@ -9,13 +9,26 @@ Mensajero de élite: los paynani eran los corredores y mensajeros oficiales del 
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · **Español (ES)** · [Français (FR)](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)
 
-Correo electrónico por notificación inmediata para un agente de IA. Se entera de
-que ha llegado correo en un segundo aproximadamente, sin sondear el buzón, y puede
-leer y enviar dentro de una lista de destinatarios autorizados.
+Paynani permite que tu agente de IA lea automáticamente su propio correo
+electrónico unos segundos después de que llega, procese los mensajes recibidos y
+atienda las instrucciones del correo igual que lo haría un compañero humano.
 
-Construido sobre [Himalaya](https://github.com/pimalaya/himalaya) para una cuenta
-IMAP/SMTP corriente, en Ubuntu 24.04 bajo el entorno OpenClaw, Hermes Agent o
-Claude Code u OpenAI Codex.
+Se leen todos los correos que llegan, pero solo se siguen las instrucciones de
+los que vienen de una lista de contactos autorizados.
+
+Paynani está construido sobre [Himalaya](https://github.com/pimalaya/himalaya) y
+funciona con una cuenta IMAP/SMTP corriente.
+
+**¡Usarlo es totalmente gratis!** No necesitas contratar ningún servicio
+adicional para darle a tu agente una dirección de correo electrónico que pueda
+usar por su cuenta.
+
+Actualmente lo usan agentes de IA como OpenClaw, Hermes Agent, Claude Code y
+OpenAI Codex.
+
+Desarrollado y probado en Linux (Ubuntu 24.04) y macOS (26.4.1).
+
+Hecho con cariño por humanos y agentes de IA, desde México para el mundo.
 
 ---
 

--- a/i18n/README.fr-FR.md
+++ b/i18n/README.fr-FR.md
@@ -9,13 +9,26 @@ Messager d'élite : les paynani étaient les coureurs et messagers officiels de 
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · [Español (ES)](README.es-ES.md) · **Français (FR)** · [Português (BR)](README.pt-BR.md)
 
-Notification immédiate des courriels pour un agent IA. Il apprend l'arrivée d'un
-message en une seconde environ, sans interroger la boîte en boucle, et peut lire
-et envoyer dans les limites d'une liste de destinataires autorisés.
+Paynani permet à votre agent IA de lire automatiquement sa propre messagerie
+quelques secondes après l'arrivée d'un message, de traiter les courriels reçus et
+d'exécuter leurs instructions comme le ferait un collègue humain.
 
-Construit autour de [Himalaya](https://github.com/pimalaya/himalaya) pour un
-compte IMAP/SMTP ordinaire, sous Ubuntu 24.04 avec l'environnement OpenClaw,
-Hermes Agent, Claude Code ou OpenAI Codex.
+Tous les courriels reçus sont lus, mais seules les instructions provenant d'une
+liste de contacts autorisés sont suivies.
+
+Paynani est construit sur [Himalaya](https://github.com/pimalaya/himalaya) et
+fonctionne avec un compte IMAP/SMTP ordinaire.
+
+**Son utilisation est entièrement gratuite !** Aucun service supplémentaire à
+souscrire pour donner à votre agent une adresse de courriel qu'il peut utiliser
+tout seul.
+
+Il est aujourd'hui utilisé par des agents IA comme OpenClaw, Hermes Agent, Claude
+Code et OpenAI Codex.
+
+Développé et testé sous Linux (Ubuntu 24.04) et macOS (26.4.1).
+
+Fait avec amour par des humains et des agents IA, du Mexique vers le monde.
 
 ---
 

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -9,13 +9,26 @@ Mensageiro de elite: os paynani eram os corredores e mensageiros oficiais do Imp
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · [Español (ES)](README.es-ES.md) · [Français (FR)](README.fr-FR.md) · **Português (BR)**
 
-E-mail com aviso imediato para um agente de IA. Ele fica sabendo que chegou
-mensagem em cerca de um segundo, sem ficar consultando a caixa, e consegue ler e
-enviar dentro de uma lista de destinatários autorizados.
+O paynani permite que seu agente de IA leia automaticamente o próprio e-mail
+poucos segundos depois que ele chega, processe as mensagens recebidas e atenda às
+instruções do e-mail como faria um colega humano.
 
-Construído sobre o [Himalaya](https://github.com/pimalaya/himalaya) para uma conta
-IMAP/SMTP comum, no Ubuntu 24.04 sob o ambiente OpenClaw, Hermes Agent ou Claude
-Code ou OpenAI Codex.
+Todos os e-mails recebidos são lidos, mas só se seguem as instruções dos que vêm
+de uma lista de contatos autorizados.
+
+O paynani foi construído sobre o [Himalaya](https://github.com/pimalaya/himalaya)
+e funciona com uma conta IMAP/SMTP comum.
+
+**Usar é totalmente gratuito!** Você não precisa contratar nenhum serviço
+adicional para dar ao seu agente um endereço de e-mail que ele possa usar
+sozinho.
+
+Atualmente é usado por agentes de IA como OpenClaw, Hermes Agent, Claude Code e
+OpenAI Codex.
+
+Desenvolvido e testado em Linux (Ubuntu 24.04) e macOS (26.4.1).
+
+Feito com amor por humanos e agentes de IA, do México para o mundo.
 
 ---
 


### PR DESCRIPTION
Las traducciones de `i18n/` se quedaron con la apertura anterior cuando se
reescribió la del README en español (#81, #84). No era una diferencia de matiz:
**describían otro producto.**

Lo que faltaba en las cuatro:

- que se leen **todos** los correos pero solo se obedecen los de la lista de
  contactos autorizados;
- que **usarlo es gratis** y no hace falta contratar nada;
- que está **probado en macOS (26.4.1)**, no solo en Ubuntu;
- la línea de cierre, "desde México para el mundo".

Y en `en-US` sobraba algo: seguía describiendo los LaunchAgents de `launchd`,
un detalle que la apertura en español ya no lleva.

## El posesivo, en los cuatro idiomas

Estas traducciones incorporan el cambio que se acaba de fusionar en #85 — el
agente lee **su** correo, no el tuyo. En cada idioma queda explícito, porque un
posesivo ambiguo es justo lo que causó el defecto en español:

| | |
|---|---|
| `en-US` | its **own** email |
| `es-ES` | su **propio** correo electrónico |
| `fr-FR` | sa **propre** messagerie |
| `pt-BR` | o **próprio** e-mail |

## Alcance

Solo cambia el bloque entre la línea de selección de idioma y el primer `---`.
Los encabezados, los pasos, las rutas y los enlaces relativos de cada archivo
quedan intactos: el diff son 4 archivos, +75 −24.

`scripts/test_all.sh` da 17/17 en local.