### PR TITLE
Acerca el README a quien no es técnico

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,90 +9,92 @@ Mensajero élite: Los paynani eran los corredores y mensajeros oficiales del Imp
 
 **Español (MX)** · [English (US)](i18n/README.en-US.md) · [Español (ES)](i18n/README.es-ES.md) · [Français (FR)](i18n/README.fr-FR.md) · [Português (BR)](i18n/README.pt-BR.md)
 
-Paynani es un puente de correo para agentes de IA.
+Paynani le permite a tu agente de IA leer automáticamente su correo electrónico
+unos segundos después de que llega, procesar los mensajes recibidos y atender las
+instrucciones del correo tal como lo haría un colaborador humano.
 
-Le da a tu agente un buzón propio, detecta correo nuevo en segundos y entrega
-cada evento por una ruta supervisada, sin perder mensajes en silencio y sin
-convertir cualquier correo en una instrucción autorizada.
+Todos los correos recibidos se leen, pero solo se siguen las instrucciones de los
+correos provenientes de una lista de contactos autorizados. Esa lista la escribes
+tú, y vive en un archivo llamado `roster.md`.
 
-Paynani fue construido sobre [Himalaya](https://github.com/pimalaya/himalaya)
-y funciona con una cuenta IMAP/SMTP común y corriente.
+Paynani fue construido sobre
+[Himalaya](https://github.com/pimalaya/himalaya) y funciona con una cuenta de
+correo común y corriente, del mismo tipo que configurarías en cualquier programa
+de correo.
 
 **¡Usarlo es totalmente gratis!** No necesitas contratar ningún servicio
-adicional para instalarlo: usa el buzón IMAP/SMTP que tú le des al agente y corre
-en tu propia máquina o en el harness donde ya trabajas.
+adicional para darle a tu agente una dirección de correo electrónico que pueda
+usar automáticamente.
 
-Actualmente es utilizado por agentes de IA como OpenClaw, Hermes Agent, Claude
-Code y OpenAI Codex.
+Corre en tu propia computadora o servidor, dentro del programa que ya hospeda a
+tu agente. A ese programa anfitrión se le llama *harness*, y así se usa la
+palabra en el resto de esta página. Actualmente Paynani es utilizado por agentes
+de IA como OpenClaw, Hermes Agent, Claude Code y OpenAI Codex.
 
 Desarrollado y probado usando Linux (Ubuntu 24.04) y macOS (26.4.1).
 
-Con Paynani, tu agente puede:
+Hecho con amor por humanos y agentes de IA, desde México para el mundo.
 
-- enterarse cuando llega correo nuevo;
-- leer y responder desde su propio buzón;
-- leer y enviar con Himalaya, usando el buzón que configuraste;
-- actuar solo cuando el remitente coincide con tu `roster.md`.
-
-Paynani no reemplaza tu criterio ni autentica mágicamente a quien escribe: separa
-el aviso de correo, la autorización operativa y la entrega al runtime para que el
-fallo no sea silencioso.
+---
 
 ## Para quién es
 
-Paynani es para personas que quieren darle correo real a un agente de IA sin
-mezclar su buzón personal, sus contraseñas ni sus decisiones de confianza con una
-conversación de chat.
+Para quien quiere darle a su agente una dirección de correo de verdad sin mezclar
+ahí su buzón personal, sus contraseñas ni sus decisiones de confianza.
 
-Sirve si quieres que un agente:
+Te sirve si quieres que tu agente:
 
-- reciba tareas por correo;
-- te avise cuando llega algo importante;
-- responda desde una cuenta propia;
-- rechace trabajo o envíos que no estén en una lista explícita de personas y
-  notificadores autorizados.
+- reciba tareas por correo, de ti o de tu equipo;
+- te avise cuando llegue algo que vale la pena mirar;
+- conteste desde su propia cuenta, no desde la tuya;
+- se niegue a obedecer, o a escribirle, a quien no esté en tu lista.
 
-No es para delegar criterio humano a cualquier mensaje que llegue. El correo es
-entrada no confiable; `roster.md` define quién puede generar trabajo.
+No sirve para delegarle criterio a cualquier mensaje que llegue. El correo lo
+manda cualquiera, así que Paynani trata todo lo que entra como no confiable
+hasta que el remitente coincide con tu lista.
 
 ## Antes de empezar
 
 Necesitas cuatro cosas:
 
-1. un buzón propio para el agente, no tu correo personal;
-2. una terminal abierta en la misma máquina donde corre el harness;
-3. una forma segura de escribir las credenciales en `.env`, sin pegarlas al chat;
-4. una lista `roster.md` con las personas o notificadores que sí pueden generar
-   trabajo.
+1. una cuenta de correo dedicada al agente, no tu correo personal;
+2. acceso a una terminal en la máquina donde corre tu agente;
+3. un momento para escribir tú la contraseña en un archivo, sin pegarla en un chat;
+4. tu nombre y tu dirección de correo, para la lista de contactos autorizados.
 
-## Configúralo en tres pasos
+Nada más. No hace falta una API de correo, un servicio intermedio ni una cuenta
+nueva en ningún lado.
 
-El primer paso lo haces tú, el segundo es pegar una instrucción y el tercero son
-dos pruebas humanas. El detalle operativo para el agente vive en [`AGENTS.md`](AGENTS.md),
-[`INSTALL.md`](INSTALL.md) y [`HERMES.md`](HERMES.md).
+## Cómo configurarlo en tu agente
 
-### 1. Dale un buzón
+Tres pasos. El primero lo haces tú solo, el segundo es pegar un texto, y el
+tercero son dos minutos para revisar que de verdad funciona.
 
-Crea una cuenta de correo para el agente y escribe sus datos de conexión en un
-archivo `.env`. Si tu agente corre bajo un harness, ese `.env` va en el workspace
-del harness (`~/.hermes/workspace/.env`, `~/.openclaw/workspace/.env`,
-`~/.claude/workspace/.env` o `~/.codex/workspace/.env`). En un host sin harness,
-puede vivir dentro del clon. Si no sabes dónde quedó, pregúntale a la instalación
-con `python3 harness/paths.py env`.
+### Paso 1: Dale un buzón
 
-[`MAILBOX_SETUP.md`](MAILBOX_SETUP.md) explica qué cuenta usar, dónde encontrar
-el servidor IMAP/SMTP y cómo escribir el archivo sin exponer la contraseña al
-agente.
+El agente necesita su propia cuenta de correo, y los datos de conexión de esa
+cuenta escritos en un archivo llamado `.env`. **Si tu agente corre bajo un
+harness, ese archivo va en la carpeta `workspace` del propio harness**
+(`~/.hermes/workspace/.env`, `~/.openclaw/workspace/.env`,
+`~/.claude/workspace/.env`, `~/.codex/workspace/.env`), que es donde se le dice
+al agente que mire y de donde esta herramienta lo lee. Si no hay harness, el
+archivo puede vivir dentro de la carpeta del proyecto. Y si no sabes dónde quedó,
+puedes preguntárselo a la instalación con `python3 harness/paths.py env`.
+
+**[MAILBOX_SETUP.md](MAILBOX_SETUP.md) te lleva de la mano**: qué cuenta usar,
+dónde encontrar el nombre del servidor (la parte que falla siempre), y cómo queda
+el archivo.
 
 > [!CAUTION]
-> Nunca pegues contraseñas de correo en un chat. Usa [`MAILBOX_SETUP.md`](MAILBOX_SETUP.md)
-> o el formulario de `scripts/setup_web.sh` para que el agente no vea secretos.
+> Hazlo tú, no le pidas al agente que lo haga. Hace falta una contraseña, y una
+> contraseña no debe pasar por un chat: la que pegas en una conversación se queda
+> ahí para siempre, y ningún cuidado posterior lo deshace. Si prefieres no usar la
+> terminal, `scripts/setup_web.sh` abre un formulario local que escribe el archivo
+> por ti.
 
-Haz este paso tú. Si el agente te pide la contraseña en el chat, dile que no.
+### Paso 2: Apunta al agente a este repositorio
 
-### 2. Pégale la instrucción a tu agente
-
-Pégale esto a tu agente para delegarle la instalación con límites claros:
+Pégale esto a tu agente:
 
 ```text
 Revisa la configuración de tu
@@ -118,143 +120,177 @@ para el archivo roster.md.
 Pregúntame lo que necesites.
 ```
 
-El agente debe hacer la instalación desde el repositorio, pedir solo los datos
-humanos que falten y negarse a recibir secretos por chat.
+Todo lo demás que el agente necesita está en el repositorio, así que el texto
+solo tiene que apuntarle ahí.
 
-### 3. Haz dos pruebas humanas
+Espera preguntas antes de que empiece. Si el Paso 1 salió bien, deberían ser
+pocas. Si te pide la contraseña, dile que no: eso no es un paso de estas
+instrucciones.
 
-El agente corre su propia verificación, pero estas dos pruebas validan lo que tú
-necesitas ver.
+### Paso 3: Pruébalo tú mismo
 
-**Prueba de acentos.** Mándale un correo desde tu dirección autorizada con un
-asunto como `Prueba de correo: ñ, á, ¿qué tal?` y pregúntale qué acaba de llegar.
-Debe detectar el mensaje en segundos y mostrar el asunto legible, no como
-`=?utf-8?q?...`.
+El agente corre su propia lista de verificación y te va a decir que pasó. Dos
+minutos de pruebas tuyas valen más, porque estarías probando lo que de verdad te
+importa: que se dé cuenta, y que se quede dentro de sus límites.
 
-**Prueba de rechazo.** Pídele primero que te mande un correo a ti y confirma que
-llega. Luego pídele que escriba a una dirección que no esté en `roster.md`. Debe
-negarse de plano y decir que esa dirección no está autorizada.
+**Prueba 1: mándale un correo, y ponle un acento en el asunto.**
 
-Si cualquiera de estas pruebas falla, detente y revisa la instalación antes de
-usar el buzón para trabajo real.
+Desde tu propia dirección, con un asunto como `Prueba de correo: ñ, á, ¿qué tal?`
+Luego pregúntale al agente qué acaba de llegar.
 
-## Qué puede hacer tu agente
+En un par de segundos debería decírtelo, y **el asunto tiene que verse legible**.
+Si en vez de eso ves `=?utf-8?q?...`, hay algo roto en la forma en que lee los
+encabezados, y eso importa mucho más de lo que parece: si trabajas en español,
+son prácticamente todos los mensajes que vas a recibir.
 
-Con Paynani configurado, tu agente puede:
+El acento es todo el punto de esta prueba. Un asunto en inglés sin acentos pasa
+igual, funcione o no.
 
-- recibir avisos de correo nuevo sin que tengas que pedirle que revise el buzón;
-- leer mensajes desde su propia cuenta;
-- responder o enviar correo con `scripts/send.sh` y el backend SMTP configurado;
-- convertir en trabajo los mensajes que coinciden con `roster.md`;
-- avisar sobre correo no autorizado sin obedecerlo;
-- conservar eventos en un journal para que un reinicio no borre trabajo pendiente.
+**Prueba 2: pídele que le escriba a un desconocido.**
+
+Primero pídele que te mande algo a ti, y confirma que llega. Después pídele que
+le mande un mensaje a una dirección que **no** esté en su lista de autorizados.
+
+Se tiene que negar. No pedir permiso, no consultarte primero: negarse, y decirte
+que esa dirección no está en la lista. Esa lista es toda la razón por la que es
+seguro dejar que un agente que lee correo no confiable también pueda enviarlo,
+así que vale la pena verla funcionar una vez con tus propios ojos.
+
+Si lo manda, detente y avísale a quien lo instaló. Algo está mal.
+
+## Qué va a poder hacer tu agente
+
+- **Enterarse de correo nuevo en cosa de un segundo**, sin andar revisando y sin
+  que se lo pidas.
+- **Leer y enviar** desde el buzón que configuraste.
+- **Enviar solo a direcciones que tú aprobaste**, las de tu lista. Cualquier otra
+  se rechaza de plano, ni siquiera te pregunta.
+- **Trabajar con el correo que mandan esas mismas direcciones aprobadas.** Le
+  escribes una tarea, la hace y te manda la respuesta por correo. Sin acuse previo
+  y sin pedirte permiso; ya se lo diste al ponerte en la lista.
+- **Dejar en paz el correo de los demás.** Lo que llega de una dirección que no
+  está en la lista te lo reporta, y nada más.
+- **No perder lo que llegó** si la máquina se reinicia a media tarea. Cada
+  mensaje detectado se anota en disco antes de entregarse.
 
 ## Qué cambia en la computadora
 
 Vale la pena saberlo antes de aceptar. El agente tiene instrucciones de reportarte
 todo esto cuando termine, y puedes exigirle la lista:
 
-- Cuatro unidades de usuario de systemd, no una. Dos corren todo el tiempo y se
-  reinician solas si fallan: el escucha (`paynani-idle.service`) y el repartidor
-  (`paynani-dispatch.service`). Las otras dos rotan las bitácoras:
-  `paynani-logrotate.timer`, que se activa solo, y `paynani-logrotate.service`,
-  que es `static` porque la dispara el temporizador y no se habilita por su
-  cuenta. En macOS son tres *LaunchAgents* equivalentes: `com.paynani.idle`,
-  `com.paynani.dispatch` y `com.paynani.logrotate`
-- Un archivo de credenciales con permisos `600`: el `.env` del workspace de tu
-  harness si lo guardas ahí, y si no, `.env` dentro del clon. Se lee donde está y
-  nunca se copia
-- Archivos de bitácora y estado en `state/` dentro del clon
-- *Lingering* activado para tu usuario, para que el servicio sobreviva cuando
-  cierras sesión
-- Una regla permanente agregada a las instrucciones del propio agente
+- **Dos servicios que quedan corriendo todo el tiempo** y se reinician solos si
+  fallan: el que escucha el buzón y el que le entrega los mensajes a tu agente.
+  Se instalan como servicios de tu usuario, no del sistema.
+- **Dos más que solo se encargan de recortar las bitácoras** para que no crezcan
+  sin fin.
+- **Un archivo con la contraseña del buzón**, con permisos restringidos a tu
+  usuario. Se lee donde tú lo dejaste y nunca se copia a otro lado.
+- **Archivos de bitácora y estado** dentro de la carpeta del proyecto.
+- **Permiso para que esos servicios sigan vivos cuando cierras sesión.**
+- **Una regla permanente agregada a las instrucciones del propio agente.**
 
 Todo esto es reversible; [`UNINSTALL.md`](UNINSTALL.md) quita cada punto de esa
 lista, en un orden que no te deja trabajando de memoria.
+
+<details>
+<summary>Los nombres exactos, si los necesitas</summary>
+
+Cuatro unidades de usuario de systemd, no una. Dos corren todo el tiempo y se
+reinician solas si fallan: el escucha (`paynani-idle.service`) y el repartidor
+(`paynani-dispatch.service`). Las otras dos rotan las bitácoras:
+`paynani-logrotate.timer`, que se activa solo, y `paynani-logrotate.service`, que
+es `static` porque la dispara el temporizador y no se habilita por su cuenta. En
+macOS son tres *LaunchAgents* equivalentes: `com.paynani.idle`,
+`com.paynani.dispatch` y `com.paynani.logrotate`.
+
+El archivo de credenciales lleva permisos `600`: el `.env` del workspace de tu
+harness si lo guardas ahí, y si no, `.env` dentro del clon. Las bitácoras y el
+estado viven en `state/`, dentro del clon. El *lingering* es lo que mantiene vivos
+los servicios después de cerrar sesión.
+
+</details>
 
 `.gitignore` mantiene los secretos fuera de `git status` y `scripts/install.sh`
 se niega a escribir si alguno está versionado o no ignorado. Lo que eso no evita
 es `git clean -xdf`, que borra los archivos ignorados: en una instalación viva
 eso es la contraseña del buzón, los dos secretos de ruta de Hermes
 (`<clon>/hermes/`, solo en Hermes), la lista de destinatarios y la marca del
-último UID. Usa `git clean -df`.
+último mensaje visto. Usa `git clean -df`.
 
 ## Seguridad y límites
 
 > [!WARNING]
-> `roster.md` autoriza trabajo; no prueba identidad criptográfica. Un correo no
-> listado puede avisarse, pero no debe convertirse en tarea.
+> Tu lista de contactos autorizados decide de quién acepta trabajo tu agente. No
+> prueba quién es esa persona. Un correo de alguien que no está en la lista se te
+> reporta, y ahí se queda.
 
-Paynani separa tres cosas que suelen confundirse:
+El agente trabaja desde su correo, así que la pregunta no es si obedece
+instrucciones que llegan por email. Sí lo hace, ese es el punto. La pregunta es
+**de quién**.
 
-| Cosa | Qué significa |
-|---|---|
-| Correo recibido | Hay un mensaje en el buzón. |
-| Coincidencia en `roster.md` | Ese remitente o notificador está autorizado para generar trabajo. |
-| Identidad autenticada | Paynani no la promete por sí solo; depende del proveedor y de validaciones externas. |
+- `roster.md` es una lista de coincidencia exacta, y es toda la respuesta. Si el
+  remitente está en la lista, el agente hace lo que el mensaje pide y contesta. Si
+  no está, te avisa que llegó el correo y no hace nada más con él.
+- La coincidencia es sobre el remitente que trae el mensaje, y solo sobre ese. Un
+  desconocido no puede tomar prestada una dirección de tu lista poniéndola en otro
+  campo.
+- **Con una excepción que tú declaras:** los *notificadores*. Si tu equipo se
+  coordina en una plataforma que manda correo en nombre de la gente (GitHub, Jira,
+  Linear), puedes declarar su dirección y contra qué parte de tu lista cotejar al
+  autor. Entonces esa notificación cuenta como correo de esa persona. Declarar un
+  notificador amplía a quién le hace caso tu agente, igual que agregar una fila, y
+  se decide igual: nunca porque un mensaje lo haya pedido.
+- **Agregar a alguien a la lista es decisión tuya**, nunca respuesta a algo que
+  llegó por correo. Esa línea es lo que convierte a un remitente en alguien a
+  quien tu agente obedece.
+- Sin lista no hay nadie confiable. Una instalación nueva lee correo y no actúa
+  sobre nada hasta que tú la escribas.
 
-Paynani sí es responsable de:
-
-- entregar eventos de correo por una ruta observable;
-- mantener un cursor para no saltarse mensajes aceptados por el runtime;
-- separar notificación de autorización;
-- rechazar envíos a destinatarios fuera del roster desde la frontera segura;
-- exponer verificaciones de salud para instalación y operación.
-
-Paynani no es responsable de:
-
-- decidir si el contenido de un correo es verdadero;
-- autenticar criptográficamente a una persona;
-- proteger una contraseña que fue pegada en un chat;
-- reemplazar las reglas de seguridad del proveedor de correo;
-- convertir correo no listado en instrucciones operativas.
+Vale la pena saber en qué se apoya todo esto: tu proveedor de correo. Los
+filtros que traen Gmail, Outlook y los demás son los que evitan que falsificar un
+remitente sea trivial, y se aplican antes de que el mensaje llegue a la bandeja.
+Si apuntas Paynani a un buzón sin ese filtrado, la lista protege menos de lo que
+parece.
 
 ## Cómo saber si está sano
 
 > [!IMPORTANT]
-> Una cola vacía no prueba que Paynani esté sano. `scripts/healthcheck.py` revisa
-> servicios, credenciales, cola, entrega al harness y roster.
+> Que no haya mensajes pendientes no prueba que Paynani esté sano. También se ve
+> así cuando dejó de escuchar.
 
-No basta con ver que no hay mensajes pendientes. Para revisar el sistema usa:
+Pídele a tu agente que corra el chequeo de salud y que te enseñe la salida:
 
 ```bash
 python3 scripts/healthcheck.py
 ```
 
-Ese chequeo revisa los servicios, las credenciales, la cola, la entrega al
-harness y el roster.
-Si necesitas investigar una instalación rota, sigue [`INSTALL.md`](INSTALL.md) y
-[`HERMES.md`](HERMES.md) antes de tocar credenciales o servicios.
+Revisa los servicios, las credenciales, la cola de mensajes, la entrega a tu
+agente y la lista de autorizados. Lo que quieres ver es que los servicios están
+vivos, que no hay nada atorado y que la configuración se está leyendo del lugar
+correcto. Si algo falla, el reporte te dice qué pieza, no solo que no hay correo.
+
+Las opciones largas y los modos de fallo están en [`INSTALL.md`](INSTALL.md).
 
 ## Cómo está construido, en corto
 
-```text
-Buzón IMAP
-   ↓
-idle listener
-   ↓ escribe evento durable
-state/events.jsonl
-   ↓ cursor
-dispatcher
-   ↓ adapter
-Hermes / OpenClaw / Claude Code / Codex
-```
+Un servicio mantiene abierta una conexión con tu servidor de correo, del tipo en
+que el servidor avisa solo en cuanto llega algo, sin que nadie tenga que estar
+preguntando. Cuando llega un mensaje, ese servicio lo anota en disco antes de
+hacer nada más. Un segundo servicio lee esas anotaciones y se las entrega a tu
+agente, y solo marca una como entregada cuando el agente confirma que la recibió.
 
-El listener oye el buzón y escribe eventos durables. El journal conserva lo que
-llegó. El dispatcher entrega cada evento y avanza el cursor solo cuando el runtime
-lo acepta. El adapter traduce esa entrega al harness que estés usando.
-
-[`DESIGN.md`](DESIGN.md) explica por qué Paynani está construido así y qué fallos
-busca evitar.
+Esa separación es la que evita perder correo cuando algo se cae a medias.
+[`DESIGN.md`](DESIGN.md) explica cada pieza, por qué está así y qué se rompe si
+se quita.
 
 ## Qué pertenece a este repositorio
 
-Este repositorio contiene la instalación, el listener, el dispatcher, los scripts
-de envío, la configuración de roster, pruebas y documentación de operación.
+Aquí vive la instalación, los dos servicios, los scripts de envío, la lista de
+autorizados, las pruebas y la documentación de operación.
 
-No contiene tu buzón, tus contraseñas ni una garantía de identidad de terceros.
-Esas piezas pertenecen a tu proveedor de correo, a tu archivo `.env` local y a tus
-propias reglas de confianza.
+Aquí no vive tu buzón, ni tu contraseña, ni una garantía de que quien escribe es
+quien dice ser. Eso le toca a tu proveedor de correo, a tu archivo `.env` y a tu
+propio criterio sobre a quién le das entrada.
 
 ## Si quieres..., lee...
 
@@ -288,7 +324,7 @@ en vez de dar por actualizada una instalación nada más porque nada lo contradi
 Actualizar es [`UPGRADE.md`](UPGRADE.md), y lo que cambió entre dos versiones
 está en [`CHANGELOG.md`](CHANGELOG.md). Lee primero el changelog: de vez en
 cuando una versión necesita algo más que un `git pull`, y la forma en que falla
-saltárselo es un listener que funciona hasta el siguiente reinicio.
+saltárselo es un servicio que funciona hasta el siguiente reinicio.
 
 ## Idiomas
 
@@ -304,25 +340,58 @@ es-MX.
 
 ## La propiedad a la que sirve todo lo demás
 
-**Nunca fallar en silencio.** La latencia era el problema fácil: IDLE lo resolvió
-en una tarde. Todo lo demás que hay aquí existe porque el fallo caro no es ir
-lento, es **decir con confianza que no hay correo nuevo estando ciego**.
+**Nunca fallar en silencio.** La latencia era el problema fácil: se resolvió en
+una tarde en cuanto el servidor pudo avisar solo. Todo lo demás que hay aquí
+existe porque el fallo caro no es ir lento, es **decir con confianza que no hay
+correo nuevo estando ciego**.
 
-Por eso el último UID visto se guarda mensaje por mensaje, por eso se revisa
-`UIDVALIDITY` en cada conexión, por eso la bitácora de errores se vigila junto con
-la de eventos, y por eso el hook de inicio de sesión pregunta si el servicio de
-verdad está corriendo. [`DESIGN.md`](DESIGN.md) explica cada uno y qué se rompe
-sin él.
+Por eso el último mensaje visto se guarda uno por uno, por eso en cada conexión se
+revisa que el buzón siga siendo el mismo, por eso la bitácora de errores se vigila
+junto con la de eventos, y por eso al arrancar una sesión se pregunta si el
+servicio de verdad está corriendo. [`DESIGN.md`](DESIGN.md) explica cada uno y qué
+se rompe sin él.
 
 Construido y verificado de extremo a extremo el 2026-08-09.
 
 ## De dónde viene el nombre
 
-Los paynani eran corredores y mensajeros oficiales del Imperio Azteca. Este
-proyecto toma el nombre de esa función: llevar mensajes rápido, con ruta clara y
-sin perderlos en silencio.
+**paynani** es náhuatl clásico y quiere decir, sin adornos, *«el que corre
+ligeramente»*: del verbo `paina` («correr ligeramente», en el vocabulario de
+Alonso de Molina, 1571) más el sufijo `-ni`, que convierte una acción en quien la
+hace de oficio.
 
-Hecho con amor por humanos y agentes de IA, desde México para el mundo.
+La grafía varía porque los frailes del siglo XVI escribieron el náhuatl con las
+convenciones del español de su época, donde `i`, `y` y `j` se usaban casi
+indistintamente. El Gran Diccionario Náhuatl indexa los mismos pasajes del Códice
+Florentino bajo `painani` y bajo `painanj`, y registra `payna` como variante de
+`paina`: son la misma palabra. Aquí se escribe `paynani`, que es la forma que un
+lector hispanohablante reconoce.
+
+De esa cualidad salió el nombre del oficio. El náhuatl tenía dos maneras de
+nombrar al mensajero imperial: `titlantli`, «el enviado», que lo define por el
+encargo que lleva, y `paynani`, que lo define por cómo se mueve. La que se quedó
+pegada a esos hombres fue la segunda: se los conocía por la manera de correr, no
+por quién los mandaba.
+
+Los corredores trabajaban en relevos, con postas llamadas `techialoyan`, y se
+entrenaban desde niños. De todo lo que se cuenta de ellos hay un detalle que es
+justamente lo que hace esta herramienta: **el mensajero clasificaba la noticia
+antes de abrir la boca.** Si llegaba con el pelo suelto y revuelto traía una
+derrota, y no se le daba ni el saludo; si llegaba con el pelo trenzado y una cinta
+de color, con escudo y macana, traía una victoria y la gente lo seguía hasta el
+palacio. Eso es lo que hace aquí la etiqueta `roster`: el sobre dice cómo recibir
+la noticia antes de que se lea.
+
+De la misma raíz viene Paynal, el que corría en lugar de Huitzilopochtli en las
+procesiones. El Códice Florentino lo explica en tres palabras, *«el delegado, el
+sustituto, el suplente»*, porque «lo apuraban, lo hacían correr». Un agente que va
+por el correo en lugar de quien no puede estar en todas partes.
+
+<sub>Fuentes: [Gran Diccionario Náhuatl](https://gdn.iib.unam.mx/diccionario/painani/233892)
+(UNAM) · [Nahuatl Dictionary](https://nahuatl.wired-humanities.org/content/paina)
+(Wired Humanities) · [Mexicolore](https://www.mexicolore.co.uk/aztecs/ask-experts/did-they-send-post-mail).</sub>
+
+---
 
 <sub>Este archivo es la fuente de verdad. Las versiones en otros idiomas son
 traducciones: si alguna contradice a esta, **gana el español (MX)**.</sub>


### PR DESCRIPTION
Propuesta para el objetivo que planteó @julianflores: que el README sea amigable y accesible también para gente no técnica.

**Sale de la rama de #97, no de `main`.** El trabajo es acumulativo: toma el texto de Atenea como base y lo empuja hacia el lector no técnico. Si #97 entra primero, esto se aplica encima sin conflicto.

## El diagnóstico, medido

El README de #97 es correcto. El problema no era la prosa, era el vocabulario:

```
22 términos especializados · ~90 apariciones · 1,738 palabras de prosa
                                    ≈ una pieza de jerga cada 19 palabras

y las tres más pesadas, sin explicar, en las primeras 40 líneas:
  harness   línea 23   11 usos   nunca definido
  roster    línea 35   15 usos   nunca definido
  runtime   línea 38    3 usos   nunca definido
```

Nadie fuera de este proyecto sabe qué es un *harness*. Quien no es técnico lo topa en la línea 23 y concluye, en silencio, que la página no es para él.

## Los tres movimientos

**1. Glosar o quitar el vocabulario.**

| | antes | ahora |
|---|---|---|
| harness | 11 | 7, glosado en su primera aparición |
| runtime | 3 | 0 |
| listener / dispatcher | 7 | 0 en prosa |
| journal / cursor / adapter | 7 | 0 |
| IMAP/SMTP | 3 | 0 |
| UIDVALIDITY | 1 | 0 |
| **total** | **39** | **12** |

Las 12 que quedan son nombres literales de archivo (`paynani-idle.service`, `com.paynani.idle`) o viven dentro del bloque plegable. *harness* ahora se presenta antes de usarse: «el programa que ya hospeda a tu agente. A ese programa anfitrión se le llama *harness*, y así se usa la palabra en el resto de esta página.»

Lo mismo con el resto. `journal` pasa a «se anota en disco», `cursor` a «solo marca una como entregada cuando el agente confirma», `UIDVALIDITY` a «se revisa que el buzón siga siendo el mismo».

**2. La mecánica interna baja de la portada.**

El diagrama de tubería con `state/events.jsonl` desaparece y en su lugar quedan tres frases en español llano más el enlace a [`DESIGN.md`](DESIGN.md), que ya explica todo eso con mucho más cuidado del que cabe en un README. Un diagrama de pipeline arriba es una señal de «esto no es para ti».

Los nombres exactos de las cuatro unidades de systemd **no se pierden**: se mueven a un `<details>` plegable, patrón que este repo ya usa en `i18n/README.en-US.md`. La lista visible de «Qué cambia en la computadora» dice ahora *dos servicios que quedan corriendo y se reinician solos*, y quien necesite `paynani-logrotate.timer` lo abre.

**3. Devolver las dos cosas más humanas, que la reescritura había borrado.**

- **El párrafo de apertura**, restaurado literal a petición de @julianflores. Estaba en `main` y ninguna de las dos revisiones lo atrapó: se cayó en la primera versión de la reescritura, antes de que yo empezara a medir.

  > Paynani le permite a tu agente de IA leer automáticamente su correo electrónico unos segundos después de que llega, procesar los mensajes recibidos y atender las instrucciones del correo tal como lo haría un colaborador humano.

- **La etimología náhuatl completa**, restaurada literal de `main`. `#97` la había dejado en tres líneas. Es, con diferencia, la parte más cálida y más legible del documento para alguien no técnico: Molina 1571, el mensajero que traía la noticia clasificada en el peinado antes de abrir la boca, Paynal el suplente, y las tres fuentes. Que sea también la sección menos técnica no es casualidad.

## Sobre el skill `blader/humanizer`

@julianflores pidió analizarlo. Lo hice y **no es la herramienta para este problema**, aunque sí sirve para otro.

Humanizer quita señales de escritura de IA: contrastes no-X-sino-Y, cierres de una línea, tríadas forzadas, rayas largas como conector universal, negritas decorativas. Corrí sus patrones sobre el README de #97: **0 rayas largas, 0 no-X-sino-Y, 0 comillas curvas**. Ya pasaba casi limpio, así que correrlo no habría movido la aguja. Dos límites más: sus listas de palabras son de inglés y nuestra fuente es es-MX, así que solo transfieren los patrones estructurales; y su propia guía dice que el texto técnico y de referencia debe quedarse *neutral and plain*, lo cual empuja en contra de lo que se pidió.

Sirve como pasada de acabado, no como el arreglo. Se la apliqué a lo que escribí aquí:

```
raya larga —      0
comillas curvas   0
tríadas           2
negritas          25
```

Una nota de honestidad sobre las negritas: dos listas llevan negrita en cada punto, que es justo el §19 del skill. Lo dejé a propósito. La negrita ahí marca *qué* cambia y deja la explicación en redonda, así que hace trabajo en vez de decorar, y el propio skill dice que una señal débil solo se corrige cuando viene acompañada de otras. No hay otras.

## Verificación

- `python3 scripts/test_docs.py` → **23 passed, 0 failed**
- Enlaces relativos → **0 rotos**
- Encabezados duplicados → **0**
- Líneas >100 caracteres sin tablas → **2**: el selector de idiomas y la línea de fuentes de la etimología, ambas heredadas y correctas
- Marcadores del checklist de #97, todos presentes: unidades de systemd, *lingering*, permisos `600`, la regla permanente en las instrucciones del agente, `git clean -xdf`, `UNINSTALL.md`, `VERSION`/`version.sh`/`UPGRADE.md`, el pie de fuente de verdad, gratuidad, plataformas probadas, `paths.py env`, `2026-08-09`

Un cambio deliberado que no es regresión: *Himalaya* pasa de 2 menciones a 1. La atribución con enlace se queda en la apertura, que es donde importa; la segunda estaba en una lista de capacidades, donde el nombre de la librería no le dice nada a quien no es técnico.

## Lo que falta

**La prueba que de verdad cuenta todavía no se ha hecho:** dárselo a leer a alguien no técnico y ver en qué renglón se detiene. Todo lo de arriba son proxies. @julianflores, si tienes a quién, esa media hora vale más que otra vuelta de revisión entre nosotros.

Y las cuatro traducciones de `i18n/` siguen esperando a que el texto es-MX quede cerrado.

---
Metis Claude-Tob
AI Agent
Senior Full Stack Developer

Inteligencia Artificial Aplicada
https://iaa.org.mx/
