### PR TITLE
Distingue listener reintentando en healthcheck

### DIFF
--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -185,7 +185,8 @@ def tail(path, lines=1):
 def listener_facts():
     out = {"unit": unit_state(LISTENER_UNIT), "mailbox": None,
            "last_uid": None, "uidvalidity": None, "heartbeat_at": None,
-           "heartbeat_age_seconds": None, "last_error": None}
+           "heartbeat_age_seconds": None, "last_error": None,
+           "last_error_age_seconds": None}
     try:
         state = json.loads(LISTENER_STATE.read_text())
         out["mailbox"] = state.get("mailbox")
@@ -199,6 +200,13 @@ def listener_facts():
         pass
     last = tail(IDLE_ERR)
     out["last_error"] = last[0] if last else None
+    try:
+        # Unlike queue and heartbeat ages, the useful fact here is the write
+        # time itself: a retrying listener keeps touching the diagnostic file
+        # even while it cannot complete an IDLE cycle.
+        out["last_error_age_seconds"] = max(0, int(time.time() - IDLE_ERR.stat().st_mtime))
+    except OSError:
+        pass
     return out
 
 
@@ -595,9 +603,15 @@ def assess(facts):
             warnings.append("the listener state has no heartbeat_at; this listener is from "
                             "a version that does not report heartbeat, so its liveness is unknown")
         elif heartbeat_age > STALE_LISTENER_HEARTBEAT:
-            problems.append(f"the listener last reported {heartbeat_age}s ago and its unit "
-                            "cannot be queried: it is probably dead, and this host has no "
-                            "supervisor to restart it")
+            error_age = listener.get("last_error_age_seconds")
+            if error_age is not None and error_age < STALE_LISTENER_HEARTBEAT:
+                problems.append(f"the listener last completed a cycle {heartbeat_age}s ago "
+                                "but is still logging retries: it is running and cannot "
+                                "reach the mail server, so restarting it will not help")
+            else:
+                problems.append(f"the listener last reported {heartbeat_age}s ago and its unit "
+                                "cannot be queried: it is probably dead, and this host has no "
+                                "supervisor to restart it")
         else:
             warnings.append("the listener unit cannot be queried on this host "
                             "(no observable service manager); its state is unknown, not stopped")

--- a/scripts/test_healthcheck.py
+++ b/scripts/test_healthcheck.py
@@ -163,6 +163,13 @@ class Fixture:
         hc.LISTENER_STATE.write_text(json.dumps(state))
         return self
 
+    def listener_error(self, age_seconds=0):
+        hc.IDLE_ERR.write_text("connection lost (TimeoutError); retrying in 300s\n",
+                               encoding="utf-8")
+        stamp = time.time() - age_seconds
+        os.utime(hc.IDLE_ERR, (stamp, stamp))
+        return self
+
     def run(self):
         facts = {
             "listener": hc.listener_facts(),
@@ -215,7 +222,17 @@ check("and says the listener state is unknown, not stopped", True,
       "the listener unit cannot be queried on this host (no observable service manager); "
       "its state is unknown, not stopped" in text)
 
-f = Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"}).heartbeat(16 * 60)
+f = (Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"})
+     .heartbeat(16 * 60).listener_error(60))
+code, text = f.exit_code()
+check("an unqueryable listener with stale heartbeat but fresh retries is a failure", 1, code)
+check("and says the listener cannot reach the mail server", True,
+      "the listener last completed a cycle" in text
+      and "but is still logging retries: it is running and cannot reach the mail server, "
+      "so restarting it will not help" in text)
+
+f = (Fixture(units={hc.LISTENER_UNIT: "unknown", hc.DISPATCH_UNIT: "active"})
+     .heartbeat(16 * 60).listener_error(16 * 60))
 code, text = f.exit_code()
 check("an unqueryable listener with a stale heartbeat is a failure", 1, code)
 check("and says the listener is probably dead", True,


### PR DESCRIPTION
## Resumen
- `listener_facts()` expone `last_error_age_seconds` desde el `mtime` de `state/idle.err.log`
- cuando el latido está viejo y la unidad es `unknown`, `assess()` distingue un listener que sigue escribiendo reintentos recientes de uno probablemente muerto
- mantiene el diagnóstico de `probably dead` cuando el log de errores también está viejo o ausente

## Base
- PR apilado sobre #92 / `agrega-latido-listener`, porque usa `heartbeat_at`

## Pruebas
- `python3 scripts/test_healthcheck.py` — 105 passed, 0 failed
- `python3 scripts/healthcheck.py --json`

Closes #93