### PR TITLE
Documenta la puerta humana en el changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,82 @@
 # Changelog
 
+## Sin publicar
+
+**El README dejó de ser mitad puerta humana y mitad manual del agente.** Catorce
+commits desde 0.4.0, todos de documentación: ninguna línea de código cambió.
+
+### El diagnóstico no era la prosa, era el vocabulario
+
+El README anterior estaba bien escrito y era correcto. Seguía siendo ilegible
+para alguien sin formación técnica, y eso no se arregla escribiendo mejor:
+
+```
+22 términos especializados · ~90 apariciones · 1,738 palabras de prosa
+                                  ≈ una pieza de jerga cada 19 palabras
+```
+
+Las tres más pesadas caían en las primeras 40 líneas sin explicarse nunca:
+`harness` once veces, `roster` quince, `runtime` tres. Nadie fuera de este
+proyecto sabe qué es un *harness*, así que quien no es técnico lo topaba en la
+línea 23 y concluía, en silencio, que la página no era para él.
+
+Medido después del cambio, la jerga baja de **39 apariciones a 12**. Las que
+quedan son nombres literales de archivo o viven dentro de un bloque plegable.
+`harness` ahora se presenta antes de usarse; `journal` pasó a «se anota en
+disco», `cursor` a «solo marca una como entregada cuando el agente confirma», y
+`UIDVALIDITY` a «se revisa que el buzón siga siendo el mismo».
+
+### La mecánica interna bajó de la portada
+
+El diagrama de tubería con `state/events.jsonl` se fue, y en su lugar quedaron
+tres frases en español llano más el enlace a `DESIGN.md`, que ya explicaba todo
+eso con mucho más cuidado del que cabe en un README. Un diagrama de *pipeline*
+arriba es una señal de «esto no es para ti».
+
+Los nombres exactos de las cuatro unidades de systemd **no se perdieron**: se
+movieron a un `<details>` plegable. La lista visible de «Qué cambia en la
+computadora» dice ahora *dos servicios que quedan corriendo y se reinician
+solos*, y quien necesite `paynani-logrotate.timer` lo abre.
+
+### Lo que la reescritura borró, y volvió
+
+Este trabajo salió en cinco vueltas, y en el camino se borraron cosas que había
+que devolver: la sección de consentimiento con las unidades y la regla permanente
+que se agrega a las instrucciones del agente, el aviso de que `git clean -xdf`
+se lleva la contraseña del buzón, el mecanismo de actualización completo, toda
+referencia a `UNINSTALL.md`, y el pie que declara cuál idioma gana.
+
+Dos se recuperaron al final y son las más humanas del documento: el párrafo de
+apertura, y la etimología náhuatl completa, que había quedado en tres líneas. Que
+la sección menos técnica del README sea también la más legible para quien no es
+técnico no es casualidad.
+
+### Las cuatro traducciones no estaban atrasadas
+
+Estaban traduciendo un documento que ya no existe. Las cuatro conservaban
+`Arquitectura de entrega por entorno` y `Rutas en esta máquina`, secciones que la
+reescritura eliminó, así que se reconstruyeron enteras en vez de parchearse.
+
+Esa reconstrucción trajo una restricción que las traducciones antes no tenían: la
+reducción de jerga **es** el cambio, y en inglés `harness`, `listener`,
+`dispatcher`, `journal`, `cursor` y `runtime` son las palabras naturales. Una
+traducción fiel las repone sola y deshace el trabajo sin que nadie lo note. Las
+cinco versiones quedaron medidas entre 12 y 15 términos.
+
+### Sobre `blader/humanizer`
+
+Se evaluó el skill para este objetivo y no era la herramienta. Quita señales de
+escritura de IA —contrastes no-X-sino-Y, cierres de una línea, tríadas forzadas,
+rayas largas como conector— y el README ya pasaba casi limpio: **0 rayas largas,
+0 no-X-sino-Y, 0 comillas curvas**. Sirve como pasada de acabado, no como el
+arreglo. Sus listas de palabras además son de inglés, así que sobre una fuente
+es-MX solo transfieren los patrones estructurales.
+
+### Lo que sigue pendiente
+
+La prueba que de verdad cuenta no se ha hecho: dárselo a leer a alguien no
+técnico y ver en qué renglón se detiene. Todo lo anterior son proxies.
+
 ## 0.4.0 — 2026-09-07
 
 **`main` ya no depende de que nadie se acuerde de correr las pruebas.** 30 commits


### PR DESCRIPTION
## Qué cambia

Solo `CHANGELOG.md`. Agrega una sección **Sin publicar** que describe los catorce commits de documentación que entraron a `main` después de `v0.4.0`, ninguno de los cuales estaba descrito en ningún lado.

Es la misma situación que nos costó la mañana —quince commits posteriores al rc sin documentar, reconstruidos a mano en #98— atrapada esta vez el mismo día en que se creó, mientras las mediciones siguen a la mano.

## Qué documenta

- El diagnóstico medido: 22 términos especializados en 1,738 palabras, uno cada 19, y los tres más pesados sin explicar en las primeras 40 líneas.
- La reducción de jerga de 39 apariciones a 12, y cómo se logró término por término.
- La mecánica interna que bajó de la portada, y el `<details>` que conserva los nombres exactos de las unidades.
- Lo que la reescritura borró en el camino y hubo que devolver, incluida la etimología náhuatl y el párrafo de apertura.
- Por qué las cuatro traducciones se reconstruyeron en vez de parchearse, y la trampa que esta ronda les agregaba.
- La evaluación de `blader/humanizer` y por qué no era la herramienta para este objetivo.
- Lo que sigue pendiente: la prueba con una persona no técnica de verdad.

## Por qué "Sin publicar" y no "0.4.1"

`VERSION` sigue en `0.4.0`, y en este repositorio `VERSION` y el encabezado del changelog se mueven juntos: los tres tags publicados apuntan a commits donde `VERSION` ya decía ese número. Ponerle `0.4.1` a la sección sin bajar también `VERSION` crearía la contradicción que `scripts/version.sh` existe para evitar.

**Decisión tuya, @julianflores:** si quieres cortar `0.4.1` con esto, renombro la sección a `## 0.4.1 — <fecha>`, subo `VERSION` y corto el tag. Si prefieres que espere a que se acumule algo más, la sección se queda como está y el encabezado se renombra cuando decidas.

## Verificación

- `./scripts/test_all.sh` → 17 passed, 0 failed
- Líneas >93 caracteres, el máximo del archivo → 0
- Ninguna sección `##` duplicada