### PR TITLE
Trata unidades unknown como no consultables

### DIFF
--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -579,13 +579,19 @@ def assess(facts):
     listener, queue, runtime, config = (facts["listener"], facts["queue"],
                                         facts["runtime"], facts["config"])
 
-    if listener["unit"] != "active":
+    if listener["unit"] == "unknown":
+        warnings.append("the listener unit cannot be queried on this host "
+                        "(no observable service manager); its state is unknown, not stopped")
+    elif listener["unit"] != "active":
         problems.append(f"the listener is {listener['unit']}: no new mail is being detected at all")
     if listener["last_uid"] is None:
         warnings.append("the listener has no recorded position yet, so it has not "
                         "completed a first pass over the mailbox")
 
-    if facts["dispatcher_unit"] != "active":
+    if facts["dispatcher_unit"] == "unknown":
+        warnings.append("the dispatcher unit cannot be queried on this host "
+                        "(no observable service manager); its state is unknown, not stopped")
+    elif facts["dispatcher_unit"] != "active":
         problems.append(f"the dispatcher is {facts['dispatcher_unit']}: mail is being "
                         "journalled but nothing is delivering it")
 

--- a/scripts/test_healthcheck.py
+++ b/scripts/test_healthcheck.py
@@ -193,9 +193,23 @@ code, text = f.exit_code()
 check("a dead listener is a failure, not a quiet mailbox", 1, code)
 check("and says no mail is being detected at all", True, "detected at all" in text)
 
+f = Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"})
+code, text = f.exit_code()
+check("an unqueryable listener is not treated as stopped", 0, code)
+check("and says the listener state is unknown, not stopped", True,
+      "the listener unit cannot be queried on this host (no observable service manager); "
+      "its state is unknown, not stopped" in text)
+
 f = Fixture(units={hc.LISTENER_UNIT: "active", hc.DISPATCH_UNIT: "failed"})
 code, _ = f.exit_code()
 check("a failed dispatcher is a failure", 1, code)
+
+f = Fixture(units={hc.LISTENER_UNIT: "active", hc.DISPATCH_UNIT: "unknown"})
+code, text = f.exit_code()
+check("an unqueryable dispatcher is not treated as stopped", 0, code)
+check("and says the dispatcher state is unknown, not stopped", True,
+      "the dispatcher unit cannot be queried on this host (no observable service manager); "
+      "its state is unknown, not stopped" in text)
 
 f = Fixture(reachable=False)
 code, text = f.exit_code()


### PR DESCRIPTION
## Resumen
- separa el estado `unknown` de listener y dispatcher de los estados detenidos
- mueve `unknown` a warnings con el texto pedido en #87
- conserva fallas para estados realmente distintos de `active`, como `inactive` y `failed`

## Pruebas
- `python3 scripts/test_healthcheck.py`
- `python3 scripts/healthcheck.py`

Closes #87