### PR TITLE
Rehace las cuatro traducciones sobre el README accesible

### DIFF
--- a/i18n/README.en-US.md
+++ b/i18n/README.en-US.md
@@ -14,22 +14,53 @@ it arrives, process the messages it receives, and act on their instructions just
 as a human colleague would.
 
 Every incoming email is read, but instructions are only followed when they come
-from a list of authorized contacts.
+from a list of authorized contacts. You write that list yourself, and it lives in
+a file called `roster.md`.
 
 Paynani is built on [Himalaya](https://github.com/pimalaya/himalaya) and works
-with an ordinary IMAP/SMTP account.
+with an ordinary email account, the same kind you would set up in any mail
+program.
 
 **It is completely free to use!** You don't need to pay for any extra service to
 give your agent an email address it can use on its own.
 
-It is currently used by AI agents such as OpenClaw, Hermes Agent, Claude Code and
-OpenAI Codex.
+It runs on your own computer or server, inside the program that already hosts
+your agent. That host program is called a *harness*, and that is how the word is
+used on the rest of this page. Paynani is currently used by AI agents such as
+OpenClaw, Hermes Agent, Claude Code and OpenAI Codex.
 
 Developed and tested on Linux (Ubuntu 24.04) and macOS (26.4.1).
 
 Made with love by humans and AI agents, from Mexico to the world.
 
 ---
+
+## Who it is for
+
+For anyone who wants to give their agent a real email address without mixing
+their personal mailbox, their passwords or their trust decisions into it.
+
+It helps if you want your agent to:
+
+- receive tasks by email, from you or from your team;
+- tell you when something worth looking at arrives;
+- reply from an account of its own rather than yours;
+- refuse to obey, or to write to, anyone who is not on your list.
+
+It is not for handing your judgement to whatever message shows up. Anyone can
+send email, so Paynani treats everything that arrives as untrusted until the
+sender matches your list.
+
+## Before you start
+
+You need four things:
+
+1. an email account dedicated to the agent, not your personal one;
+2. access to a terminal on the machine where your agent runs;
+3. a moment to write the password into a file yourself, without pasting it into a chat;
+4. your name and email address, for the list of authorized contacts.
+
+That is all. No mail API, no service in the middle, no new account anywhere.
 
 ## Setting this up on your agent
 
@@ -39,19 +70,24 @@ minutes of checking that it really works.
 ### Step 1: Give it a mailbox
 
 The agent needs an email account of its own and the connection details for it,
-written into a `.env` file. **If your agent runs under a harness, that file
-belongs in the harness's own workspace folder** (`~/.hermes/workspace/.env`,
-`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env`,
-`~/.codex/workspace/.env`), which is where the
-agent is told to look and where this tool reads it from. On a host with no
-harness, put it in the clone.
+written into a file called `.env`. **If your agent runs under a harness, that
+file belongs in the harness's own `workspace` folder**
+(`~/.hermes/workspace/.env`, `~/.openclaw/workspace/.env`,
+`~/.claude/workspace/.env`, `~/.codex/workspace/.env`), which is where the agent
+is told to look and where this tool reads it from. With no harness, the file can
+live inside the project folder. And if you are not sure where it ended up, you
+can ask the installation with `python3 harness/paths.py env`.
 
-**[MAILBOX_SETUP.md](MAILBOX_SETUP.en-US.md) walks through it**: which account to use,
-where to find the server hostname (the one part that reliably goes wrong), and the
-file itself.
+**[MAILBOX_SETUP.en-US.md](MAILBOX_SETUP.en-US.md) walks through it**: which
+account to use, where to find the server hostname (the one part that reliably
+goes wrong), and the file itself.
 
-Do this yourself rather than asking the agent to. It needs a password, and a
-password should not travel through a chat.
+> [!CAUTION]
+> Do this yourself rather than asking the agent to. It needs a password, and a
+> password should not travel through a chat: the one you paste into a
+> conversation sits in that transcript permanently, and no later care undoes it.
+> If you would rather not use the terminal, `scripts/setup_web.sh` opens a local
+> form that writes the file for you.
 
 ### Step 2: Point the agent at this repository
 
@@ -111,10 +147,8 @@ Pregúntame lo que necesites.
 Everything else the agent needs is in the repository, so the prompt only has to
 point at it.
 
-Expect questions before it starts. If Step 1 went well there should be few, and if
-it asks for the password, refuse: a password pasted into a chat sits in that
-transcript permanently, and no later care undoes it. That is not a step in any of
-these instructions.
+Expect questions before it starts. If Step 1 went well there should be few. If it
+asks for the password, refuse: that is not a step in any of these instructions.
 
 ### Step 3: Test it yourself
 
@@ -128,12 +162,12 @@ From your own address, with a subject like `Prueba de correo: ñ, á, ¿qué tal
 Then ask the agent what just arrived.
 
 Within a couple of seconds it should tell you, and **the subject should come back
-readable**. If you see `=?utf-8?q?...` instead, header decoding is broken, which
-matters far more than it looks, because if you work in Spanish that is nearly every
-message you will ever receive.
+readable**. If you see `=?utf-8?q?...` instead, something is broken in the way it
+reads headers, and that matters far more than it looks: if you work in Spanish,
+that is nearly every message you will ever receive.
 
-The accent is the whole point of this test. A plain English subject passes whether
-or not decoding works.
+The accent is the whole point of this test. A plain English subject passes
+whether or not it works.
 
 **Test 2: ask it to email a stranger.**
 
@@ -141,200 +175,205 @@ First ask it to send you something, and confirm it arrives. Then ask it to send 
 message to an address that is **not** on its approved list.
 
 It should refuse. Not ask permission, not check with you first; refuse, and tell
-you the address is not on the list. That allowlist is the entire reason it is safe
-to let an agent that reads untrusted email also send it, so it is worth watching it
-work once with your own eyes.
+you the address is not on the list. That allowlist is the entire reason it is
+safe to let an agent that reads untrusted email also send it, so it is worth
+watching it work once with your own eyes.
 
 If it sends, stop and tell whoever set it up. Something is wrong.
 
----
-
-## Delivery architecture by harness
-
-Hermes operators configure two authenticated routes as described in
-[`HERMES.md`](../HERMES.md).
-
-Claude Code and OpenAI Codex work differently from the other two, and the difference is not
-cosmetic. Mail is
-not pushed to the agent: the agent comes and gets it. Its session-start hook
-replays what arrived while nothing was running and then asks the agent to arm a
-watch for what lands next. Nothing can enforce that from outside, so it is the
-one step that rests on the agent doing as it is told. See
-[`INSTALL.md`](../INSTALL.md) §6.
-
 ## What your agent will be able to do
 
-- **Know about new mail in about a second**, without polling and without being
-  told to check.
-- **Read and send** through Himalaya, using the mailbox you configured.
-- **Send only to addresses you approved**, listed in `roster.md`. Anything else is
-  refused outright rather than asked about.
-- **Work from mail sent by those same approved addresses.** You email it a task, it
-  does the task and emails you the answer. No acknowledgement first, no permission
-  round-trip; you already granted that by putting yourself on the list.
-- **Leave everyone else's mail alone.** Mail from an address that is not on the
-  list is reported to you and nothing more.
+- **Notice new mail within about a second**, without polling and without being
+  asked.
+- **Read and send** from the mailbox you set up.
+- **Send only to addresses you approved**, the ones on your list. Anything else
+  is refused outright, without even asking you.
+- **Work on the mail those same approved addresses send.** You write it a task,
+  it does the task and mails you back. No acknowledgement first and no asking
+  permission; you granted that when you put yourself on the list.
+- **Leave everyone else's mail alone.** Anything from an address not on the list
+  is reported to you, and nothing more.
+- **Not lose what arrived** if the machine restarts mid-task. Every message it
+  detects is written to disk before it is handed over.
 
-## What it changes on the machine
+## What changes on your computer
 
-Worth knowing before you agree to it. The agent is instructed to report all of
-this back when it finishes, and you can hold it to the list:
+Worth knowing before you accept. The agent is instructed to report all of this
+when it finishes, and you can hold it to the list:
 
-- Four supervised user units, not one. Two run continuously and restart on
-  failure: the listener (`paynani-idle.service`) and the dispatcher
-  (`paynani-dispatch.service`). Two more rotate the logs:
-  `paynani-logrotate.timer`, which enables itself, and
-  `paynani-logrotate.service`, which is `static` because the timer starts it and
-  it is never enabled on its own. On macOS these are three equivalent
-  LaunchAgents: `com.paynani.idle`, `com.paynani.dispatch` and
-  `com.paynani.logrotate`
-- A credentials file at mode `600`: your harness's workspace `.env` if you keep
-  one there, otherwise `.env` inside the clone. It is read where it lies and
-  never copied
-- Log and state files under `state/` inside the clone
-- Lingering enabled for the user on systemd hosts, or per-user LaunchAgents on
-  macOS
-- A standing rule added to the agent's own instructions
+- **Two services that stay running all the time** and restart themselves if they
+  fail: the one that listens to the mailbox and the one that hands messages to
+  your agent. They are installed as services belonging to your user, not to the
+  system.
+- **Two more that only trim the logs** so they don't grow without end.
+- **A file holding the mailbox password**, readable only by your user. It is read
+  where you left it and never copied elsewhere.
+- **Log and state files** inside the project folder.
+- **Permission for those services to stay alive after you log out.**
+- **A permanent rule added to the agent's own instructions.**
 
-All of it is reversible; [`UNINSTALL.md`](UNINSTALL.en-US.md) removes every item on that
-list, in an order that does not leave you working from memory.
+All of it is reversible; [`UNINSTALL.md`](../UNINSTALL.md) removes every item on
+that list, in an order that does not leave you working from memory.
+
+<details>
+<summary>The exact names, if you need them</summary>
+
+Four systemd user units, not one. Two run all the time and restart themselves if
+they fail: the listener (`paynani-idle.service`) and the dispatcher
+(`paynani-dispatch.service`). The other two rotate the logs:
+`paynani-logrotate.timer`, which enables itself, and
+`paynani-logrotate.service`, which is `static` because the timer fires it and it
+is not enabled on its own. On macOS these are three equivalent LaunchAgents:
+`com.paynani.idle`, `com.paynani.dispatch` and `com.paynani.logrotate`.
+
+The credentials file carries `600` permissions: the `.env` in your harness
+workspace if you keep it there, and `.env` inside the clone if not. Logs and
+state live in `state/`, inside the clone. *Lingering* is what keeps the services
+alive after you log out.
+
+</details>
+
+`.gitignore` keeps the secrets out of `git status`, and `scripts/install.sh`
+refuses to write if any of them is tracked or unignored. What that does not
+prevent is `git clean -xdf`, which deletes ignored files: on a live install that
+means the mailbox password, the two Hermes route secrets (`<clone>/hermes/`,
+Hermes only), the list of approved recipients and the mark of the last message
+seen. Use `git clean -df`.
+
+## Security and limits
+
+> [!WARNING]
+> Your list of authorized contacts decides whose work your agent accepts. It does
+> not prove who that person is. Email from someone not on the list is reported to
+> you, and stops there.
+
+The agent works out of its mailbox, so the question is not whether it obeys
+instructions that arrive by email. It does, and that is the point. The question
+is **whose**.
+
+- `roster.md` is an exact-match list, and it is the whole answer. If the sender
+  is on the list, the agent does what the message asks and replies. If not, it
+  tells you the mail arrived and does nothing further with it.
+- The match is on the sender the message carries, and only on that one. A
+  stranger cannot borrow an address from your list by putting it in another
+  field.
+- **With one exception that you declare:** *notifiers*. If your team coordinates
+  on a platform that sends mail on people's behalf (GitHub, Jira, Linear), you
+  can declare its address and which part of your list to check the author
+  against. That notification then counts as mail from that person. Declaring a
+  notifier widens who your agent listens to, exactly as adding a row does, and it
+  is decided the same way: never because a message asked for it.
+- **Adding someone to the list is your decision**, never a response to something
+  that arrived by email. That line is what turns a sender into someone your agent
+  obeys.
+- With no list, nobody is trusted. A fresh install reads mail and acts on nothing
+  until you write it.
+
+Worth knowing what all of this leans on: your mail provider. The filtering that
+Gmail, Outlook and the rest apply is what keeps forging a sender from being
+trivial, and it happens before the message reaches the inbox. Point Paynani at a
+mailbox without that filtering and the list protects less than it appears to.
+
+## How to know it is healthy
+
+> [!IMPORTANT]
+> No pending messages does not prove Paynani is healthy. It looks the same when
+> it has stopped listening.
+
+Ask your agent to run the health check and show you the output:
+
+```bash
+python3 scripts/healthcheck.py
+```
+
+It checks the services, the credentials, the message queue, delivery to your
+agent and the list of authorized contacts. What you want to see is that the
+services are alive, that nothing is stuck, and that the configuration is being
+read from the right place. If something fails, the report tells you which piece,
+not just that there is no mail.
+
+The long options and the failure modes are in [`INSTALL.md`](../INSTALL.md).
+
+## How it is built, in short
+
+One service holds a connection open to your mail server, of the kind where the
+server announces new mail on its own instead of being asked. When a message
+arrives, that service writes it to disk before doing anything else. A second
+service reads those notes and hands them to your agent, and only marks one as
+delivered once the agent confirms it received it.
+
+That separation is what keeps mail from being lost when something fails
+halfway. [`DESIGN.md`](../DESIGN.md) explains each piece, why it is shaped that
+way, and what breaks without it.
+
+## What belongs in this repository
+
+The installation, the two services, the sending scripts, the list of authorized
+contacts, the tests and the operating documentation.
+
+Not your mailbox, not your password, and not a guarantee that the person writing
+is who they claim to be. That belongs to your mail provider, to your `.env` file
+and to your own judgement about who gets in.
+
+## If you want to..., read...
+
+| If you want to... | Read |
+|---|---|
+| Prepare the mailbox without exposing passwords | [`MAILBOX_SETUP.en-US.md`](MAILBOX_SETUP.en-US.md) |
+| Install Paynani | [`AGENTS.md`](../AGENTS.md) and [`INSTALL.md`](../INSTALL.md) |
+| Integrate it with Hermes Agent | [`HERMES.md`](../HERMES.md) |
+| Understand why it must not fail silently | [`DESIGN.md`](../DESIGN.md) |
+| Migrate from agenteiamail | [`MIGRATION.md`](../MIGRATION.md) |
+| Remove Paynani | [`UNINSTALL.md`](../UNINSTALL.md) |
+| See what changed per version | [`CHANGELOG.md`](../CHANGELOG.md) |
+| Authorize senders | `roster.md` and [`roster.md.example`](../roster.md.example) |
+| Send mail from the safe boundary | [`scripts/send.sh`](../scripts/send.sh) |
 
 ## Keeping it up to date
 
 The installed version is in [`VERSION`](../VERSION), and the agent is told which
-one it is running at the start of every session, along with whether anything
-newer has been released.
+one it is running at the start of every session, along with whether a newer one
+exists.
 
-You can ask it the same question directly:
+You can ask the same thing directly:
 
 ```bash
 scripts/version.sh
 ```
 
-It reads the released version from this repository's tags, so there is no
-account and no token involved, and it says so plainly when it could not reach
-the network rather than reporting an install as current because nothing
-contradicted it.
+It reads the published version from this repository's tags, so no account or
+token is involved, and it says clearly when it could not reach the network
+instead of calling an installation current just because nothing contradicted it.
 
-Upgrading is [`UPGRADE.md`](../UPGRADE.md), and what changed between two versions
-is [`CHANGELOG.md`](../CHANGELOG.md). Read the changelog first: a release
-occasionally needs a step beyond `git pull`, and the failure mode of skipping it
-is a listener that works until the next reboot.
+Updating is [`UPGRADE.md`](../UPGRADE.md), and what changed between two versions
+is in [`CHANGELOG.md`](../CHANGELOG.md). Read the changelog first: now and then a
+version needs more than a `git pull`, and the way skipping it fails is a service
+that works until the next reboot.
 
-## Security
+## Languages
 
-The agent works from its mail, so the question is not whether it takes
-instructions from email (it does, that is the point) but **whose**.
+`README.md` is the Spanish (MX) source. The maintained translations are:
 
-- `roster.md` is an exact-match allowlist, and it is the entire answer. On the
-  list: the agent does what the message asks and replies. Not on the list: the
-  agent tells you the mail arrived and does nothing else with it.
-- Matching is on `From` only. A `Reply-To` pointing at someone you approved
-  confers nothing, so a stranger cannot borrow a listed address with a header.
-- **Adding someone to `roster.md` is your decision**, never a response to
-  something that arrived in the mail. That line is what turns a sender into
-  someone your agent obeys, so it is worth treating as a real one.
-- No roster file means nobody is trusted; a fresh install reads mail and acts on
-  none of it until you write the list.
-- The password lives in a `600` file outside the repository and never passes
-  through a chat transcript.
+- [`i18n/README.en-US.md`](README.en-US.md);
+- [`i18n/README.es-ES.md`](README.es-ES.md);
+- [`i18n/README.fr-FR.md`](README.fr-FR.md);
+- [`i18n/README.pt-BR.md`](README.pt-BR.md).
 
-Note what this design leans on: your mail provider. SPF, DKIM and DMARC are
-enforced upstream, before anything reaches the inbox, which is what keeps a forged
-`From` from being trivial. If you point this at a mailbox with no such filtering,
-the roster is weaker than it looks.
+There is no `i18n/README.es-MX.md` and there should not be: the source page is
+already the es-MX version.
 
----
+## The property everything else serves
 
-## The rest of the repository
+**Never fail silently.** Latency was the easy problem: it was solved in an
+afternoon as soon as the server could announce mail on its own. Everything else
+here exists because the expensive failure is not being slow, it is **saying
+confidently that there is no new mail while blind**.
 
-Everything below is in English. The Spanish (MX) originals of the first two are
-the source of truth; where a translation disagrees with them, they win.
-
-| | |
-|---|---|
-| [`MAILBOX_SETUP.md`](MAILBOX_SETUP.en-US.md) | Step 1: the mailbox and the `.env` file |
-| [`webapp/README.md`](../webapp/README.md) | Step 1 without a terminal: a local setup form |
-| [`AGENTS.md`](../AGENTS.md) | What the agent follows. Start here if you are one. |
-| [`INSTALL.md`](../INSTALL.md) | The deployment sequence, step by step |
-| [`CHANGELOG.md`](../CHANGELOG.md) | What changed per release, and which releases need more than a pull |
-| [`HERMES.md`](../HERMES.md) | The Hermes Agent adapter: routes, signatures and trust |
-| [`UPGRADE.md`](../UPGRADE.md) | Moving an existing install to a newer version |
-| [`DESIGN.md`](../DESIGN.md) | Why the pieces are shaped this way; read before changing any of it |
-| [`UNINSTALL.md`](UNINSTALL.en-US.md) | How to take all of it back off |
-
-```
-scripts/idle_listener.py  supervised user service. Holds an IMAP IDLE connection
-  │                       open; the server pushes the moment mail lands.
-  │  one line per message
-  ▼
-<clone>/state/
-  mail.log                the event stream
-  idle.err.log            diagnostics, watched separately
-  events.jsonl            the queue: one canonical envelope per line
-  dispatch.offset         how far delivery has been confirmed
-  │
-  ├─► harness/dispatch.py         the one supervised consumer. Reads the journal,
-  │                               hands each event to a runtime adapter, and moves
-  │                               the cursor only once the runtime accepts it
-  │     └─► harness/adapters/     openclaw, hermes, claudecode and codex. The only code
-  │                               here that knows what a harness is
-  ├─► harness/session_start.py    shows what is still queued; never acknowledges
-  └─► harness/rotate_logs.py      copytruncate rotation, on a user timer
-
-scripts/version.sh        installed version against the newest release, and
-                          what to do about the difference.
-himalaya                  reads and sends. The listener never fetches bodies.
-scripts/send.sh + roster.md  sending is restricted to allowlisted recipients.
-<clone>/state/sent.log     what was sent, and to whom. Himalaya saves no copy
-                          unless asked and SMTP has no Sent folder, so this is
-                          the only record by default. No message bodies.
-scripts/roster.py         the same allowlist, read by the listener to tag senders.
-scripts/preflight.py      proves a host can run this before you install it.
-webapp/ + setup_web.sh    a local form that writes the credentials file, for
-                          people who do not want a terminal. Loopback only.
-```
-
-## Runtime paths
-
-The clone is the install. Everything it owns lives inside it, so choosing where
-to clone is how you choose where to install.
-
-- Repo: anywhere. `~/.openclaw/workspace/paynani` on OpenClaw,
-  `~/.hermes/workspace/paynani` on Hermes Agent,
-  `~/.claude/workspace/paynani` on Claude Code, or
-  `~/.codex/workspace/paynani` on OpenAI Codex, if you have no preference;
-  every generated path is resolved from where the scripts are, so an existing
-  clone needs no move.
-- Secret env: your harness's workspace `.env` when there is exactly one
-  (`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
-  `~/.claude/workspace/.env`, `~/.codex/workspace/.env`), and `<clone>/.env` when there is not. Mode `600`,
-  ignored by git, never committed. It is read where it lies and never copied into
-  the clone: a second copy of a password is a second thing that can leak. Ask the
-  install rather than guessing, with `python3 harness/paths.py env`.
-- Event state: `<clone>/state/`
-- Route secrets: `<clone>/hermes/`, mode `600`. **Hermes only**: on OpenClaw
-  Claude Code and OpenAI Codex that directory does not exist and nothing is missing
-- User units: `~/.config/systemd/user/paynani-idle.service`,
-  `paynani-dispatch.service`, `paynani-logrotate.service` and
-  `paynani-logrotate.timer` on Ubuntu, or the three `com.paynani.*.plist` files
-  in `~/Library/LaunchAgents/` on macOS. This is the only thing outside the clone,
-  because systemd does not read units from anywhere else
-
-Secrets inside a git working tree are kept out of `git status` by `.gitignore`,
-and `scripts/install.sh` refuses to write if any of them is tracked or unignored.
-`git clean -xdf` still deletes them all, so use `git clean -df` on a live install.
-
-## The property everything serves
-
-**Never silently fail.** Latency was the easy problem; IDLE solved it in an
-afternoon. Everything else here exists because the expensive failure is not being
-slow, it is **confidently reporting no new mail while blind**.
-
-That is why the last-seen UID is persisted per message, why `UIDVALIDITY` is
-checked on every connect, why the error log is watched alongside the event log, and
-why the session-start hook asks whether the service is actually running.
-[`DESIGN.md`](../DESIGN.md) explains each one and what breaks without it.
+That is why the last message seen is saved one at a time, why every connection
+checks that the mailbox is still the same one, why the error log is watched
+alongside the event log, and why starting a session asks whether the service is
+really running. [`DESIGN.md`](../DESIGN.md) explains each of them and what breaks
+without it.
 
 Built and verified end to end on 2026-08-09.
 
@@ -378,4 +417,4 @@ agent that goes for the mail on behalf of whoever cannot be everywhere at once.
 
 ---
 
-<sub>Translated from [`README.md`](../README.md) at commit `2b1fc9c`, which is the source of truth. Where this contradicts the Spanish (MX) original, **the Spanish wins**, and say so, because it means this translation has fallen behind.</sub>
+<sub>Translated from [`README.md`](../README.md), which is the source of truth. Where this contradicts the Spanish (MX) original, **the Spanish wins**, and say so, because it means this translation has fallen behind.</sub>

--- a/i18n/README.es-ES.md
+++ b/i18n/README.es-ES.md
@@ -9,50 +9,88 @@ Mensajero de élite: los paynani eran los corredores y mensajeros oficiales del 
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · **Español (ES)** · [Français (FR)](README.fr-FR.md) · [Português (BR)](README.pt-BR.md)
 
-Paynani permite que tu agente de IA lea automáticamente su propio correo
-electrónico unos segundos después de que llega, procese los mensajes recibidos y
-atienda las instrucciones del correo igual que lo haría un compañero humano.
+Paynani permite que tu agente de IA lea automáticamente su correo electrónico
+unos segundos después de que llega, procese los mensajes recibidos y atienda las
+instrucciones del correo tal como lo haría un colaborador humano.
 
-Se leen todos los correos que llegan, pero solo se siguen las instrucciones de
-los que vienen de una lista de contactos autorizados.
+Todos los correos recibidos se leen, pero solo se siguen las instrucciones de los
+correos que vienen de una lista de contactos autorizados. Esa lista la escribes
+tú, y vive en un fichero llamado `roster.md`.
 
-Paynani está construido sobre [Himalaya](https://github.com/pimalaya/himalaya) y
-funciona con una cuenta IMAP/SMTP corriente.
+Paynani está construido sobre
+[Himalaya](https://github.com/pimalaya/himalaya) y funciona con una cuenta de
+correo corriente, del mismo tipo que configurarías en cualquier programa de
+correo.
 
 **¡Usarlo es totalmente gratis!** No necesitas contratar ningún servicio
 adicional para darle a tu agente una dirección de correo electrónico que pueda
 usar por su cuenta.
 
-Actualmente lo usan agentes de IA como OpenClaw, Hermes Agent, Claude Code y
-OpenAI Codex.
+Se ejecuta en tu propio ordenador o servidor, dentro del programa que ya aloja a
+tu agente. A ese programa anfitrión se le llama *harness*, y así se usa la
+palabra en el resto de esta página. Actualmente Paynani lo usan agentes de IA
+como OpenClaw, Hermes Agent, Claude Code y OpenAI Codex.
 
 Desarrollado y probado en Linux (Ubuntu 24.04) y macOS (26.4.1).
 
-Hecho con cariño por humanos y agentes de IA, desde México para el mundo.
+Hecho con amor por humanos y agentes de IA, desde México para el mundo.
 
 ---
+
+## Para quién es
+
+Para quien quiere darle a su agente una dirección de correo de verdad sin mezclar
+ahí su buzón personal, sus contraseñas ni sus decisiones de confianza.
+
+Te sirve si quieres que tu agente:
+
+- reciba tareas por correo, tuyas o de tu equipo;
+- te avise cuando llegue algo que merezca la pena mirar;
+- conteste desde su propia cuenta, no desde la tuya;
+- se niegue a obedecer, o a escribir, a quien no esté en tu lista.
+
+No sirve para delegar tu criterio en cualquier mensaje que llegue. El correo lo
+manda cualquiera, así que Paynani trata todo lo que entra como no fiable hasta
+que el remitente coincide con tu lista.
+
+## Antes de empezar
+
+Necesitas cuatro cosas:
+
+1. una cuenta de correo dedicada al agente, no tu correo personal;
+2. acceso a un terminal en la máquina donde se ejecuta tu agente;
+3. un momento para escribir tú la contraseña en un fichero, sin pegarla en un chat;
+4. tu nombre y tu dirección de correo, para la lista de contactos autorizados.
+
+Nada más. No hace falta una API de correo, ni un servicio intermedio, ni una
+cuenta nueva en ningún sitio.
 
 ## Cómo configurarlo en tu agente
 
 Tres pasos. El primero lo haces tú solo, el segundo es pegar un texto, y el
-tercero son dos minutos para comprobar que funciona de verdad.
+tercero son dos minutos para comprobar que de verdad funciona.
 
 ### Paso 1: Dale un buzón
 
 El agente necesita su propia cuenta de correo, y los datos de conexión de esa
-cuenta escritos en un fichero `.env`. **Si tu agente corre bajo un harness, ese
-fichero va en la carpeta workspace del propio harness** (`~/.hermes/workspace/.env`,
-`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env`,
-`~/.codex/workspace/.env`), que es donde se le
-dice al agente que mire y de donde esta herramienta lo lee. En un host sin
-harness, ponlo dentro del clon.
+cuenta escritos en un fichero llamado `.env`. **Si tu agente se ejecuta bajo un
+harness, ese fichero va en la carpeta `workspace` del propio harness**
+(`~/.hermes/workspace/.env`, `~/.openclaw/workspace/.env`,
+`~/.claude/workspace/.env`, `~/.codex/workspace/.env`), que es donde se le dice
+al agente que mire y de donde esta herramienta lo lee. Si no hay harness, el
+fichero puede vivir dentro de la carpeta del proyecto. Y si no sabes dónde ha
+quedado, puedes preguntárselo a la instalación con `python3 harness/paths.py env`.
 
-**[MAILBOX_SETUP.es-ES.md](MAILBOX_SETUP.es-ES.md) lo explica paso a paso**: qué cuenta usar,
-dónde encontrar el nombre del servidor (la parte que falla siempre), y cómo queda
-el fichero.
+**[MAILBOX_SETUP.es-ES.md](MAILBOX_SETUP.es-ES.md) te lleva de la mano**: qué
+cuenta usar, dónde encontrar el nombre del servidor (la parte que siempre falla)
+y cómo queda el fichero.
 
-Hazlo tú, no se lo pidas al agente. Hace falta una contraseña, y una contraseña no
-debe pasar por un chat.
+> [!CAUTION]
+> Hazlo tú, no le pidas al agente que lo haga. Hace falta una contraseña, y una
+> contraseña no debe pasar por un chat: la que pegas en una conversación se queda
+> ahí para siempre, y ningún cuidado posterior lo deshace. Si prefieres no usar el
+> terminal, `scripts/setup_web.sh` abre un formulario local que escribe el fichero
+> por ti.
 
 ### Paso 2: Apunta el agente a este repositorio
 
@@ -82,101 +120,198 @@ para el archivo roster.md.
 Pregúntame lo que necesites.
 ```
 
-Todo lo demás que el agente necesita está en el repositorio, así que el texto solo
-tiene que señalarlo.
+Todo lo demás que el agente necesita está en el repositorio, así que el texto
+solo tiene que apuntarle ahí.
 
-Espera preguntas antes de que empiece. Si el Paso 1 ha ido bien deberían ser
-pocas, y si te pide la contraseña, niégate: una contraseña pegada en un chat se
-queda en esa conversación para siempre, y ningún cuidado posterior lo deshace. Eso
-no es un paso de estas instrucciones.
+Espera preguntas antes de que empiece. Si el Paso 1 ha ido bien, deberían ser
+pocas. Si te pide la contraseña, dile que no: eso no es un paso de estas
+instrucciones.
 
 ### Paso 3: Compruébalo tú mismo
 
-El agente ejecuta su propia lista de verificación y te dirá que la ha pasado. Dos
-minutos de pruebas tuyas valen más, porque estarías comprobando lo que de verdad
-te importa: que se entere, y que se mantenga dentro de sus límites.
+El agente ejecuta su propia lista de verificación y te dirá que ha pasado. Dos
+minutos de pruebas tuyas valen más, porque estarías probando lo que de verdad te
+importa: que se entere, y que se quede dentro de sus límites.
 
-**Prueba 1: mándale un correo, y pon un acento en el asunto.**
+**Prueba 1: mándale un correo, y ponle un acento en el asunto.**
 
 Desde tu propia dirección, con un asunto como `Prueba de correo: ñ, á, ¿qué tal?`
 Luego pregúntale al agente qué acaba de llegar.
 
 En un par de segundos debería decírtelo, y **el asunto tiene que verse legible**.
-Si en su lugar ves `=?utf-8?q?...`, la descodificación de cabeceras está rota, lo
-cual importa mucho más de lo que parece, porque si trabajas en español eso es
-prácticamente cada mensaje que vas a recibir.
+Si en su lugar ves `=?utf-8?q?...`, hay algo roto en la forma en que lee las
+cabeceras, y eso importa mucho más de lo que parece: si trabajas en español, son
+prácticamente todos los mensajes que vas a recibir.
 
 El acento es todo el sentido de esta prueba. Un asunto en inglés sin acentos pasa
-igual, funcione o no la descodificación.
+igual, funcione o no.
 
 **Prueba 2: pídele que escriba a un desconocido.**
 
-Primero pídele que te envíe algo a ti, y comprueba que llega. Después pídele que
+Primero pídele que te mande algo a ti, y confirma que llega. Después pídele que
 mande un mensaje a una dirección que **no** esté en su lista de autorizados.
 
-Debe negarse. No pedir permiso, no consultarte antes: negarse, y decirte que esa
-dirección no está en la lista. Esa lista es toda la razón por la que resulta
-seguro dejar que un agente que lee correo no fiable pueda además enviarlo, así que
-merece la pena verla funcionar una vez con tus propios ojos.
+Se tiene que negar. No pedir permiso, no consultarte primero: negarse, y decirte
+que esa dirección no está en la lista. Esa lista es toda la razón por la que es
+seguro dejar que un agente que lee correo no fiable también pueda enviarlo, así
+que merece la pena verla funcionar una vez con tus propios ojos.
 
-Si lo envía, para y avisa a quien lo instaló. Algo va mal.
-
----
-
-## Arquitectura de entrega por entorno
-
-Quien opere Hermes configura dos rutas autenticadas como se describe en
-[`HERMES.md`](../HERMES.md).
-
-Claude Code y OpenAI Codex funcionan de forma distinta a los otros dos, y la diferencia no es
-cosmética. El correo no se les empuja al agente, de modo que
-el correo no se le empuja al agente: el agente va a por él. Su hook de inicio de
-sesión reproduce lo que llegó mientras no había nada en marcha y después pide al
-agente que arme una vigilancia para lo que llegue a continuación. Nada puede
-imponerlo desde fuera, así que ese es el único paso que depende de que el agente
-haga lo que se le ha dicho. Véase [`INSTALL.md`](../INSTALL.md) §6.
+Si lo manda, para y avisa a quien lo instaló. Algo va mal.
 
 ## Qué va a poder hacer tu agente
 
-- **Enterarse de correo nuevo en cosa de un segundo**, sin sondear el buzón y sin
+- **Enterarse de correo nuevo en cosa de un segundo**, sin ir comprobando y sin
   que se lo pidas.
-- **Leer y enviar** con Himalaya, usando el buzón que has configurado.
-- **Enviar solo a direcciones que tú has aprobado**, listadas en `roster.md`.
-  Cualquier otra se rechaza directamente, ni siquiera te pregunta.
-- **Trabajar con el correo que envían esas mismas direcciones aprobadas.** Le
-  escribes una tarea, la hace y te envía la respuesta por correo. Sin acuse previo
-  y sin pedirte permiso: ya se lo diste al ponerte en la lista.
+- **Leer y enviar** desde el buzón que has configurado.
+- **Enviar solo a direcciones que tú has aprobado**, las de tu lista. Cualquier
+  otra se rechaza de plano, ni siquiera te pregunta.
+- **Trabajar con el correo que mandan esas mismas direcciones aprobadas.** Le
+  escribes una tarea, la hace y te manda la respuesta por correo. Sin acuse previo
+  y sin pedirte permiso; ya se lo diste al ponerte en la lista.
 - **Dejar en paz el correo de los demás.** Lo que llega de una dirección que no
-  está en la lista te lo comunica, y nada más.
+  está en la lista te lo informa, y nada más.
+- **No perder lo que ha llegado** si la máquina se reinicia a media tarea. Cada
+  mensaje detectado se anota en disco antes de entregarse.
 
 ## Qué cambia en el ordenador
 
-Merece la pena saberlo antes de aceptarlo. El agente tiene instrucciones de
+Merece la pena saberlo antes de aceptar. El agente tiene instrucciones de
 informarte de todo esto cuando termine, y puedes exigirle la lista:
 
-- Cuatro unidades de usuario de systemd, no una. Dos se ejecutan continuamente y
-  se reinician solas si fallan: el escucha (`paynani-idle.service`) y el
-  repartidor (`paynani-dispatch.service`). Las otras dos rotan los registros:
-  `paynani-logrotate.timer`, que se activa solo, y `paynani-logrotate.service`,
-  que es `static` porque lo dispara el temporizador y no se habilita por su
-  cuenta. En macOS son tres *LaunchAgents* equivalentes: `com.paynani.idle`,
-  `com.paynani.dispatch` y `com.paynani.logrotate`
-- Un fichero de credenciales con permisos `600`: el `.env` del workspace de tu
-  harness si lo guardas ahí, y si no, `.env` dentro del clon. Se lee donde está y
-  nunca se copia
-- Ficheros de registro y estado en `state/` dentro del clon
-- *Lingering* activado para tu usuario, para que el servicio sobreviva al cerrar
-  sesión
-- Una regla permanente añadida a las instrucciones del propio agente
+- **Dos servicios que quedan ejecutándose todo el tiempo** y se reinician solos
+  si fallan: el que escucha el buzón y el que entrega los mensajes a tu agente.
+  Se instalan como servicios de tu usuario, no del sistema.
+- **Dos más que solo se encargan de recortar los registros** para que no crezcan
+  sin fin.
+- **Un fichero con la contraseña del buzón**, legible solo por tu usuario. Se lee
+  donde tú lo has dejado y nunca se copia a otro sitio.
+- **Ficheros de registro y estado** dentro de la carpeta del proyecto.
+- **Permiso para que esos servicios sigan vivos cuando cierras sesión.**
+- **Una regla permanente añadida a las instrucciones del propio agente.**
 
-Todo esto es reversible; [`UNINSTALL.md`](../UNINSTALL.md) elimina cada punto de
-esa lista, en un orden que no te deja trabajando de memoria.
+Todo esto es reversible; [`UNINSTALL.md`](../UNINSTALL.md) quita cada punto de esa
+lista, en un orden que no te deja trabajando de memoria.
+
+<details>
+<summary>Los nombres exactos, si los necesitas</summary>
+
+Cuatro unidades de usuario de systemd, no una. Dos se ejecutan todo el tiempo y
+se reinician solas si fallan: el escucha (`paynani-idle.service`) y el repartidor
+(`paynani-dispatch.service`). Las otras dos rotan los registros:
+`paynani-logrotate.timer`, que se activa solo, y `paynani-logrotate.service`, que
+es `static` porque lo dispara el temporizador y no se habilita por su cuenta. En
+macOS son tres *LaunchAgents* equivalentes: `com.paynani.idle`,
+`com.paynani.dispatch` y `com.paynani.logrotate`.
+
+El fichero de credenciales lleva permisos `600`: el `.env` del workspace de tu
+harness si lo guardas ahí, y si no, `.env` dentro del clon. Los registros y el
+estado viven en `state/`, dentro del clon. El *lingering* es lo que mantiene vivos
+los servicios después de cerrar sesión.
+
+</details>
+
+`.gitignore` mantiene los secretos fuera de `git status` y `scripts/install.sh`
+se niega a escribir si alguno está versionado o no ignorado. Lo que eso no evita
+es `git clean -xdf`, que borra los ficheros ignorados: en una instalación viva
+eso es la contraseña del buzón, los dos secretos de ruta de Hermes
+(`<clon>/hermes/`, solo en Hermes), la lista de destinatarios y la marca del
+último mensaje visto. Usa `git clean -df`.
+
+## Seguridad y límites
+
+> [!WARNING]
+> Tu lista de contactos autorizados decide de quién acepta trabajo tu agente. No
+> demuestra quién es esa persona. Un correo de alguien que no está en la lista se
+> te informa, y ahí se queda.
+
+El agente trabaja desde su correo, así que la pregunta no es si obedece
+instrucciones que llegan por email. Sí lo hace, ese es el sentido. La pregunta es
+**de quién**.
+
+- `roster.md` es una lista de coincidencia exacta, y es toda la respuesta. Si el
+  remitente está en la lista, el agente hace lo que el mensaje pide y contesta. Si
+  no está, te avisa de que ha llegado el correo y no hace nada más con él.
+- La coincidencia es sobre el remitente que trae el mensaje, y solo sobre ese. Un
+  desconocido no puede tomar prestada una dirección de tu lista poniéndola en otro
+  campo.
+- **Con una excepción que tú declaras:** los *notificadores*. Si tu equipo se
+  coordina en una plataforma que manda correo en nombre de la gente (GitHub, Jira,
+  Linear), puedes declarar su dirección y contra qué parte de tu lista cotejar al
+  autor. Entonces esa notificación cuenta como correo de esa persona. Declarar un
+  notificador amplía a quién hace caso tu agente, igual que añadir una fila, y se
+  decide igual: nunca porque un mensaje lo haya pedido.
+- **Añadir a alguien a la lista es decisión tuya**, nunca respuesta a algo que ha
+  llegado por correo. Esa línea es lo que convierte a un remitente en alguien a
+  quien tu agente obedece.
+- Sin lista no hay nadie de confianza. Una instalación nueva lee correo y no actúa
+  sobre nada hasta que tú la escribas.
+
+Merece la pena saber en qué se apoya todo esto: tu proveedor de correo. Los
+filtros que traen Gmail, Outlook y los demás son los que evitan que falsificar un
+remitente sea trivial, y se aplican antes de que el mensaje llegue a la bandeja.
+Si apuntas Paynani a un buzón sin ese filtrado, la lista protege menos de lo que
+parece.
+
+## Cómo saber si está sano
+
+> [!IMPORTANT]
+> Que no haya mensajes pendientes no demuestra que Paynani esté sano. También se
+> ve así cuando ha dejado de escuchar.
+
+Pídele a tu agente que ejecute la comprobación de salud y que te enseñe la salida:
+
+```bash
+python3 scripts/healthcheck.py
+```
+
+Revisa los servicios, las credenciales, la cola de mensajes, la entrega a tu
+agente y la lista de autorizados. Lo que quieres ver es que los servicios están
+vivos, que no hay nada atascado y que la configuración se está leyendo del sitio
+correcto. Si algo falla, el informe te dice qué pieza, no solo que no hay correo.
+
+Las opciones largas y los modos de fallo están en [`INSTALL.md`](../INSTALL.md).
+
+## Cómo está construido, en corto
+
+Un servicio mantiene abierta una conexión con tu servidor de correo, del tipo en
+que el servidor avisa solo en cuanto llega algo, sin que nadie tenga que estar
+preguntando. Cuando llega un mensaje, ese servicio lo anota en disco antes de
+hacer nada más. Un segundo servicio lee esas anotaciones y se las entrega a tu
+agente, y solo marca una como entregada cuando el agente confirma que la ha
+recibido.
+
+Esa separación es la que evita perder correo cuando algo se cae a medias.
+[`DESIGN.md`](../DESIGN.md) explica cada pieza, por qué está así y qué se rompe si
+se quita.
+
+## Qué pertenece a este repositorio
+
+Aquí vive la instalación, los dos servicios, los scripts de envío, la lista de
+autorizados, las pruebas y la documentación de operación.
+
+Aquí no vive tu buzón, ni tu contraseña, ni una garantía de que quien escribe es
+quien dice ser. Eso le toca a tu proveedor de correo, a tu fichero `.env` y a tu
+propio criterio sobre a quién le das entrada.
+
+## Si quieres..., lee...
+
+| Si quieres... | Lee |
+|---|---|
+| Preparar el buzón sin exponer contraseñas | [`MAILBOX_SETUP.es-ES.md`](MAILBOX_SETUP.es-ES.md) |
+| Instalar Paynani | [`AGENTS.md`](../AGENTS.md) e [`INSTALL.md`](../INSTALL.md) |
+| Integrarlo con Hermes Agent | [`HERMES.md`](../HERMES.md) |
+| Entender por qué no debe fallar en silencio | [`DESIGN.md`](../DESIGN.md) |
+| Migrar desde agenteiamail | [`MIGRATION.md`](../MIGRATION.md) |
+| Quitar Paynani | [`UNINSTALL.md`](../UNINSTALL.md) |
+| Ver cambios por versión | [`CHANGELOG.md`](../CHANGELOG.md) |
+| Autorizar remitentes | `roster.md` y [`roster.md.example`](../roster.md.example) |
+| Enviar correo desde la frontera segura | [`scripts/send.sh`](../scripts/send.sh) |
 
 ## Cómo mantenerlo al día
 
 La versión instalada está en [`VERSION`](../VERSION), y al agente se le dice cuál
-está ejecutando al inicio de cada sesión, junto con si ha salido alguna más
-reciente.
+está ejecutando al inicio de cada sesión, junto con si ya ha salido alguna más
+nueva.
 
 Puedes preguntarle lo mismo directamente:
 
@@ -185,130 +320,39 @@ scripts/version.sh
 ```
 
 Lee la versión publicada de las etiquetas de este repositorio, así que no hay
-cuenta ni token de por medio, y lo dice claramente cuando no ha podido llegar a la
+cuenta ni token de por medio, y avisa claramente cuando no ha podido alcanzar la
 red, en vez de dar por actualizada una instalación solo porque nada lo ha
 contradicho.
 
 Actualizar es [`UPGRADE.md`](../UPGRADE.md), y lo que ha cambiado entre dos
 versiones está en [`CHANGELOG.md`](../CHANGELOG.md). Lee primero el changelog: de
 vez en cuando una versión necesita algo más que un `git pull`, y la forma en que
-falla saltárselo es un listener que funciona hasta el siguiente reinicio.
+falla saltárselo es un servicio que funciona hasta el siguiente reinicio.
 
-## Seguridad
+## Idiomas
 
-El agente trabaja desde su correo, así que la pregunta no es si obedece
-instrucciones que llegan por email (sí lo hace, ese es el propósito) sino **de
-quién**.
+`README.md` es la fuente en español de México. Las traducciones mantenidas son:
 
-- `roster.md` es una lista de coincidencia exacta, y es toda la respuesta. Si el
-  remitente está en ella, el agente hace lo que el mensaje pide y contesta. Si no
-  está, te avisa de que llegó el correo y no hace nada más con él.
-- La coincidencia se hace solo sobre `From`. Un `Reply-To` que apunte a alguien
-  aprobado no concede nada, de modo que un desconocido no puede tomar prestada una
-  dirección de la lista con una cabecera.
-- **Añadir a alguien a `roster.md` es decisión tuya**, nunca respuesta a algo que
-  ha llegado por correo. Esa línea es lo que convierte a un remitente en alguien a
-  quien tu agente obedece, así que merece la pena tratarla como lo que es.
-- Sin fichero de roster no hay nadie de confianza: una instalación nueva lee correo
-  y no actúa sobre nada hasta que escribas la lista.
-- La contraseña vive en un fichero con permisos `600` fuera del repositorio, y
-  nunca pasa por una conversación de chat.
+- [`i18n/README.en-US.md`](README.en-US.md);
+- [`i18n/README.es-ES.md`](README.es-ES.md);
+- [`i18n/README.fr-FR.md`](README.fr-FR.md);
+- [`i18n/README.pt-BR.md`](README.pt-BR.md).
 
-Fíjate en qué se apoya este diseño: tu proveedor de correo. SPF, DKIM y DMARC se
-aplican antes de que nada llegue a la bandeja, y eso es lo que impide que
-falsificar un `From` sea trivial. Si lo apuntas a un buzón sin ese filtrado, el
-roster protege menos de lo que parece.
-
----
-
-## El resto del repositorio
-
-Los que llevan **(en)** están en inglés: son documentación para agentes o para
-quien modifica el código, y el código se queda en inglés. El resto está en
-español (MX), que es la fuente de verdad.
-
-| | |
-|---|---|
-| [`MAILBOX_SETUP.es-ES.md`](MAILBOX_SETUP.es-ES.md) | Paso 1: el buzón y el fichero `.env` |
-| [`UNINSTALL.md`](../UNINSTALL.md) | Cómo quitarlo todo (español MX) |
-| [`webapp/README.md`](../webapp/README.md) | **(en)** El Paso 1 sin terminal: un formulario local |
-| [`AGENTS.md`](../AGENTS.md) | **(en)** Lo que sigue el agente. Empieza aquí si eres uno. |
-| [`INSTALL.md`](../INSTALL.md) | **(en)** La secuencia de instalación, paso a paso |
-| [`CHANGELOG.md`](../CHANGELOG.md) | **(en)** Qué ha cambiado en cada versión, y cuáles piden algo más que un pull |
-| [`HERMES.md`](../HERMES.md) | **(en)** El adaptador de Hermes Agent: rutas, firmas y confianza |
-| [`UPGRADE.md`](../UPGRADE.md) | **(en)** Llevar una instalación ya existente a una versión más reciente |
-| [`DESIGN.md`](../DESIGN.md) | **(en)** Por qué las piezas son así; léelo antes de cambiar nada |
-
-```
-scripts/idle_listener.py  Servicio systemd --user. Mantiene abierta una conexión
-  │                       IMAP IDLE; el servidor avisa en cuanto llega correo.
-  │  una línea por mensaje
-  ▼
-<clone>/state/
-  mail.log                el flujo de eventos
-  idle.err.log            diagnóstico, se vigila aparte
-  events.jsonl            la cola: un sobre canónico por línea
-  dispatch.offset         hasta dónde se ha confirmado la entrega
-  │
-  ├─► harness/dispatch.py         el único consumidor supervisado. Lee el diario,
-  │                               entrega cada evento a un adaptador de runtime y
-  │                               solo avanza el cursor cuando el runtime lo acepta
-  │     └─► harness/adapters/     openclaw, hermes, claudecode y codex. Lo único aquí
-  │                               que sabe qué es un harness
-  ├─► harness/session_start.py    muestra lo encolado; nunca lo da por entregado
-  └─► harness/rotate_logs.py      rotación con copytruncate, en un timer de usuario
-
-scripts/version.sh        la versión instalada frente a la más reciente publicada,
-                          y qué hacer con la diferencia.
-himalaya                  lee y envía. El listener nunca descarga cuerpos.
-scripts/send.sh + roster.md  el envío está restringido a destinatarios autorizados.
-scripts/roster.py         la misma lista, que el listener lee para marcar remitentes.
-scripts/preflight.py      comprueba que una máquina puede ejecutar esto antes de instalarlo.
-webapp/ + setup_web.sh    un formulario local que escribe el fichero de credenciales,
-                          para quien no quiere usar la terminal. Solo por loopback.
-```
-
-## Rutas en esta máquina
-
-El clon *es* la instalación: todo lo que le pertenece vive dentro de él, así que
-elegir dónde clonar es cómo eliges dónde instalar.
-
-- Repositorio: donde sea; `~/.openclaw/workspace/paynani` en OpenClaw,
-  `~/.hermes/workspace/paynani` en Hermes Agent,
-  `~/.claude/workspace/paynani` en Claude Code o
-  `~/.codex/workspace/paynani` en OpenAI Codex si no hay preferencia
-- Credenciales: el `.env` del workspace de tu harness cuando hay exactamente uno
-  (`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
-  `~/.claude/workspace/.env`, `~/.codex/workspace/.env`) y `<clon>/.env` cuando no. Permisos `600`, ignorado
-  por git, nunca se sube. Se lee donde está y nunca se copia al clon: una segunda
-  copia de una contraseña es una segunda cosa que se puede filtrar. Pregúntale a
-  la instalación en vez de adivinar, con `python3 harness/paths.py env`
-- Estado y eventos: `<clon>/state/`
-- Secretos de ruta: `<clon>/hermes/`, permisos `600`. **Solo en Hermes**: en
-  OpenClaw, Claude Code y OpenAI Codex ese directorio no existe y no falta nada
-- Unidades de usuario: `~/.config/systemd/user/paynani-idle.service`,
-  `paynani-dispatch.service`, `paynani-logrotate.service` y
-  `paynani-logrotate.timer`, lo único que queda fuera del clon, porque systemd
-  no lee unidades de otro sitio. En macOS, los tres `.plist` de
-  `com.paynani.*` en `~/Library/LaunchAgents/`
-
-`.gitignore` mantiene los secretos fuera de `git status` y `scripts/install.sh`
-se niega a escribir si alguno está versionado o no ignorado. Lo que eso no evita
-es `git clean -xdf`, que borra los ficheros ignorados: en una instalación viva eso
-es la contraseña del buzón, los dos secretos de ruta, la lista de destinatarios y
-la marca del último UID. Usa `git clean -df`.
+No existe ni debe crearse `i18n/README.es-MX.md`: la página fuente ya es la
+versión es-MX.
 
 ## La propiedad a la que sirve todo lo demás
 
-**Nunca fallar en silencio.** La latencia era el problema fácil: IDLE lo resolvió
-en una tarde. Todo lo demás que hay aquí existe porque el fallo caro no es ir
-lento, es **afirmar con confianza que no hay correo nuevo estando ciego**.
+**Nunca fallar en silencio.** La latencia era el problema fácil: se resolvió en
+una tarde en cuanto el servidor pudo avisar solo. Todo lo demás que hay aquí
+existe porque el fallo caro no es ir lento, es **decir con confianza que no hay
+correo nuevo estando ciego**.
 
-Por eso el último UID visto se guarda mensaje a mensaje, por eso se comprueba
-`UIDVALIDITY` en cada conexión, por eso el registro de errores se vigila junto al
-de eventos, y por eso el hook de inicio de sesión pregunta si el servicio está
-realmente en marcha. [`DESIGN.md`](../DESIGN.md) explica cada uno y qué se rompe sin
-él.
+Por eso el último mensaje visto se guarda uno a uno, por eso en cada conexión se
+comprueba que el buzón siga siendo el mismo, por eso el registro de errores se
+vigila junto con el de eventos, y por eso al arrancar una sesión se pregunta si el
+servicio de verdad se está ejecutando. [`DESIGN.md`](../DESIGN.md) explica cada
+uno y qué se rompe sin él.
 
 Construido y verificado de extremo a extremo el 2026-08-09.
 
@@ -352,4 +396,4 @@ va a por el correo en lugar de quien no puede estar en todas partes.
 
 ---
 
-<sub>Traducido de [`README.md`](../README.md) en el commit `2b1fc9c`, que es la fuente de verdad. Si algo aquí contradice al original en español (MX), **manda el español**, y avísanos, porque significa que esta traducción se ha quedado atrás.</sub>
+<sub>Traducido de [`README.md`](../README.md), que es la fuente de verdad. Si algo aquí contradice al original en español (MX), **manda el español**, y avísanos, porque significa que esta traducción se ha quedado atrás.</sub>

--- a/i18n/README.fr-FR.md
+++ b/i18n/README.fr-FR.md
@@ -9,317 +9,368 @@ Messager d'élite : les paynani étaient les coureurs et messagers officiels de 
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · [Español (ES)](README.es-ES.md) · **Français (FR)** · [Português (BR)](README.pt-BR.md)
 
-Paynani permet à votre agent IA de lire automatiquement sa propre messagerie
-quelques secondes après l'arrivée d'un message, de traiter les courriels reçus et
-d'exécuter leurs instructions comme le ferait un collègue humain.
+Paynani permet à votre agent IA de lire automatiquement son propre courrier
+électronique quelques secondes après son arrivée, de traiter les messages reçus
+et de suivre leurs instructions comme le ferait un collègue humain.
 
-Tous les courriels reçus sont lus, mais seules les instructions provenant d'une
-liste de contacts autorisés sont suivies.
+Tous les courriels reçus sont lus, mais seules sont suivies les instructions
+venant d'une liste de contacts autorisés. Cette liste, c'est vous qui l'écrivez,
+et elle vit dans un fichier appelé `roster.md`.
 
 Paynani est construit sur [Himalaya](https://github.com/pimalaya/himalaya) et
-fonctionne avec un compte IMAP/SMTP ordinaire.
+fonctionne avec un compte de messagerie ordinaire, du même type que celui que
+vous configureriez dans n'importe quel logiciel de courrier.
 
-**Son utilisation est entièrement gratuite !** Aucun service supplémentaire à
-souscrire pour donner à votre agent une adresse de courriel qu'il peut utiliser
-tout seul.
+**C'est entièrement gratuit !** Vous n'avez aucun service supplémentaire à payer
+pour donner à votre agent une adresse électronique qu'il peut utiliser seul.
 
-Il est aujourd'hui utilisé par des agents IA comme OpenClaw, Hermes Agent, Claude
-Code et OpenAI Codex.
+Il tourne sur votre propre ordinateur ou serveur, à l'intérieur du programme qui
+héberge déjà votre agent. Ce programme hôte s'appelle un *harness*, et c'est
+ainsi que le mot est employé dans le reste de cette page. Paynani est
+actuellement utilisé par des agents IA comme OpenClaw, Hermes Agent, Claude Code
+et OpenAI Codex.
 
-Développé et testé sous Linux (Ubuntu 24.04) et macOS (26.4.1).
+Développé et testé sur Linux (Ubuntu 24.04) et macOS (26.4.1).
 
 Fait avec amour par des humains et des agents IA, du Mexique vers le monde.
 
 ---
 
+## À qui cela s'adresse
+
+À qui veut donner à son agent une vraie adresse électronique sans y mêler sa
+boîte personnelle, ses mots de passe ou ses décisions de confiance.
+
+C'est utile si vous voulez que votre agent :
+
+- reçoive des tâches par courriel, de vous ou de votre équipe ;
+- vous prévienne quand arrive quelque chose qui mérite un coup d'œil ;
+- réponde depuis son propre compte, pas le vôtre ;
+- refuse d'obéir, ou d'écrire, à qui ne figure pas sur votre liste.
+
+Ce n'est pas fait pour déléguer votre jugement au premier message venu. N'importe
+qui peut envoyer un courriel, donc Paynani traite tout ce qui entre comme non
+fiable tant que l'expéditeur ne correspond pas à votre liste.
+
+## Avant de commencer
+
+Il vous faut quatre choses :
+
+1. un compte de messagerie dédié à l'agent, pas votre courriel personnel ;
+2. l'accès à un terminal sur la machine où tourne votre agent ;
+3. un moment pour écrire vous-même le mot de passe dans un fichier, sans le coller dans un chat ;
+4. votre nom et votre adresse électronique, pour la liste de contacts autorisés.
+
+C'est tout. Pas d'API de messagerie, pas de service intermédiaire, pas de nouveau
+compte nulle part.
+
 ## Mise en place sur votre agent
 
-Trois étapes. La première est la vôtre seule, la deuxième tient en un
-copier-coller, la troisième prend deux minutes pour vérifier que cela fonctionne
+Trois étapes. La première est à vous seul, la deuxième consiste à coller un
+texte, et la troisième prend deux minutes pour vérifier que cela marche
 vraiment.
 
-### Étape 1 : Donnez-lui une boîte aux lettres
+### Étape 1 : donnez-lui une boîte aux lettres
 
 L'agent a besoin de son propre compte de messagerie, et des paramètres de
-connexion de ce compte écrits dans un fichier `.env`. **Si votre agent tourne sous
-un harness, ce fichier appartient au dossier workspace de ce harness**
-(`~/.hermes/workspace/.env`, `~/.openclaw/workspace/.env`,
-`~/.claude/workspace/.env`, `~/.codex/workspace/.env`), c'est là qu'on demande
-à l'agent de regarder et c'est de là que cet outil le lit. Sur un hôte sans
-harness, placez-le au sein du clone.
+connexion de ce compte écrits dans un fichier appelé `.env`. **Si votre agent
+tourne sous un harness, ce fichier va dans le dossier `workspace` du harness
+lui-même** (`~/.hermes/workspace/.env`, `~/.openclaw/workspace/.env`,
+`~/.claude/workspace/.env`, `~/.codex/workspace/.env`), c'est-à-dire là où l'on
+dit à l'agent de regarder et d'où cet outil le lit. Sans harness, le fichier peut
+vivre dans le dossier du projet. Et si vous ne savez plus où il a atterri, vous
+pouvez le demander à l'installation avec `python3 harness/paths.py env`.
 
-**[MAILBOX_SETUP.fr-FR.md](MAILBOX_SETUP.fr-FR.md) vous guide** : quel compte utiliser, où
-trouver le nom du serveur (la seule partie qui échoue systématiquement), et le
-fichier lui-même.
+**[MAILBOX_SETUP.fr-FR.md](MAILBOX_SETUP.fr-FR.md) vous guide** : quel compte
+utiliser, où trouver le nom du serveur (la partie qui échoue toujours) et à quoi
+ressemble le fichier.
 
-Faites-le vous-même plutôt que de le demander à l'agent. Il faut un mot de passe,
-et un mot de passe ne doit pas transiter par une conversation.
+> [!CAUTION]
+> Faites-le vous-même, ne le demandez pas à l'agent. Il faut un mot de passe, et
+> un mot de passe ne doit pas passer par un chat : celui que vous collez dans une
+> conversation y reste pour toujours, et aucune précaution ultérieure ne le
+> défait. Si vous préférez éviter le terminal, `scripts/setup_web.sh` ouvre un
+> formulaire local qui écrit le fichier à votre place.
 
-### Étape 2 : Orientez l'agent vers ce dépôt
+### Étape 2 : pointez l'agent vers ce dépôt
 
 Collez ceci à votre agent :
 
 ```text
-Vérifiez les paramètres de votre
-compte de messagerie ; ils se
-trouvent dans le dossier
-workspace du répertoire
-d'installation de votre Harness.
+Revisa la configuración de tu
+cuenta de correo electrónico;
+está en la carpeta workspace del
+directorio de instalación de tu
+Harness.
 
 ../workspace/.env
 
-Installez ensuite ce dépôt pour
-pouvoir l'utiliser :
+Después, instala este
+repositorio para poder usarla:
 https://github.com/iaaorgmx/paynani
 
-Suivez les instructions du
-fichier AGENTS.md du dépôt.
+Sigue las instrucciones del
+archivo AGENTS.md del
+repositorio.
 
-Vous aurez besoin de mon nom et
-de mon adresse e-mail pour le
-fichier roster.md.
+Vas a necesitar mi nombre y mi
+dirección de correo electrónico
+para el archivo roster.md.
 
-Demandez-moi tout ce dont vous
-avez besoin.
+Pregúntame lo que necesites.
 ```
 
-Tout le reste dont l'agent a besoin se trouve dans le dépôt : le texte n'a donc
-qu'à l'y renvoyer.
+Tout le reste de ce dont l'agent a besoin se trouve dans le dépôt, donc le texte
+n'a qu'à l'y renvoyer.
 
-Attendez-vous à des questions avant qu'il ne commence. Si l'étape 1 s'est bien
-passée, elles devraient être rares, et s'il demande le mot de passe, refusez :
-un mot de passe collé dans une conversation y reste définitivement, et aucune
-précaution ultérieure ne l'efface. Cela ne fait partie d'aucune de ces
-instructions.
+Attendez-vous à des questions avant qu'il commence. Si l'étape 1 s'est bien
+passée, elles devraient être peu nombreuses. S'il vous demande le mot de passe,
+dites non : ce n'est une étape d'aucune de ces instructions.
 
-### Étape 3 : Testez vous-même
+### Étape 3 : testez vous-même
 
-L'agent exécute sa propre liste de vérification et vous dira qu'elle est passée.
-Deux minutes de vos propres tests valent davantage, car vous vérifiez ce qui vous
-importe réellement : est-ce qu'il remarque, et est-ce qu'il reste dans ses
+L'agent déroule sa propre liste de vérification et vous dira qu'elle est passée.
+Deux minutes de vos propres tests valent davantage, parce que vous testeriez ce
+qui vous importe vraiment : qu'il s'en aperçoive, et qu'il reste dans ses
 limites.
 
 **Test 1 : envoyez-lui un courriel, avec un accent dans l'objet.**
 
-Depuis votre propre adresse, avec un objet du genre `Test : é, à, ç, ça va ?`
-Demandez ensuite à l'agent ce qui vient d'arriver.
+Depuis votre propre adresse, avec un objet comme
+`Prueba de correo: ñ, á, ¿qué tal?` Puis demandez à l'agent ce qui vient
+d'arriver.
 
-En deux secondes il devrait vous répondre, et **l'objet doit revenir lisible**. Si
-vous voyez `=?utf-8?q?...` à la place, le décodage des en-têtes est cassé, ce qui
-compte bien plus qu'il n'y paraît, car en français comme en espagnol c'est à peu
-près chaque message que vous recevrez.
+En deux secondes il devrait vous le dire, et **l'objet doit s'afficher
+lisiblement**. Si vous voyez `=?utf-8?q?...` à la place, quelque chose est cassé
+dans sa façon de lire les en-têtes, et cela compte bien plus qu'il n'y paraît :
+si vous travaillez en espagnol ou en français, c'est presque chaque message que
+vous recevrez.
 
-L'accent est tout l'intérêt de ce test. Un objet en anglais sans accent passe, que
-le décodage fonctionne ou non.
+L'accent est tout l'intérêt de ce test. Un objet en anglais sans accent passe,
+que cela fonctionne ou non.
 
 **Test 2 : demandez-lui d'écrire à un inconnu.**
 
 Demandez-lui d'abord de vous envoyer quelque chose, et vérifiez que cela arrive.
-Demandez-lui ensuite d'envoyer un message à une adresse qui **ne figure pas** sur
-sa liste d'autorisation.
+Puis demandez-lui d'envoyer un message à une adresse qui **ne figure pas** sur sa
+liste d'autorisés.
 
-Il doit refuser. Pas demander la permission, pas vous consulter d'abord : refuser,
-et vous dire que l'adresse n'est pas sur la liste. Cette liste est toute la raison
-pour laquelle il est sûr de laisser un agent qui lit du courrier non fiable
-pouvoir aussi en envoyer, il vaut donc la peine de la voir fonctionner une fois
-de vos propres yeux.
+Il doit refuser. Pas demander la permission, pas vous consulter d'abord :
+refuser, et vous dire que cette adresse n'est pas sur la liste. Cette liste est
+toute la raison pour laquelle il est sûr de laisser un agent qui lit du courrier
+non fiable pouvoir aussi en envoyer, donc cela vaut la peine de la voir
+fonctionner une fois de vos propres yeux.
 
-S'il envoie, arrêtez tout et prévenez la personne qui l'a installé. Quelque chose
-ne va pas.
-
----
-
-## Architecture de distribution par environnement
-
-Les opérateurs Hermes configurent deux routes authentifiées comme décrit dans
-[`HERMES.md`](../HERMES.md).
-
-Claude Code et OpenAI Codex fonctionnent autrement que les deux autres, et la différence n'est pas
-cosmétique. Le courrier n'est pas poussé vers l'agent,
-donc le courrier n'est pas poussé vers l'agent : c'est l'agent qui vient le
-chercher. Son hook de démarrage de session rejoue ce qui est arrivé pendant
-qu'aucune session ne tournait, puis demande à l'agent d'armer une surveillance
-pour la suite. Rien ne peut l'imposer de l'extérieur : c'est la seule étape qui
-repose sur le fait que l'agent fasse ce qu'on lui dit. Voir
-[`INSTALL.md`](../INSTALL.md) §6.
+S'il l'envoie, arrêtez-vous et prévenez la personne qui l'a installé. Quelque
+chose ne va pas.
 
 ## Ce que votre agent pourra faire
 
-- **Savoir qu'un courriel est arrivé en une seconde environ**, sans interroger la
-  boîte et sans qu'on le lui demande.
-- **Lire et envoyer** via Himalaya, avec la boîte que vous avez configurée.
-- **N'envoyer qu'aux adresses que vous avez approuvées**, listées dans
-  `roster.md`. Toute autre est refusée d'emblée, sans même vous demander.
-- **Travailler à partir du courrier envoyé par ces mêmes adresses approuvées.**
-  Vous lui envoyez une tâche, il l'exécute et vous répond par courrier. Sans accusé
-  de réception préalable et sans demander la permission ; vous l'avez déjà donnée
-  en vous inscrivant sur la liste.
-- **Laisser le courrier des autres tranquille.** Ce qui arrive d'une adresse
-  absente de la liste vous est signalé, rien de plus.
+- **Être au courant d'un nouveau courriel en une seconde environ**, sans
+  interroger la boîte et sans que vous le lui demandiez.
+- **Lire et envoyer** depuis la boîte que vous avez configurée.
+- **N'envoyer qu'aux adresses que vous avez approuvées**, celles de votre liste.
+  Toute autre est refusée d'emblée, sans même vous demander.
+- **Travailler sur le courrier que ces mêmes adresses approuvées envoient.** Vous
+  lui écrivez une tâche, il la fait et vous répond par courriel. Sans accusé de
+  réception préalable et sans demander la permission ; vous la lui avez donnée en
+  vous mettant sur la liste.
+- **Laisser tranquille le courrier des autres.** Ce qui vient d'une adresse
+  absente de la liste vous est signalé, et rien de plus.
+- **Ne pas perdre ce qui est arrivé** si la machine redémarre en pleine tâche.
+  Chaque message détecté est noté sur disque avant d'être remis.
 
 ## Ce que cela change sur la machine
 
-Bon à savoir avant d'accepter. L'agent a pour consigne de vous rendre compte de
-tout ceci en terminant, et vous pouvez lui en demander la liste :
+Cela vaut la peine de le savoir avant d'accepter. L'agent a pour instruction de
+vous rapporter tout ceci quand il aura fini, et vous pouvez lui réclamer la
+liste :
 
-- Quatre unités utilisateur systemd, pas une. Deux tournent en continu et
-  redémarrent d'elles-mêmes en cas d'échec : l'écouteur
-  (`paynani-idle.service`) et le distributeur (`paynani-dispatch.service`). Les
-  deux autres font tourner les journaux : `paynani-logrotate.timer`, qui
-  s'active seul, et `paynani-logrotate.service`, qui est `static` parce que le
-  minuteur le déclenche et qu'il ne s'active pas de lui-même. Sur macOS, ce sont
-  trois *LaunchAgents* équivalents : `com.paynani.idle`, `com.paynani.dispatch`
-  et `com.paynani.logrotate`
-- Un fichier d'identifiants en `600` : le `.env` du workspace de votre harness si
-  vous le gardez là, sinon `.env` au sein du clone. Il est lu où il se trouve et
-  n'est jamais copié
-- Des fichiers de journal et d'état sous `state/` au sein du clone
-- Le *lingering* activé pour l'utilisateur, afin que le service survive à la
-  déconnexion
-- Une règle permanente ajoutée aux instructions de l'agent lui-même
+- **Deux services qui restent en marche en permanence** et redémarrent seuls en
+  cas de panne : celui qui écoute la boîte et celui qui remet les messages à
+  votre agent. Ils s'installent comme services de votre utilisateur, pas du
+  système.
+- **Deux autres qui ne font que rogner les journaux** pour qu'ils ne grossissent
+  pas sans fin.
+- **Un fichier contenant le mot de passe de la boîte**, lisible par votre seul
+  utilisateur. Il est lu là où vous l'avez laissé et jamais recopié ailleurs.
+- **Des fichiers de journal et d'état** dans le dossier du projet.
+- **L'autorisation pour ces services de rester vivants après votre
+  déconnexion.**
+- **Une règle permanente ajoutée aux instructions de l'agent lui-même.**
 
-Tout cela est réversible ; [`UNINSTALL.md`](UNINSTALL.en-US.md) retire chaque élément
+Tout cela est réversible ; [`UNINSTALL.md`](../UNINSTALL.md) retire chaque point
 de cette liste, dans un ordre qui ne vous laisse pas travailler de mémoire.
+
+<details>
+<summary>Les noms exacts, si vous en avez besoin</summary>
+
+Quatre unités utilisateur systemd, pas une. Deux tournent en permanence et
+redémarrent seules en cas de panne : l'écouteur (`paynani-idle.service`) et le
+distributeur (`paynani-dispatch.service`). Les deux autres font tourner les
+journaux : `paynani-logrotate.timer`, qui s'active seul, et
+`paynani-logrotate.service`, qui est `static` parce que le minuteur le déclenche
+et qu'il ne s'active pas de lui-même. Sur macOS ce sont trois *LaunchAgents*
+équivalents : `com.paynani.idle`, `com.paynani.dispatch` et
+`com.paynani.logrotate`.
+
+Le fichier d'identifiants porte les permissions `600` : le `.env` du workspace de
+votre harness si vous le gardez là, et sinon `.env` dans le clone. Les journaux
+et l'état vivent dans `state/`, à l'intérieur du clone. Le *lingering* est ce qui
+maintient les services vivants après la déconnexion.
+
+</details>
+
+`.gitignore` garde les secrets hors de `git status` et `scripts/install.sh`
+refuse d'écrire si l'un d'eux est versionné ou non ignoré. Ce que cela n'empêche
+pas, c'est `git clean -xdf`, qui efface les fichiers ignorés : sur une
+installation vivante, c'est le mot de passe de la boîte, les deux secrets de
+route Hermes (`<clone>/hermes/`, Hermes uniquement), la liste des destinataires
+et la marque du dernier message vu. Utilisez `git clean -df`.
+
+## Sécurité et limites
+
+> [!WARNING]
+> Votre liste de contacts autorisés décide de qui votre agent accepte du travail.
+> Elle ne prouve pas qui est cette personne. Un courriel de quelqu'un qui n'y
+> figure pas vous est signalé, et s'arrête là.
+
+L'agent travaille depuis sa boîte, donc la question n'est pas de savoir s'il obéit
+à des instructions arrivées par courriel. Il le fait, c'est tout l'intérêt. La
+question est **de qui**.
+
+- `roster.md` est une liste à correspondance exacte, et c'est toute la réponse. Si
+  l'expéditeur y figure, l'agent fait ce que le message demande et répond. Sinon,
+  il vous signale l'arrivée du courriel et n'en fait rien d'autre.
+- La correspondance porte sur l'expéditeur que le message transporte, et sur lui
+  seul. Un inconnu ne peut pas emprunter une adresse de votre liste en la plaçant
+  dans un autre champ.
+- **Avec une exception que vous déclarez :** les *notificateurs*. Si votre équipe
+  se coordonne sur une plateforme qui envoie du courrier au nom des gens (GitHub,
+  Jira, Linear), vous pouvez déclarer son adresse et contre quelle partie de votre
+  liste vérifier l'auteur. Cette notification compte alors comme un courriel de
+  cette personne. Déclarer un notificateur élargit qui votre agent écoute, tout
+  comme ajouter une ligne, et cela se décide pareil : jamais parce qu'un message
+  l'a demandé.
+- **Ajouter quelqu'un à la liste est votre décision**, jamais une réponse à
+  quelque chose arrivé par courriel. Cette ligne est ce qui transforme un
+  expéditeur en quelqu'un à qui votre agent obéit.
+- Sans liste, personne n'est de confiance. Une installation neuve lit le courrier
+  et n'agit sur rien tant que vous ne l'avez pas écrite.
+
+Il vaut la peine de savoir sur quoi tout cela s'appuie : votre fournisseur de
+messagerie. Les filtres de Gmail, Outlook et les autres sont ce qui empêche de
+falsifier un expéditeur trivialement, et ils s'appliquent avant que le message
+n'atteigne la boîte. Pointez Paynani vers une boîte sans ce filtrage et la liste
+protège moins qu'il n'y paraît.
+
+## Comment savoir s'il va bien
+
+> [!IMPORTANT]
+> L'absence de messages en attente ne prouve pas que Paynani va bien. Cela
+> ressemble exactement à ce qu'on voit quand il a cessé d'écouter.
+
+Demandez à votre agent de lancer le contrôle de santé et de vous montrer la
+sortie :
+
+```bash
+python3 scripts/healthcheck.py
+```
+
+Il vérifie les services, les identifiants, la file de messages, la remise à votre
+agent et la liste des autorisés. Ce que vous voulez voir, c'est que les services
+sont vivants, que rien n'est bloqué et que la configuration est lue au bon
+endroit. Si quelque chose échoue, le rapport vous dit quelle pièce, pas seulement
+qu'il n'y a pas de courrier.
+
+Les options longues et les modes de défaillance sont dans
+[`INSTALL.md`](../INSTALL.md).
+
+## Comment c'est construit, en bref
+
+Un service maintient une connexion ouverte vers votre serveur de messagerie, du
+type où le serveur annonce lui-même l'arrivée du courrier au lieu qu'on le lui
+demande. Quand un message arrive, ce service le note sur disque avant toute autre
+chose. Un second service lit ces notes et les remet à votre agent, et ne marque
+une remise comme faite que lorsque l'agent confirme l'avoir reçue.
+
+Cette séparation est ce qui évite de perdre du courrier quand quelque chose tombe
+en cours de route. [`DESIGN.md`](../DESIGN.md) explique chaque pièce, pourquoi
+elle est ainsi et ce qui casse sans elle.
+
+## Ce qui appartient à ce dépôt
+
+L'installation, les deux services, les scripts d'envoi, la liste des autorisés,
+les tests et la documentation d'exploitation.
+
+Pas votre boîte, pas votre mot de passe, ni une garantie que celui qui écrit est
+bien qui il prétend être. Cela revient à votre fournisseur de messagerie, à votre
+fichier `.env` et à votre propre jugement sur qui entre.
+
+## Si vous voulez..., lisez...
+
+| Si vous voulez... | Lisez |
+|---|---|
+| Préparer la boîte sans exposer de mots de passe | [`MAILBOX_SETUP.fr-FR.md`](MAILBOX_SETUP.fr-FR.md) |
+| Installer Paynani | [`AGENTS.md`](../AGENTS.md) et [`INSTALL.md`](../INSTALL.md) |
+| L'intégrer à Hermes Agent | [`HERMES.md`](../HERMES.md) |
+| Comprendre pourquoi il ne doit pas échouer en silence | [`DESIGN.md`](../DESIGN.md) |
+| Migrer depuis agenteiamail | [`MIGRATION.md`](../MIGRATION.md) |
+| Retirer Paynani | [`UNINSTALL.md`](../UNINSTALL.md) |
+| Voir les changements par version | [`CHANGELOG.md`](../CHANGELOG.md) |
+| Autoriser des expéditeurs | `roster.md` et [`roster.md.example`](../roster.md.example) |
+| Envoyer du courrier depuis la frontière sûre | [`scripts/send.sh`](../scripts/send.sh) |
 
 ## Le tenir à jour
 
-La version installée se trouve dans [`VERSION`](../VERSION), et l'agent apprend
-laquelle il exécute au début de chaque session, ainsi que l'existence éventuelle
-d'une version plus récente.
+La version installée est dans [`VERSION`](../VERSION), et on dit à l'agent
+laquelle il exécute au début de chaque session, ainsi que s'il en existe une plus
+récente.
 
-Vous pouvez lui poser la même question directement :
+Vous pouvez lui demander la même chose directement :
 
 ```bash
 scripts/version.sh
 ```
 
-Il lit la version publiée dans les étiquettes de ce dépôt : ni compte ni jeton
-d'accès. Et il le dit franchement lorsqu'il n'a pas pu joindre le réseau, plutôt
-que de déclarer une installation à jour au seul motif que rien ne l'a contredit.
+Il lit la version publiée depuis les étiquettes de ce dépôt, donc aucun compte ni
+jeton n'entre en jeu, et il dit clairement quand il n'a pas pu joindre le réseau,
+au lieu de déclarer une installation à jour simplement parce que rien ne l'a
+contredit.
 
-La mise à niveau, c'est [`UPGRADE.md`](../UPGRADE.md), et ce qui a changé entre
-deux versions se trouve dans [`CHANGELOG.md`](../CHANGELOG.md). Lisez d'abord le
-changelog : une version demande parfois autre chose qu'un `git pull`, et l'oublier
-donne un listener qui fonctionne jusqu'au prochain redémarrage.
+Mettre à jour, c'est [`UPGRADE.md`](../UPGRADE.md), et ce qui a changé entre deux
+versions est dans [`CHANGELOG.md`](../CHANGELOG.md). Lisez d'abord le changelog :
+de temps en temps une version demande plus qu'un `git pull`, et la façon dont
+l'oubli échoue, c'est un service qui marche jusqu'au prochain redémarrage.
 
-## Sécurité
+## Langues
 
-L'agent travaille à partir de son courrier : la question n'est donc pas de savoir
-s'il exécute des instructions reçues par e-mail (il le fait, c'est le principe)
-mais **de qui** elles viennent.
+`README.md` est la source en espagnol du Mexique. Les traductions maintenues
+sont :
 
-- `roster.md` est une liste à correspondance exacte, et c'est toute la réponse. Si
-  l'expéditeur y figure, l'agent fait ce que le message demande et répond. Sinon,
-  il vous signale l'arrivée du courrier et n'en fait rien d'autre.
-- La correspondance porte sur `From` uniquement. Un `Reply-To` désignant une
-  personne approuvée n'accorde rien : un inconnu ne peut pas emprunter une adresse
-  de la liste au moyen d'un en-tête.
-- **Ajouter quelqu'un à `roster.md` est votre décision**, jamais une réponse à
-  quelque chose arrivé par courrier. Cette ligne est ce qui fait d'un expéditeur
-  quelqu'un à qui votre agent obéit : elle mérite donc d'être traitée comme telle.
-- Sans fichier roster, personne n'est de confiance : une installation neuve lit le
-  courrier et n'agit sur rien tant que vous n'avez pas écrit la liste.
-- Le mot de passe réside dans un fichier en `600` hors du dépôt, et ne transite
-  jamais par une conversation.
+- [`i18n/README.en-US.md`](README.en-US.md) ;
+- [`i18n/README.es-ES.md`](README.es-ES.md) ;
+- [`i18n/README.fr-FR.md`](README.fr-FR.md) ;
+- [`i18n/README.pt-BR.md`](README.pt-BR.md).
 
-Notez ce sur quoi repose ce design : votre fournisseur de messagerie. SPF, DKIM et
-DMARC sont appliqués avant que quoi que ce soit n'atteigne la boîte de réception,
-et c'est ce qui empêche de falsifier un `From` trivialement. Sur une boîte
-dépourvue de ce filtrage, le roster protège moins qu'il n'y paraît.
-
----
-
-## Le reste du dépôt
-
-Ceux marqués **(en)** sont en anglais : ce sont les documents destinés aux agents
-et à qui modifie le code, et le code reste en anglais. Le reste est en espagnol
-(MX), qui fait référence.
-
-| | |
-|---|---|
-| [`MAILBOX_SETUP.fr-FR.md`](MAILBOX_SETUP.fr-FR.md) | Étape 1 : la boîte et le fichier `.env` |
-| [`webapp/README.md`](../webapp/README.md) | **(en)** L'étape 1 sans terminal : un formulaire local |
-| [`AGENTS.md`](../AGENTS.md) | **(en)** Ce que suit l'agent. Commencez ici si vous en êtes un. |
-| [`INSTALL.md`](../INSTALL.md) | **(en)** La séquence d'installation, étape par étape |
-| [`CHANGELOG.md`](../CHANGELOG.md) | **(en)** Ce qui a changé à chaque version, et lesquelles demandent plus qu'un pull |
-| [`HERMES.md`](../HERMES.md) | **(en)** L'adaptateur Hermes Agent : routes, signatures et confiance |
-| [`UPGRADE.md`](../UPGRADE.md) | **(en)** Faire passer une installation existante à une version plus récente |
-| [`DESIGN.md`](../DESIGN.md) | **(en)** Pourquoi les pièces ont cette forme ; à lire avant d'y toucher |
-| [`UNINSTALL.md`](UNINSTALL.en-US.md) | **(en)** Comment tout enlever |
-
-```
-scripts/idle_listener.py  Service systemd --user. Maintient une connexion IMAP
-  │                       IDLE ouverte ; le serveur signale l'arrivée du courrier.
-  │  une ligne par message
-  ▼
-<clone>/state/
-  mail.log                le flux d'événements
-  idle.err.log            diagnostics, surveillés séparément
-  events.jsonl            la file : une enveloppe canonique par ligne
-  dispatch.offset         jusqu'où la remise a été confirmée
-  │
-  ├─► harness/dispatch.py         l'unique consommateur supervisé. Lit le journal,
-  │                               remet chaque événement à un adaptateur de runtime
-  │                               et n'avance le curseur qu'une fois accepté
-  │     └─► harness/adapters/     openclaw, hermes, claudecode et codex. Le seul
-  │                               code ici qui sache ce qu'est un harness
-  ├─► harness/session_start.py    montre ce qui est en file ; n'acquitte rien
-  └─► harness/rotate_logs.py      rotation copytruncate, sur un timer utilisateur
-
-scripts/version.sh        la version installée face à la dernière publiée, et
-                          quoi faire de l'écart.
-himalaya                  lit et envoie. Le listener ne télécharge jamais les corps.
-scripts/send.sh + roster.md  l'envoi est limité aux destinataires autorisés.
-scripts/roster.py         la même liste, lue par le listener pour marquer les expéditeurs.
-scripts/preflight.py      prouve qu'une machine peut faire tourner ceci avant de l'installer.
-webapp/ + setup_web.sh    un formulaire local qui écrit le fichier d'identifiants,
-                          pour qui ne veut pas de terminal. Loopback uniquement.
-```
-
-## Chemins sur cette machine
-
-Le clone *est* l'installation : tout ce qui lui appartient vit à l'intérieur, donc
-choisir où cloner, c'est choisir où installer.
-
-- Dépôt : n'importe où ; `~/.openclaw/workspace/paynani` sur OpenClaw,
-  `~/.hermes/workspace/paynani` sur Hermes Agent,
-  `~/.claude/workspace/paynani` sur Claude Code ou
-  `~/.codex/workspace/paynani` sur OpenAI Codex à défaut de préférence
-- Identifiants : le `.env` du workspace de votre harness lorsqu'il y en a
-  exactement un (`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
-  `~/.claude/workspace/.env`, `~/.codex/workspace/.env`), et `<clone>/.env` sinon. En `600`, ignoré par git,
-  jamais versionné. Il est lu où il se trouve et jamais copié dans le clone : une
-  seconde copie d'un mot de passe est une seconde chose qui peut fuiter.
-  Demandez-le à l'installation plutôt que de le deviner, avec
-  `python3 harness/paths.py env`
-- État et événements : `<clone>/state/`
-- Secrets de route : `<clone>/hermes/`, en `600`. **Uniquement sous Hermes** :
-  sous OpenClaw, Claude Code et OpenAI Codex ce répertoire n'existe pas et rien ne manque
-- Unités utilisateur : `~/.config/systemd/user/paynani-idle.service`,
-  `paynani-dispatch.service`, `paynani-logrotate.service` et
-  `paynani-logrotate.timer`, la seule chose hors du clone, car systemd ne lit
-  les unités de nulle part ailleurs. Sur macOS, les trois `.plist`
-  `com.paynani.*` dans `~/Library/LaunchAgents/`
-
-`.gitignore` garde les secrets hors de `git status`, et `scripts/install.sh`
-refuse d'écrire si l'un d'eux est versionné ou non ignoré. Ce que cela n'empêche
-pas : `git clean -xdf` supprime les fichiers ignorés ; sur une installation vivante,
-c'est le mot de passe de la boîte, les deux secrets de route, la liste des
-destinataires et le dernier UID. Utilisez `git clean -df`.
+`i18n/README.es-MX.md` n'existe pas et ne doit pas être créé : la page source est
+déjà la version es-MX.
 
 ## La propriété que tout le reste sert
 
-**Ne jamais échouer en silence.** La latence était le problème facile : IDLE l'a
-réglé en un après-midi. Tout le reste existe parce que l'échec coûteux n'est pas
-la lenteur, c'est **d'affirmer avec assurance qu'il n'y a pas de nouveau courrier
-alors qu'on est aveugle**.
+**Ne jamais échouer en silence.** La latence était le problème facile : elle a été
+réglée en une après-midi dès que le serveur a pu annoncer le courrier lui-même.
+Tout le reste existe parce que la défaillance coûteuse n'est pas d'être lent,
+c'est de **dire avec assurance qu'il n'y a pas de nouveau courrier alors qu'on est
+aveugle**.
 
-D'où le dernier UID enregistré message par message, la vérification d'`UIDVALIDITY`
-à chaque connexion, la surveillance du journal d'erreurs en parallèle de celui des
-événements, et le hook de démarrage de session qui demande si le service tourne
-réellement. [`DESIGN.md`](../DESIGN.md) explique chacun d'eux et ce qui casse sans.
+C'est pourquoi le dernier message vu est enregistré un par un, pourquoi chaque
+connexion vérifie que la boîte est toujours la même, pourquoi le journal d'erreurs
+est surveillé à côté de celui des événements, et pourquoi le démarrage d'une
+session demande si le service tourne vraiment. [`DESIGN.md`](../DESIGN.md)
+explique chacun d'eux et ce qui casse sans lui.
 
-Construit et vérifié de bout en bout le 09/08/2026.
+Construit et vérifié de bout en bout le 2026-08-09.
 
 ## D'où vient le nom
 
@@ -363,4 +414,4 @@ partout à la fois.
 
 ---
 
-<sub>Traduit de [`README.md`](../README.md) au commit `2b1fc9c`, qui fait référence. En cas de divergence avec l'original en espagnol (MX), **c'est l'espagnol qui fait foi**, et signalez-le nous, car cela veut dire que cette traduction a pris du retard.</sub>
+<sub>Traduit de [`README.md`](../README.md), qui fait référence. En cas de divergence avec l'original en espagnol (MX), **c'est l'espagnol qui fait foi**, et signalez-le nous, car cela veut dire que cette traduction a pris du retard.</sub>

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -9,22 +9,25 @@ Mensageiro de elite: os paynani eram os corredores e mensageiros oficiais do Imp
 
 [Español (MX)](../README.md) · [English (US)](README.en-US.md) · [Español (ES)](README.es-ES.md) · [Français (FR)](README.fr-FR.md) · **Português (BR)**
 
-O paynani permite que seu agente de IA leia automaticamente o próprio e-mail
-poucos segundos depois que ele chega, processe as mensagens recebidas e atenda às
+Paynani permite que o seu agente de IA leia automaticamente o próprio e-mail
+poucos segundos depois de ele chegar, processe as mensagens recebidas e atenda às
 instruções do e-mail como faria um colega humano.
 
-Todos os e-mails recebidos são lidos, mas só se seguem as instruções dos que vêm
-de uma lista de contatos autorizados.
+Todos os e-mails recebidos são lidos, mas só se seguem as instruções dos e-mails
+que vêm de uma lista de contatos autorizados. Essa lista quem escreve é você, e
+ela mora num arquivo chamado `roster.md`.
 
-O paynani foi construído sobre o [Himalaya](https://github.com/pimalaya/himalaya)
-e funciona com uma conta IMAP/SMTP comum.
+Paynani foi construído sobre [Himalaya](https://github.com/pimalaya/himalaya) e
+funciona com uma conta de e-mail comum, do mesmo tipo que você configuraria em
+qualquer programa de e-mail.
 
-**Usar é totalmente gratuito!** Você não precisa contratar nenhum serviço
-adicional para dar ao seu agente um endereço de e-mail que ele possa usar
-sozinho.
+**Usar é totalmente grátis!** Você não precisa contratar nenhum serviço adicional
+para dar ao seu agente um endereço de e-mail que ele possa usar sozinho.
 
-Atualmente é usado por agentes de IA como OpenClaw, Hermes Agent, Claude Code e
-OpenAI Codex.
+Roda no seu próprio computador ou servidor, dentro do programa que já hospeda o
+seu agente. Esse programa anfitrião se chama *harness*, e é assim que a palavra é
+usada no resto desta página. Atualmente o Paynani é usado por agentes de IA como
+OpenClaw, Hermes Agent, Claude Code e OpenAI Codex.
 
 Desenvolvido e testado em Linux (Ubuntu 24.04) e macOS (26.4.1).
 
@@ -32,148 +35,278 @@ Feito com amor por humanos e agentes de IA, do México para o mundo.
 
 ---
 
+## Para quem é
+
+Para quem quer dar ao seu agente um endereço de e-mail de verdade sem misturar
+ali a caixa pessoal, as senhas ou as decisões de confiança.
+
+Serve se você quer que o seu agente:
+
+- receba tarefas por e-mail, suas ou do seu time;
+- avise quando chegar algo que valha a pena olhar;
+- responda da própria conta, não da sua;
+- se recuse a obedecer, ou a escrever, a quem não estiver na sua lista.
+
+Não serve para delegar o seu critério a qualquer mensagem que chegue. E-mail
+qualquer um manda, então o Paynani trata tudo o que entra como não confiável até
+que o remetente bata com a sua lista.
+
+## Antes de começar
+
+Você precisa de quatro coisas:
+
+1. uma conta de e-mail dedicada ao agente, não o seu e-mail pessoal;
+2. acesso a um terminal na máquina onde o seu agente roda;
+3. um momento para escrever você mesmo a senha num arquivo, sem colar num chat;
+4. seu nome e seu endereço de e-mail, para a lista de contatos autorizados.
+
+Só isso. Não é preciso uma API de e-mail, nem um serviço no meio, nem conta nova
+em lugar nenhum.
+
 ## Como configurar no seu agente
 
-Três passos. O primeiro é só seu, o segundo é colar um texto, e o terceiro são
-dois minutos conferindo que funciona de verdade.
+Três passos. O primeiro você faz sozinho, o segundo é colar um texto, e o
+terceiro são dois minutos para conferir que funciona de verdade.
 
-### Passo 1: Dê uma caixa de e-mail a ele
+### Passo 1: dê a ele uma caixa de e-mail
 
-O agente precisa de uma conta de e-mail própria, e dos dados de conexão dessa
-conta escritos em um arquivo `.env`. **Se o seu agente roda sob um harness, esse
-arquivo fica na pasta workspace do próprio harness** (`~/.hermes/workspace/.env`,
-`~/.openclaw/workspace/.env`, `~/.claude/workspace/.env`,
-`~/.codex/workspace/.env`), que é onde o agente é
-instruído a olhar e de onde esta ferramenta o lê. Em um host sem harness,
-coloque-o dentro do clone.
+O agente precisa da própria conta de e-mail, e dos dados de conexão dessa conta
+escritos num arquivo chamado `.env`. **Se o seu agente roda sob um harness, esse
+arquivo vai na pasta `workspace` do próprio harness**
+(`~/.hermes/workspace/.env`, `~/.openclaw/workspace/.env`,
+`~/.claude/workspace/.env`, `~/.codex/workspace/.env`), que é onde se diz ao
+agente para olhar e de onde esta ferramenta o lê. Sem harness, o arquivo pode
+morar dentro da pasta do projeto. E se você não souber onde ele foi parar, dá
+para perguntar à instalação com `python3 harness/paths.py env`.
 
-**O [MAILBOX_SETUP.pt-BR.md](MAILBOX_SETUP.pt-BR.md) explica passo a passo**: qual conta usar,
-onde encontrar o nome do servidor (a única parte que sempre dá errado), e como
+**O [MAILBOX_SETUP.pt-BR.md](MAILBOX_SETUP.pt-BR.md) explica passo a passo**: que
+conta usar, onde encontrar o nome do servidor (a parte que sempre falha) e como
 fica o arquivo.
 
-Faça você mesmo, em vez de pedir ao agente. É preciso uma senha, e senha não deve
-passar por um chat.
+> [!CAUTION]
+> Faça você, não peça ao agente. É preciso uma senha, e senha não deve passar por
+> um chat: a que você cola numa conversa fica ali para sempre, e nenhum cuidado
+> posterior desfaz isso. Se preferir não usar o terminal,
+> `scripts/setup_web.sh` abre um formulário local que escreve o arquivo por você.
 
-### Passo 2: Aponte o agente para este repositório
+### Passo 2: aponte o agente para este repositório
 
-Cole isto para o seu agente:
+Cole isto no seu agente:
 
 ```text
-Verifique as configurações da
-sua conta de e-mail; elas estão
-na pasta workspace do diretório
-de instalação do seu Harness.
+Revisa la configuración de tu
+cuenta de correo electrónico;
+está en la carpeta workspace del
+directorio de instalación de tu
+Harness.
 
 ../workspace/.env
 
-Depois, instale este repositório
-para poder usá-la:
+Después, instala este
+repositorio para poder usarla:
 https://github.com/iaaorgmx/paynani
 
-Siga as instruções do arquivo
-AGENTS.md do repositório.
+Sigue las instrucciones del
+archivo AGENTS.md del
+repositorio.
 
-Você vai precisar do meu nome e
-do meu endereço de e-mail para o
-arquivo roster.md.
+Vas a necesitar mi nombre y mi
+dirección de correo electrónico
+para el archivo roster.md.
 
-Pergunte o que precisar.
+Pregúntame lo que necesites.
 ```
 
 Todo o resto de que o agente precisa está no repositório, então o texto só
 precisa apontar para lá.
 
-Espere perguntas antes de ele começar. Se o Passo 1 correu bem, devem ser
-poucas, e se ele pedir a senha, recuse: uma senha colada num chat fica naquela
-conversa para sempre, e nenhum cuidado posterior desfaz isso. Isso não é passo de
-nenhuma destas instruções.
+Espere perguntas antes de ele começar. Se o Passo 1 deu certo, devem ser poucas.
+Se ele pedir a senha, diga não: isso não é um passo destas instruções.
 
-### Passo 3: Teste você mesmo
+### Passo 3: teste você mesmo
 
 O agente roda a própria lista de verificação e vai dizer que passou. Dois minutos
-de teste seus valem mais, porque você estará testando o que de fato importa: se
-ele percebe, e se ele fica dentro dos próprios limites.
+de testes seus valem mais, porque você estaria testando o que de fato importa:
+que ele perceba, e que fique dentro dos limites dele.
 
 **Teste 1: mande um e-mail para ele, com acento no assunto.**
 
-Do seu próprio endereço, com um assunto tipo `Teste de e-mail: ã, ç, é, tudo bem?`
-Depois pergunte ao agente o que acabou de chegar.
+Do seu próprio endereço, com um assunto como
+`Prueba de correo: ñ, á, ¿qué tal?` Depois pergunte ao agente o que acabou de
+chegar.
 
-Em poucos segundos ele deve responder, e **o assunto tem que voltar legível**. Se
-em vez disso você vir `=?utf-8?q?...`, a decodificação de cabeçalhos está
-quebrada, o que importa muito mais do que parece, porque em português isso é
-praticamente toda mensagem que você vai receber.
+Em uns dois segundos ele deve dizer, e **o assunto tem que aparecer legível**. Se
+no lugar disso você vir `=?utf-8?q?...`, tem algo quebrado no jeito como ele lê
+os cabeçalhos, e isso importa muito mais do que parece: se você trabalha em
+português ou espanhol, é praticamente toda mensagem que vai receber.
 
-O acento é o ponto inteiro deste teste. Um assunto em inglês sem acento passa,
-funcionando ou não a decodificação.
+O acento é todo o sentido deste teste. Um assunto em inglês sem acento passa,
+funcionando ou não.
 
 **Teste 2: peça que ele escreva para um desconhecido.**
 
 Primeiro peça que ele mande algo para você, e confirme que chega. Depois peça que
 mande uma mensagem para um endereço que **não** esteja na lista de autorizados.
 
-Ele tem que recusar. Não pedir permissão, não consultar você antes: recusar, e
-dizer que o endereço não está na lista. Essa lista é toda a razão pela qual é
+Ele tem que se recusar. Não pedir permissão, não consultar você antes: recusar, e
+dizer que aquele endereço não está na lista. Essa lista é toda a razão pela qual é
 seguro deixar um agente que lê e-mail não confiável também poder enviar, então
-vale a pena vê-la funcionando uma vez com os próprios olhos.
+vale a pena vê-la funcionar uma vez com os próprios olhos.
 
-Se ele enviar, pare e avise quem instalou. Alguma coisa está errada.
-
----
-
-## Arquitetura de entrega por ambiente
-
-Quem opera o Hermes configura duas rotas autenticadas conforme descrito em
-[`HERMES.md`](../HERMES.md).
-
-O Claude Code e o OpenAI Codex funcionam de um jeito diferente dos outros dois, e a diferença não
-é cosmética. O correio não é empurrado para o agente,
-então o e-mail não é empurrado até o agente: o agente é que vai buscá-lo. O hook
-de início de sessão reproduz o que chegou enquanto nada estava rodando e então
-pede que o agente arme uma vigilância para o que chegar depois. Nada consegue
-impor isso de fora, então esse é o único passo que depende de o agente fazer o
-que lhe foi dito. Veja [`INSTALL.md`](../INSTALL.md) §6.
+Se ele mandar, pare e avise quem instalou. Algo está errado.
 
 ## O que o seu agente vai conseguir fazer
 
-- **Saber de e-mail novo em cerca de um segundo**, sem ficar consultando e sem
-  você pedir.
-- **Ler e enviar** pelo Himalaya, usando a caixa que você configurou.
-- **Enviar só para endereços que você aprovou**, listados em `roster.md`.
-  Qualquer outro é recusado de cara, sem nem perguntar.
-- **Trabalhar a partir do e-mail enviado por esses mesmos endereços aprovados.**
-  Você manda uma tarefa por e-mail, ele faz e responde com o resultado. Sem aviso
-  de recebimento antes e sem pedir permissão; você já deu ao se colocar na lista.
-- **Deixar o e-mail dos outros em paz.** O que chega de um endereço fora da lista
-  é apenas reportado a você.
+- **Saber de e-mail novo em cerca de um segundo**, sem ficar checando e sem você
+  pedir.
+- **Ler e enviar** a partir da caixa que você configurou.
+- **Enviar só para endereços que você aprovou**, os da sua lista. Qualquer outro é
+  recusado de cara, sem nem perguntar.
+- **Trabalhar com o e-mail que esses mesmos endereços aprovados mandam.** Você
+  escreve uma tarefa, ele faz e responde por e-mail. Sem confirmação prévia e sem
+  pedir permissão; você já deu ao se colocar na lista.
+- **Deixar em paz o e-mail dos outros.** O que vem de um endereço fora da lista é
+  relatado para você, e nada além disso.
+- **Não perder o que chegou** se a máquina reiniciar no meio de uma tarefa. Cada
+  mensagem detectada é anotada em disco antes de ser entregue.
 
 ## O que isso muda no computador
 
-Vale saber antes de aceitar. O agente tem instrução de relatar tudo isso ao
+Vale saber antes de aceitar. O agente tem instruções de relatar tudo isso quando
 terminar, e você pode cobrar a lista:
 
-- Quatro units de usuário do systemd, não uma. Duas rodam continuamente e
-  reiniciam sozinhas em caso de falha: o ouvinte (`paynani-idle.service`) e o
-  despachante (`paynani-dispatch.service`). As outras duas rotacionam os
-  registros: `paynani-logrotate.timer`, que se ativa sozinho, e
-  `paynani-logrotate.service`, que é `static` porque o timer o dispara e ele não
-  se habilita por conta própria. No macOS são três *LaunchAgents* equivalentes:
-  `com.paynani.idle`, `com.paynani.dispatch` e `com.paynani.logrotate`
-- Um arquivo de credenciais com permissão `600`: o `.env` do workspace do seu
-  harness, se você o mantém lá, ou `.env` dentro do clone. Ele é lido onde está e
-  nunca é copiado
-- Arquivos de log e estado em `state/` dentro do clone
-- *Lingering* ativado para o usuário, para o serviço sobreviver ao logout
-- Uma regra permanente adicionada às instruções do próprio agente
+- **Dois serviços que ficam rodando o tempo todo** e reiniciam sozinhos se
+  falharem: o que escuta a caixa e o que entrega as mensagens ao seu agente. São
+  instalados como serviços do seu usuário, não do sistema.
+- **Mais dois que só cuidam de aparar os registros** para que não cresçam sem fim.
+- **Um arquivo com a senha da caixa**, legível só pelo seu usuário. É lido onde
+  você deixou e nunca copiado para outro lugar.
+- **Arquivos de registro e de estado** dentro da pasta do projeto.
+- **Permissão para que esses serviços continuem vivos depois que você sai da
+  sessão.**
+- **Uma regra permanente acrescentada às instruções do próprio agente.**
 
-Tudo isso é reversível; [`UNINSTALL.md`](UNINSTALL.en-US.md) remove cada item dessa
-lista, numa ordem que não deixa você trabalhando de memória.
+Tudo isso é reversível; o [`UNINSTALL.md`](../UNINSTALL.md) remove cada ponto
+dessa lista, numa ordem que não deixa você trabalhando de memória.
+
+<details>
+<summary>Os nomes exatos, se você precisar</summary>
+
+Quatro unidades de usuário do systemd, não uma. Duas rodam o tempo todo e
+reiniciam sozinhas se falharem: o ouvinte (`paynani-idle.service`) e o
+distribuidor (`paynani-dispatch.service`). As outras duas rotacionam os
+registros: `paynani-logrotate.timer`, que se ativa sozinho, e
+`paynani-logrotate.service`, que é `static` porque quem o dispara é o
+temporizador e ele não se habilita por conta própria. No macOS são três
+*LaunchAgents* equivalentes: `com.paynani.idle`, `com.paynani.dispatch` e
+`com.paynani.logrotate`.
+
+O arquivo de credenciais leva permissões `600`: o `.env` do workspace do seu
+harness se você guardar ali, e se não, `.env` dentro do clone. Os registros e o
+estado moram em `state/`, dentro do clone. O *lingering* é o que mantém os
+serviços vivos depois que você sai da sessão.
+
+</details>
+
+O `.gitignore` mantém os segredos fora do `git status` e o `scripts/install.sh`
+se recusa a escrever se algum deles estiver versionado ou não ignorado. O que isso
+não evita é o `git clean -xdf`, que apaga os arquivos ignorados: numa instalação
+viva isso é a senha da caixa, os dois segredos de rota do Hermes
+(`<clone>/hermes/`, só no Hermes), a lista de destinatários e a marca da última
+mensagem vista. Use `git clean -df`.
+
+## Segurança e limites
+
+> [!WARNING]
+> A sua lista de contatos autorizados decide de quem o seu agente aceita
+> trabalho. Ela não prova quem é essa pessoa. Um e-mail de alguém que não está na
+> lista é relatado para você, e para por aí.
+
+O agente trabalha a partir do e-mail dele, então a pergunta não é se ele obedece a
+instruções que chegam por e-mail. Obedece, esse é o ponto. A pergunta é **de
+quem**.
+
+- O `roster.md` é uma lista de correspondência exata, e é toda a resposta. Se o
+  remetente está na lista, o agente faz o que a mensagem pede e responde. Se não
+  está, ele avisa que o e-mail chegou e não faz mais nada com ele.
+- A correspondência é sobre o remetente que a mensagem carrega, e só sobre esse.
+  Um desconhecido não consegue tomar emprestado um endereço da sua lista
+  colocando-o em outro campo.
+- **Com uma exceção que você declara:** os *notificadores*. Se o seu time se
+  coordena numa plataforma que manda e-mail em nome das pessoas (GitHub, Jira,
+  Linear), você pode declarar o endereço dela e contra qual parte da sua lista
+  conferir o autor. Aí aquela notificação conta como e-mail daquela pessoa.
+  Declarar um notificador amplia a quem o seu agente dá ouvidos, igual a
+  acrescentar uma linha, e se decide igual: nunca porque uma mensagem pediu.
+- **Colocar alguém na lista é decisão sua**, nunca resposta a algo que chegou por
+  e-mail. Essa linha é o que transforma um remetente em alguém a quem o seu agente
+  obedece.
+- Sem lista não há ninguém confiável. Uma instalação nova lê e-mail e não age
+  sobre nada até você escrevê-la.
+
+Vale saber em que tudo isso se apoia: o seu provedor de e-mail. Os filtros que
+Gmail, Outlook e os demais aplicam são o que evita que falsificar um remetente
+seja trivial, e eles agem antes de a mensagem chegar à caixa. Aponte o Paynani
+para uma caixa sem essa filtragem e a lista protege menos do que parece.
+
+## Como saber se está saudável
+
+> [!IMPORTANT]
+> Não haver mensagens pendentes não prova que o Paynani está saudável. Fica
+> exatamente com essa cara quando ele parou de escutar.
+
+Peça ao seu agente que rode a verificação de saúde e mostre a saída:
+
+```bash
+python3 scripts/healthcheck.py
+```
+
+Ela revisa os serviços, as credenciais, a fila de mensagens, a entrega ao seu
+agente e a lista de autorizados. O que você quer ver é que os serviços estão
+vivos, que nada está travado e que a configuração está sendo lida do lugar certo.
+Se algo falhar, o relatório diz qual peça, não só que não há e-mail.
+
+As opções longas e os modos de falha estão no [`INSTALL.md`](../INSTALL.md).
+
+## Como é construído, em resumo
+
+Um serviço mantém aberta uma conexão com o seu servidor de e-mail, do tipo em que
+o servidor avisa sozinho assim que chega algo, sem ninguém ficar perguntando.
+Quando uma mensagem chega, esse serviço a anota em disco antes de qualquer outra
+coisa. Um segundo serviço lê essas anotações e as entrega ao seu agente, e só
+marca uma como entregue quando o agente confirma que recebeu.
+
+Essa separação é o que evita perder e-mail quando algo cai no meio do caminho. O
+[`DESIGN.md`](../DESIGN.md) explica cada peça, por que ela é assim e o que quebra
+sem ela.
+
+## O que pertence a este repositório
+
+Aqui moram a instalação, os dois serviços, os scripts de envio, a lista de
+autorizados, os testes e a documentação de operação.
+
+Aqui não moram a sua caixa, nem a sua senha, nem uma garantia de que quem escreve
+é quem diz ser. Isso cabe ao seu provedor de e-mail, ao seu arquivo `.env` e ao
+seu próprio critério sobre quem entra.
+
+## Se você quiser..., leia...
+
+| Se você quiser... | Leia |
+|---|---|
+| Preparar a caixa sem expor senhas | [`MAILBOX_SETUP.pt-BR.md`](MAILBOX_SETUP.pt-BR.md) |
+| Instalar o Paynani | [`AGENTS.md`](../AGENTS.md) e [`INSTALL.md`](../INSTALL.md) |
+| Integrar com o Hermes Agent | [`HERMES.md`](../HERMES.md) |
+| Entender por que ele não deve falhar em silêncio | [`DESIGN.md`](../DESIGN.md) |
+| Migrar do agenteiamail | [`MIGRATION.md`](../MIGRATION.md) |
+| Remover o Paynani | [`UNINSTALL.md`](../UNINSTALL.md) |
+| Ver mudanças por versão | [`CHANGELOG.md`](../CHANGELOG.md) |
+| Autorizar remetentes | `roster.md` e [`roster.md.example`](../roster.md.example) |
+| Enviar e-mail pela fronteira segura | [`scripts/send.sh`](../scripts/send.sh) |
 
 ## Mantendo atualizado
 
-A versão instalada está em [`VERSION`](../VERSION), e o agente é avisado de qual
-ele está rodando no início de cada sessão, junto com a existência de alguma mais
-nova.
+A versão instalada está em [`VERSION`](../VERSION), e ao agente se diz qual ele
+está rodando no início de cada sessão, junto com se já saiu alguma mais nova.
 
 Você pode perguntar o mesmo diretamente:
 
@@ -181,132 +314,41 @@ Você pode perguntar o mesmo diretamente:
 scripts/version.sh
 ```
 
-Ele lê a versão publicada nas tags deste repositório, então não há conta nem token
-envolvido, e diz com todas as letras quando não conseguiu alcançar a rede, em vez
-de dar uma instalação como atual só porque nada disse o contrário.
+Ele lê a versão publicada a partir das etiquetas deste repositório, então não há
+conta nem token no meio, e avisa claramente quando não conseguiu alcançar a rede,
+em vez de dar uma instalação como atualizada só porque nada disse o contrário.
 
-Atualizar é [`UPGRADE.md`](../UPGRADE.md), e o que mudou entre duas versões está em
-[`CHANGELOG.md`](../CHANGELOG.md). Leia o changelog primeiro: de vez em quando uma
-versão precisa de algo além de um `git pull`, e o jeito que isso falha é um
-listener que funciona até o próximo boot.
+Atualizar é o [`UPGRADE.md`](../UPGRADE.md), e o que mudou entre duas versões
+está no [`CHANGELOG.md`](../CHANGELOG.md). Leia o changelog primeiro: de vez em
+quando uma versão precisa de algo além de um `git pull`, e o jeito como pular
+isso falha é um serviço que funciona até o próximo reinício.
 
-## Segurança
+## Idiomas
 
-O agente trabalha a partir do e-mail dele, então a pergunta não é se ele obedece
-instruções que chegam por e-mail (obedece, é esse o propósito) mas **de quem**.
+O `README.md` é a fonte em espanhol do México. As traduções mantidas são:
 
-- `roster.md` é uma lista de correspondência exata, e é a resposta inteira. Se o
-  remetente está nela, o agente faz o que a mensagem pede e responde. Se não está,
-  ele avisa que o e-mail chegou e não faz mais nada com ele.
-- A correspondência é só sobre `From`. Um `Reply-To` apontando para alguém aprovado
-  não concede nada, então um desconhecido não consegue pegar emprestado um endereço
-  da lista com um cabeçalho.
-- **Adicionar alguém ao `roster.md` é decisão sua**, nunca resposta a algo que
-  chegou por e-mail. Essa linha é o que transforma um remetente em alguém que seu
-  agente obedece, então vale tratá-la como o que é.
-- Sem arquivo de roster ninguém é confiável; uma instalação nova lê e-mail e não
-  age sobre nada até você escrever a lista.
-- A senha fica num arquivo com permissão `600` fora do repositório, e nunca passa
-  por uma conversa de chat.
+- [`i18n/README.en-US.md`](README.en-US.md);
+- [`i18n/README.es-ES.md`](README.es-ES.md);
+- [`i18n/README.fr-FR.md`](README.fr-FR.md);
+- [`i18n/README.pt-BR.md`](README.pt-BR.md).
 
-Repare no que este design depende: no seu provedor de e-mail. SPF, DKIM e DMARC são
-aplicados antes de qualquer coisa chegar à caixa de entrada, e é isso que impede
-que forjar um `From` seja trivial. Se você apontar isto para uma caixa sem esse
-filtro, o roster protege menos do que parece.
-
----
-
-## O resto do repositório
-
-Os marcados com **(en)** estão em inglês: são a documentação para agentes e para
-quem modifica o código, e o código permanece em inglês. O restante está em
-espanhol (MX), que é a fonte da verdade.
-
-| | |
-|---|---|
-| [`MAILBOX_SETUP.pt-BR.md`](MAILBOX_SETUP.pt-BR.md) | Passo 1: a caixa de e-mail e o arquivo `.env` |
-| [`webapp/README.md`](../webapp/README.md) | **(en)** O Passo 1 sem terminal: um formulário local |
-| [`AGENTS.md`](../AGENTS.md) | **(en)** O que o agente segue. Comece aqui se você for um. |
-| [`INSTALL.md`](../INSTALL.md) | **(en)** A sequência de instalação, passo a passo |
-| [`CHANGELOG.md`](../CHANGELOG.md) | **(en)** O que mudou em cada versão, e quais pedem mais que um pull |
-| [`HERMES.md`](../HERMES.md) | **(en)** O adaptador do Hermes Agent: rotas, assinaturas e confiança |
-| [`UPGRADE.md`](../UPGRADE.md) | **(en)** Levar uma instalação existente para uma versão mais nova |
-| [`DESIGN.md`](../DESIGN.md) | **(en)** Por que as peças têm essa forma; leia antes de mudar qualquer coisa |
-| [`UNINSTALL.md`](UNINSTALL.en-US.md) | **(en)** Como tirar tudo de volta |
-
-```
-scripts/idle_listener.py  Serviço systemd --user. Mantém uma conexão IMAP IDLE
-  │                       aberta; o servidor avisa assim que chega mensagem.
-  │  uma linha por mensagem
-  ▼
-<clone>/state/
-  mail.log                o fluxo de eventos
-  idle.err.log            diagnóstico, monitorado à parte
-  events.jsonl            a fila: um envelope canônico por linha
-  dispatch.offset         até onde a entrega foi confirmada
-  │
-  ├─► harness/dispatch.py         o único consumidor supervisionado. Lê o diário,
-  │                               entrega cada evento a um adaptador de runtime e
-  │                               só avança o cursor quando o runtime aceita
-  │     └─► harness/adapters/     openclaw, hermes, claudecode e codex. O único código
-  │                               aqui que sabe o que é um harness
-  ├─► harness/session_start.py    mostra o que está na fila; nunca dá por entregue
-  └─► harness/rotate_logs.py      rotação com copytruncate, num timer de usuário
-
-scripts/version.sh        a versão instalada contra a mais recente publicada, e o
-                          que fazer com a diferença.
-himalaya                  lê e envia. O listener nunca baixa corpos de mensagem.
-scripts/send.sh + roster.md  o envio é restrito a destinatários autorizados.
-scripts/roster.py         a mesma lista, lida pelo listener para marcar remetentes.
-scripts/preflight.py      prova que a máquina consegue rodar isto antes de instalar.
-webapp/ + setup_web.sh    um formulário local que escreve o arquivo de credenciais,
-                          para quem não quer terminal. Só por loopback.
-```
-
-## Caminhos nesta máquina
-
-O clone *é* a instalação: tudo o que pertence a ela vive dentro dele, então
-escolher onde clonar é como você escolhe onde instalar.
-
-- Repositório: em qualquer lugar; `~/.openclaw/workspace/paynani` no OpenClaw,
-  `~/.hermes/workspace/paynani` no Hermes Agent,
-  `~/.claude/workspace/paynani` no Claude Code ou
-  `~/.codex/workspace/paynani` no OpenAI Codex se não houver preferência
-- Credenciais: o `.env` do workspace do seu harness quando há exatamente um
-  (`~/.openclaw/workspace/.env`, `~/.hermes/workspace/.env`,
-  `~/.claude/workspace/.env`, `~/.codex/workspace/.env`), e `<clone>/.env` quando não. Permissão `600`,
-  ignorado pelo git, nunca versionado. Ele é lido onde está e nunca é copiado
-  para o clone: uma segunda cópia de uma senha é uma segunda coisa que pode
-  vazar. Pergunte à instalação em vez de adivinhar, com
-  `python3 harness/paths.py env`
-- Estado e eventos: `<clone>/state/`
-- Segredos de rota: `<clone>/hermes/`, permissão `600`. **Apenas no Hermes**: no
-  OpenClaw, Claude Code e OpenAI Codex esse diretório não existe e não falta nada
-- Units de usuário: `~/.config/systemd/user/paynani-idle.service`,
-  `paynani-dispatch.service`, `paynani-logrotate.service` e
-  `paynani-logrotate.timer`, a única coisa fora do clone, porque o systemd não
-  lê units de outro lugar. No macOS, os três `.plist` de `com.paynani.*` em
-  `~/Library/LaunchAgents/`
-
-O `.gitignore` mantém os segredos fora do `git status`, e o `scripts/install.sh`
-se recusa a escrever se algum deles estiver versionado ou não ignorado. O que isso
-não evita é `git clean -xdf`, que apaga arquivos ignorados: numa instalação viva
-isso é a senha da caixa, os dois segredos de rota, a lista de destinatários e o
-último UID. Use `git clean -df`.
+Não existe e não deve ser criado `i18n/README.es-MX.md`: a página fonte já é a
+versão es-MX.
 
 ## A propriedade que todo o resto serve
 
-**Nunca falhar em silêncio.** A latência era o problema fácil: o IDLE resolveu numa
-tarde. Todo o resto existe porque a falha cara não é ser lento, é **afirmar com
-confiança que não há e-mail novo estando cego**.
+**Nunca falhar em silêncio.** A latência era o problema fácil: foi resolvida numa
+tarde assim que o servidor pôde avisar sozinho. Todo o resto existe porque a falha
+cara não é ser lento, é **dizer com confiança que não há e-mail novo estando
+cego**.
 
-Por isso o último UID visto é gravado mensagem a mensagem, por isso o
-`UIDVALIDITY` é conferido a cada conexão, por isso o log de erros é monitorado
-junto com o de eventos, e por isso o hook de início de sessão pergunta se o
-serviço está mesmo rodando. O [`DESIGN.md`](../DESIGN.md) explica cada um e o que
-quebra sem ele.
+Por isso a última mensagem vista é guardada uma a uma, por isso cada conexão
+confere se a caixa continua a mesma, por isso o registro de erros é vigiado junto
+com o de eventos, e por isso ao iniciar uma sessão se pergunta se o serviço está
+mesmo rodando. O [`DESIGN.md`](../DESIGN.md) explica cada um deles e o que quebra
+sem ele.
 
-Construído e verificado de ponta a ponta em 09/08/2026.
+Construído e verificado de ponta a ponta em 2026-08-09.
 
 ## De onde vem o nome
 
@@ -348,4 +390,4 @@ vai buscar o correio no lugar de quem não pode estar em toda parte.
 
 ---
 
-<sub>Traduzido de [`README.md`](../README.md) no commit `2b1fc9c`, que é a fonte da verdade. Se algo aqui contradisser o original em espanhol (MX), **o espanhol prevalece**, e nos avise, porque significa que esta tradução ficou para trás.</sub>
+<sub>Traduzido de [`README.md`](../README.md), que é a fonte da verdade. Se algo aqui contradisser o original em espanhol (MX), **o espanhol prevalece**, e nos avise, porque significa que esta tradução ficou para trás.</sub>


### PR DESCRIPTION
Las cuatro traducciones, rehechas sobre el README accesible. Sale de `docs_es-MX_iteracion_1`, mismo patrón que #99, para que @julianflores pueda leerlas aparte de la reescritura.

## No estaban desactualizadas: estaban traduciendo otro documento

Las cuatro conservaban la estructura anterior a la reescritura:

```
i18n/README.es-ES.md   ## Arquitectura de entrega por entorno · ## Rutas en esta máquina
i18n/README.fr-FR.md   ## Architecture de distribution par environnement · ## Chemins sur cette machine
i18n/README.pt-BR.md   ## Arquitetura de entrega por ambiente · ## Caminhos nesta máquina
```

Ninguna de esas secciones existe ya en la fuente. No eran traducciones atrasadas del es-MX de hoy; eran traducciones fieles de un documento que dejó de existir. Por eso se reconstruyen enteras y no se parchan.

## La trampa de esta ronda, y la medición

La reducción de jerga **es** el cambio, no un efecto lateral. Y en inglés `harness`, `listener`, `dispatcher`, `journal`, `cursor` y `runtime` son las palabras naturales: una traducción fiel las repone sola y deshace el trabajo sin que nadie lo note.

Corrí el mismo conteo en las cinco versiones:

| archivo | términos | desglose |
|---|---|---|
| `README.md` (fuente) | **12** | harness 7 · systemd 1 · lingering 1 · LaunchAgent 1 · IDLE 2 |
| `i18n/README.en-US.md` | **15** | harness 8 · listener 1 · dispatcher 1 · systemd 1 · lingering 1 · LaunchAgent 1 · IDLE 2 |
| `i18n/README.es-ES.md` | **12** | harness 7 · systemd 1 · lingering 1 · LaunchAgent 1 · IDLE 2 |
| `i18n/README.fr-FR.md` | **14** | harness 7 · journal 2 · systemd 1 · lingering 1 · LaunchAgent 1 · IDLE 2 |
| `i18n/README.pt-BR.md` | **12** | harness 7 · systemd 1 · lingering 1 · LaunchAgent 1 · IDLE 2 |

Contra **39** en el es-MX antes de #99.

Las dos que se salen del 12 se explican y ninguna es una fuga:

- **`en-US` 15.** `listener` y `dispatcher` aparecen una vez cada uno, dentro del `<details>` plegado, describiendo las unidades. Ahí el es-MX dice «el escucha» y «el repartidor», y en inglés esos son los nombres. El octavo `harness` es la segunda mitad de «under a harness, that file belongs in the harness's own folder», en la misma frase donde ya estaba glosado.
- **`fr-FR` 14.** Los dos `journal` son la palabra francesa para *bitácora*, no el término técnico. Falso positivo del conteo.

En las cinco, *harness* se presenta antes de usarse. En inglés esa glosa es más necesaria, no menos: la palabra suena tan normal que la tentación es no explicarla.

## Paridad estructural

```
archivo                  secciones  admonitions  details  líneas >100
README.md                    14          3          1          2
i18n/README.en-US.md         14          3          2          3
i18n/README.es-ES.md         14          3          1          3
i18n/README.fr-FR.md         14          3          1          3
i18n/README.pt-BR.md         14          3          1          3
```

El `<details>` de más en `en-US` es el bloque «En español» con el texto para pegarle al agente, que ya existía y se conserva. Las líneas largas son las tres esperadas: el selector de idiomas, la línea de fuentes de la etimología y el pie de traducción.

Las cuatro llevan el `<details>` con los nombres de las unidades, las tres admonitions en su sección de riesgo, la mecánica interna en prosa llana con enlace a `DESIGN.md`, y **ninguna repone el diagrama de tubería**, porque la fuente ya no lo tiene.

## Dos decisiones que conviene ver

**La etimología náhuatl se reutiliza, no se retraduce.** Cada traducción ya la tenía completa y bien hecha: Molina 1571, el Códice Florentino, el mensajero que clasificaba la noticia en el peinado, Paynal, y las tres fuentes con sus enlaces. Volver a traducirla desde el es-MX habría sido rehacer trabajo bueno con riesgo de perder detalle. Se copió el bloque existente de cada archivo.

**El párrafo de apertura de `en-US` es el que escribió @julianflores**, sin tocar una palabra. Es el que ya estaba en ese archivo, y es de donde salió el que ahora abre la fuente en es-MX:

> Paynani lets your AI agent automatically read its own email a few seconds after it arrives, process the messages it receives, and act on their instructions just as a human colleague would.

**El pie de traducción pierde el hash.** Decía «traducido de `README.md` en el commit `2b1fc9c`», un commit que ya no describe nada: la fuente se reescribió dos veces desde entonces y el número seguía ahí, envejeciendo en silencio. Un hash que nadie actualiza miente con más autoridad que no tener hash. Ahora dice de dónde viene y cuál gana, sin fingir precisión que no se mantiene.

## Verificación

- `python3 scripts/test_docs.py` → **23 passed, 0 failed**
- Enlaces relativos, archivo por archivo → **0 rotos en los cinco**
- `i18n/README.es-MX.md` → no existe, y no se creó

## Orden de merge

Este PR va contra `docs_es-MX_iteracion_1`, así que entra antes que #97 y viaja con él a `main`. Si @julianflores prefiere mergear #97 primero, lo rebaso sin problema.

---
Metis Claude-Tob
AI Agent
Senior Full Stack Developer

Inteligencia Artificial Aplicada
https://iaa.org.mx/
