### PR TITLE
Agrega latido del listener al healthcheck

### DIFF
--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -185,7 +185,8 @@ def tail(path, lines=1):
 def listener_facts():
     out = {"unit": unit_state(LISTENER_UNIT), "mailbox": None,
            "last_uid": None, "uidvalidity": None, "heartbeat_at": None,
-           "heartbeat_age_seconds": None, "last_error": None}
+           "heartbeat_age_seconds": None, "last_error": None,
+           "last_error_age_seconds": None}
     try:
         state = json.loads(LISTENER_STATE.read_text())
         out["mailbox"] = state.get("mailbox")
@@ -199,6 +200,13 @@ def listener_facts():
         pass
     last = tail(IDLE_ERR)
     out["last_error"] = last[0] if last else None
+    try:
+        # Unlike queue and heartbeat ages, the useful fact here is the write
+        # time itself: a retrying listener keeps touching the diagnostic file
+        # even while it cannot complete an IDLE cycle.
+        out["last_error_age_seconds"] = max(0, int(time.time() - IDLE_ERR.stat().st_mtime))
+    except OSError:
+        pass
     return out
 
 
@@ -595,9 +603,15 @@ def assess(facts):
             warnings.append("the listener state has no heartbeat_at; this listener is from "
                             "a version that does not report heartbeat, so its liveness is unknown")
         elif heartbeat_age > STALE_LISTENER_HEARTBEAT:
-            problems.append(f"the listener last reported {heartbeat_age}s ago and its unit "
-                            "cannot be queried: it is probably dead, and this host has no "
-                            "supervisor to restart it")
+            error_age = listener.get("last_error_age_seconds")
+            if error_age is not None and error_age < STALE_LISTENER_HEARTBEAT:
+                problems.append(f"the listener last completed a cycle {heartbeat_age}s ago "
+                                "but is still logging retries: it is running and cannot "
+                                "reach the mail server, so restarting it will not help")
+            else:
+                problems.append(f"the listener last reported {heartbeat_age}s ago and its unit "
+                                "cannot be queried: it is probably dead, and this host has no "
+                                "supervisor to restart it")
         else:
             warnings.append("the listener unit cannot be queried on this host "
                             "(no observable service manager); its state is unknown, not stopped")

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -86,6 +86,11 @@ DISPATCH_LAUNCHD_LABEL = "com.paynani.dispatch"
 # nobody is draining is noticed within a working session.
 STALE_QUEUE = float(os.environ.get("HEALTH_STALE_QUEUE", 15 * 60))
 
+# A listener with no observable service manager needs its own pulse. This is
+# deliberately wider than the listener's five-minute IDLE refresh, so one slow
+# turn is not a fault but a dead process is still visible inside a session.
+STALE_LISTENER_HEARTBEAT = 15 * 60
+
 # How long roster mail may sit answered by nothing before that is worth saying
 # out loud. An agent reads the message, does what it asks and then replies, and
 # what it was asked to do can legitimately take a while, so this is deliberately
@@ -179,12 +184,17 @@ def tail(path, lines=1):
 
 def listener_facts():
     out = {"unit": unit_state(LISTENER_UNIT), "mailbox": None,
-           "last_uid": None, "uidvalidity": None, "last_error": None}
+           "last_uid": None, "uidvalidity": None, "heartbeat_at": None,
+           "heartbeat_age_seconds": None, "last_error": None}
     try:
         state = json.loads(LISTENER_STATE.read_text())
         out["mailbox"] = state.get("mailbox")
         out["last_uid"] = state.get("last_uid")
         out["uidvalidity"] = state.get("uidvalidity")
+        out["heartbeat_at"] = state.get("heartbeat_at")
+        heartbeat = _stamp_seconds(out["heartbeat_at"])
+        if heartbeat is not None:
+            out["heartbeat_age_seconds"] = max(0, int(time.time() - heartbeat))
     except (OSError, ValueError):
         pass
     last = tail(IDLE_ERR)
@@ -580,8 +590,17 @@ def assess(facts):
                                         facts["runtime"], facts["config"])
 
     if listener["unit"] == "unknown":
-        warnings.append("the listener unit cannot be queried on this host "
-                        "(no observable service manager); its state is unknown, not stopped")
+        heartbeat_age = listener.get("heartbeat_age_seconds")
+        if heartbeat_age is None:
+            warnings.append("the listener state has no heartbeat_at; this listener is from "
+                            "a version that does not report heartbeat, so its liveness is unknown")
+        elif heartbeat_age > STALE_LISTENER_HEARTBEAT:
+            problems.append(f"the listener last reported {heartbeat_age}s ago and its unit "
+                            "cannot be queried: it is probably dead, and this host has no "
+                            "supervisor to restart it")
+        else:
+            warnings.append("the listener unit cannot be queried on this host "
+                            "(no observable service manager); its state is unknown, not stopped")
     elif listener["unit"] != "active":
         problems.append(f"the listener is {listener['unit']}: no new mail is being detected at all")
     if listener["last_uid"] is None:

--- a/scripts/idle_listener.py
+++ b/scripts/idle_listener.py
@@ -365,8 +365,17 @@ def load_state(path):
         return {}
 
 
+def timestamp():
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
 def save_state(path, mailbox, validity, last_uid):
-    state = {"mailbox": mailbox, "uidvalidity": validity, "last_uid": last_uid}
+    state = {
+        "mailbox": mailbox,
+        "uidvalidity": validity,
+        "last_uid": last_uid,
+        "heartbeat_at": timestamp(),
+    }
     if str(path) == "none":
         return state
     try:
@@ -534,6 +543,7 @@ def run(env_path, mailbox, once, state_path, roster_path, journal_path):
 
             while not _stop:
                 idle(conn, IDLE_REFRESH)
+                state = save_state(state_path, mailbox, validity, last_uid)
                 # Check unconditionally, not only when IDLE reported a change:
                 # mail landing between DONE and the next IDLE produces no EXISTS we
                 # can see, and would sit unnoticed until the *next* message arrived.

--- a/scripts/test_healthcheck.py
+++ b/scripts/test_healthcheck.py
@@ -231,6 +231,12 @@ check("and says the listener cannot reach the mail server", True,
       and "but is still logging retries: it is running and cannot reach the mail server, "
       "so restarting it will not help" in text)
 
+f = Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"}).heartbeat(16 * 60)
+code, text = f.exit_code()
+check("a stale listener with no error log at all is still called probably dead", 1, code)
+check("and does not claim it is reaching the mail server", True,
+      "it is probably dead" in text and "still logging retries" not in text)
+
 f = (Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"})
      .heartbeat(16 * 60).listener_error(16 * 60))
 code, text = f.exit_code()

--- a/scripts/test_healthcheck.py
+++ b/scripts/test_healthcheck.py
@@ -62,8 +62,12 @@ class Fixture:
         hc.DELIVERY = self.dir / "delivery.json"
         hc.SENT_LOG = self.dir / "sent.log"
 
-        hc.LISTENER_STATE.write_text(json.dumps(
-            {"mailbox": "INBOX", "uidvalidity": "42", "last_uid": 117}))
+        hc.LISTENER_STATE.write_text(json.dumps({
+            "mailbox": "INBOX",
+            "uidvalidity": "42",
+            "last_uid": 117,
+            "heartbeat_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }))
 
         env = self.dir / "env"
         env.write_text("PAYNANI_EMAIL=agent@example.com\n"
@@ -148,6 +152,17 @@ class Fixture:
             hc.SENT_LOG.write_text("", encoding="utf-8")
         return self
 
+    def heartbeat(self, age_seconds=None):
+        state = json.loads(hc.LISTENER_STATE.read_text())
+        if age_seconds is None:
+            state.pop("heartbeat_at", None)
+        else:
+            stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ",
+                                  time.gmtime(time.time() - age_seconds))
+            state["heartbeat_at"] = stamp
+        hc.LISTENER_STATE.write_text(json.dumps(state))
+        return self
+
     def run(self):
         facts = {
             "listener": hc.listener_facts(),
@@ -199,6 +214,20 @@ check("an unqueryable listener is not treated as stopped", 0, code)
 check("and says the listener state is unknown, not stopped", True,
       "the listener unit cannot be queried on this host (no observable service manager); "
       "its state is unknown, not stopped" in text)
+
+f = Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"}).heartbeat(16 * 60)
+code, text = f.exit_code()
+check("an unqueryable listener with a stale heartbeat is a failure", 1, code)
+check("and says the listener is probably dead", True,
+      "the listener last reported" in text
+      and "its unit cannot be queried: it is probably dead, and this host has no "
+      "supervisor to restart it" in text)
+
+f = Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"}).heartbeat()
+code, text = f.exit_code()
+check("an old listener with no heartbeat is not called dead", 0, code)
+check("and says this version reports no heartbeat", True,
+      "this listener is from a version that does not report heartbeat" in text)
 
 f = Fixture(units={hc.LISTENER_UNIT: "active", hc.DISPATCH_UNIT: "failed"})
 code, _ = f.exit_code()

--- a/scripts/test_healthcheck.py
+++ b/scripts/test_healthcheck.py
@@ -163,6 +163,13 @@ class Fixture:
         hc.LISTENER_STATE.write_text(json.dumps(state))
         return self
 
+    def listener_error(self, age_seconds=0):
+        hc.IDLE_ERR.write_text("connection lost (TimeoutError); retrying in 300s\n",
+                               encoding="utf-8")
+        stamp = time.time() - age_seconds
+        os.utime(hc.IDLE_ERR, (stamp, stamp))
+        return self
+
     def run(self):
         facts = {
             "listener": hc.listener_facts(),
@@ -215,7 +222,17 @@ check("and says the listener state is unknown, not stopped", True,
       "the listener unit cannot be queried on this host (no observable service manager); "
       "its state is unknown, not stopped" in text)
 
-f = Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"}).heartbeat(16 * 60)
+f = (Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"})
+     .heartbeat(16 * 60).listener_error(60))
+code, text = f.exit_code()
+check("an unqueryable listener with stale heartbeat but fresh retries is a failure", 1, code)
+check("and says the listener cannot reach the mail server", True,
+      "the listener last completed a cycle" in text
+      and "but is still logging retries: it is running and cannot reach the mail server, "
+      "so restarting it will not help" in text)
+
+f = (Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"})
+     .heartbeat(16 * 60).listener_error(16 * 60))
 code, text = f.exit_code()
 check("an unqueryable listener with a stale heartbeat is a failure", 1, code)
 check("and says the listener is probably dead", True,

--- a/scripts/test_listener.py
+++ b/scripts/test_listener.py
@@ -14,7 +14,7 @@ import tempfile
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
-from idle_listener import KEEPALIVE_OPTIONS, describe, decode_hdr, keepalive
+from idle_listener import KEEPALIVE_OPTIONS, describe, decode_hdr, keepalive, save_state
 from roster import (notifier_headers, notifiers, roster_addresses,
                     roster_entries, sender_is_listed)
 
@@ -197,6 +197,13 @@ def main():
         check(encoded == "Prueba de correo — ñ, á, ¿qué tal?", f"decoded to {encoded!r}")
         check("\n" not in describe("a@b.c", encoded, "", trusted=True),
               "one message is always one line")
+
+        state = save_state(tmp / "idle.json", "INBOX", "42", 117)
+        check(state["mailbox"] == "INBOX" and state["uidvalidity"] == "42"
+              and state["last_uid"] == 117,
+              "listener state still records mailbox, uidvalidity and uid")
+        check("heartbeat_at" in state and state["heartbeat_at"].endswith("Z"),
+              "listener state records a UTC heartbeat")
 
     # --- keepalive, the thing that makes a dead connection announce itself ----
     #


### PR DESCRIPTION
## Resumen
- el listener escribe `heartbeat_at` en `state/idle.json` con timestamp UTC y lo refresca después de cada vuelta de IDLE, incluso sin correo nuevo
- `healthcheck.py` expone `heartbeat_age_seconds` desde ese timestamp, no desde `mtime`
- con unidad `unknown`, un latido fresco conserva el warning de #89; un latido mayor a 900s falla con el diagnóstico pedido; un estado heredado sin `heartbeat_at` queda como warning de versión

## Base
- PR apilado sobre #89 / `arregla-healthcheck-unknown`, porque este cambio presupone la separación de `unknown` hecha ahí

## Pruebas
- `python3 scripts/test_healthcheck.py` — 103 passed, 0 failed
- `python3 scripts/test_listener.py` — passed fuera del sandbox, porque la prueba de keepalive crea socket
- `python3 scripts/test_dispatch.py` — 104 passed, 0 failed
- `python3 scripts/healthcheck.py --json`

Closes #90