### PR TITLE
Arregla las tres pruebas que fallaban en macOS por asumir Linux

### DIFF
--- a/scripts/test_hermes_install.py
+++ b/scripts/test_hermes_install.py
@@ -6,6 +6,7 @@ import hmac
 import json
 import os
 import pathlib
+import platform
 import re
 import subprocess
 import sys
@@ -56,6 +57,26 @@ class _HermesFixture(BaseHTTPRequestHandler):
         pass
 
 
+# scripts/install.sh:17 hands the whole install to scripts/install_macos.py on
+# Darwin, and install_macos.py:215 refuses `--runtime hermes` with EX_USAGE:
+# Hermes is not a supported runtime on macOS. Every test in the class below
+# installs Hermes, so on macOS they asserted Linux exit codes against a platform
+# that had already said no -- `AssertionError: 10 != 64` with the refusal message
+# sitting in the failure text. Found by the macOS CI job in #104.
+#
+# This is a check on the operating system, on purpose, and it is not the kind
+# that caused #68 and #80. Those asked "GNU or BSD?" about a tool by asking about
+# the machine, and got it wrong the moment a machine had the other one. This asks
+# which installer the product dispatches to, and the product decides that by
+# operating system, because launchd and systemd are an operating system fact.
+HERMES_INSTALL_SUPPORTED = platform.system() != "Darwin"
+
+
+@unittest.skipUnless(
+    HERMES_INSTALL_SUPPORTED,
+    "hermes install is Linux-only: install.sh dispatches to install_macos.py, "
+    "which refuses --runtime hermes. The refusal itself is asserted below.",
+)
 class HermesInstallerTest(unittest.TestCase):
     def setUp(self):
         self.temp = tempfile.TemporaryDirectory()
@@ -396,6 +417,71 @@ printf 'Hermes webhook support\\n'
         self.assertNotIn("hermes_notify_secret=", converged.stdout)
         self.assertNotIn("hermes_roster_secret=", converged.stdout)
         self.assertEqual(["GET", "POST", "POST", "POST"], [item[0] for item in _HermesFixture.requests])
+
+
+
+@unittest.skipIf(
+    HERMES_INSTALL_SUPPORTED,
+    "there is nothing to refuse on a platform where hermes installs",
+)
+class HermesRefusedOnMacOSTest(unittest.TestCase):
+    """
+    What macOS gets instead of the suite above.
+
+    Skipping the Hermes tests on macOS is correct and would have been a gap if it
+    stopped there: the platform would go from four false failures to no coverage,
+    and both look green. This asserts the behaviour that replaces them -- that
+    asking for Hermes on macOS is refused, cleanly, before anything is written.
+
+    The refusal is worth pinning rather than assuming. A future installer that
+    grew partial Hermes support, or one that started the install and failed
+    halfway, would both pass a test that only checked "not zero".
+    """
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp.name)
+        self.home = self.root / "home"
+        self.home.mkdir(mode=0o700)
+        self.clone = self.home / "workspace" / "paynani"
+        self.clone.parent.mkdir(parents=True, mode=0o700)
+        shutil.copytree(ROOT, self.clone, symlinks=True)
+        for leftover in ("state", ".env", "runtime.env", "install.manifest", "hermes"):
+            target = self.clone / leftover
+            if target.is_dir():
+                shutil.rmtree(target)
+            elif target.exists():
+                target.unlink()
+        self.addCleanup(self.temp.cleanup)
+
+    def test_hermes_is_refused_before_anything_is_written(self):
+        completed = subprocess.run(
+            [
+                str(self.clone / "scripts" / "install.sh"),
+                "--runtime", "hermes",
+                "--profile", "default",
+                "--non-interactive",
+            ],
+            cwd=self.clone,
+            env={**os.environ, "HOME": str(self.home)},
+            text=True,
+            capture_output=True,
+        )
+        output = completed.stdout + completed.stderr
+
+        # 64 is EX_USAGE. Asserting the exact code rather than "nonzero" is the
+        # point: a crash halfway through an install is also nonzero.
+        self.assertEqual(64, completed.returncode, output)
+        self.assertIn("openclaw", output)
+        self.assertIn("codex", output)
+
+        # Refused means refused. An install that said no and still wrote is the
+        # failure this assertion exists for.
+        for leftover in ("install.manifest", "runtime.env", "hermes", "state"):
+            self.assertFalse(
+                (self.clone / leftover).exists(),
+                f"refused install wrote {leftover} into the install root",
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/test_paths.sh
+++ b/scripts/test_paths.sh
@@ -22,7 +22,24 @@ SOURCE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # on whether the person running it happened to have paynani installed — the
 # result depended on undeclared local state, which is the failure this whole
 # repository is about. Overriding HOME was never enough on its own.
-CLONE=$(mktemp -d)
+# Every temporary directory in this suite goes through here.
+#
+# macOS resolves /var to /private/var, and every implementation under test
+# resolves the paths it hands back, so a raw `mktemp -d` builds an `expected`
+# string the code can never produce: expected /var/folders/…/.env against actual
+# /private/var/folders/…/.env. 27 assertions failed on macOS for that and not one
+# of them was about a path being wrong.
+#
+# `cd` plus `pwd -P` resolves symlinks using nothing but the shell. `realpath`
+# and `readlink -f` are both GNU, and macOS ships neither -- reaching for one of
+# them here would trade this defect for the family that caused #61, #68 and #80.
+tmpdir() {
+    local d
+    d=$(mktemp -d) || return 1
+    (cd "$d" && pwd -P)
+}
+
+CLONE=$(tmpdir)
 trap 'rm -rf "$CLONE"' EXIT
 mkdir -p "$CLONE/harness" "$CLONE/scripts" "$CLONE/webapp/lib"
 cp "$SOURCE_ROOT/harness/paths.py" "$CLONE/harness/"
@@ -135,7 +152,7 @@ agree_all() {   # description, home
 # A host with nothing on it. Everything hangs off the clone, and nothing is
 # written under ~/.config or ~/.local/state at all.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 agree_all "fresh host" "$home"
 check "fresh host: credentials are .env in the clone" "$ROOT/.env" "$(py "$home" "" env)"
 check "fresh host: state is one tree in the clone" "$ROOT/state" "$(py "$home" "" state)"
@@ -157,7 +174,7 @@ rm -rf "$home"
 # directory because it is named after this project would put an agent's
 # credentials somewhere the operator never chose.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 mkdir -p "$home/.config/paynani" "$home/.local/state/paynani"
 agree_all "empty leftover directories" "$home"
 check "empty leftover directories: not adopted for credentials" "$ROOT/.env" "$(py "$home" "" env)"
@@ -169,7 +186,7 @@ rm -rf "$home"
 # disagree" property is conditional on neither being set, and this pins that
 # reading rather than leaving the docstring to carry it.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 check "PAYNANI_STATE alone moves state and leaves credentials" "$ROOT/.env" \
     "$(HOME="$home" PAYNANI_STATE=/srv/state python3 "$ROOT/harness/paths.py" env)"
 check "PAYNANI_STATE alone is honoured for state" "/srv/state" \
@@ -180,7 +197,7 @@ rm -rf "$home"
 # An install that said where its credentials are. Nothing second-guesses it,
 # including a harness file sitting right there.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 mkdir -p "$home/.openclaw/workspace"
 printf 'AGENT_EMAIL_ACCOUNT=ignored@example.com\n' >"$home/.openclaw/workspace/.env"
 agree "explicit override" "$home" "/etc/paynani/env"; resolved=$RESOLVED
@@ -190,7 +207,7 @@ rm -rf "$home"
 # ---------------------------------------------------------------------------
 # The same for the state tree. An install that pinned it stays pinned.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 check "explicit state override: wins on a fresh host" "/srv/paynani-state" \
     "$(HOME="$home" PAYNANI_STATE=/srv/paynani-state python3 "$ROOT/harness/paths.py" state)"
 check "explicit state override: shell agrees" "/srv/paynani-state" \
@@ -206,7 +223,7 @@ rm -rf "$home"
 # would adopt it: the install would read credentials it was never given. Only
 # the names this project has ever written are looked at.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 mkdir -p "$home/.config/apollo-agentmail" "$home/.hermes"
 printf 'ACCOUNT=someone-elses@example.com\n' >"$home/.config/apollo-agentmail/config"
 printf 'HERMES_TOKEN=not-ours\n' >"$home/.hermes/.env"
@@ -228,7 +245,7 @@ import sys; sys.path.insert(0, '$ROOT/harness')
 import paths; print(paths.repo_root())
 ")
 check "the repo root is this checkout" "$ROOT" "$found"
-home=$(mktemp -d)
+home=$(tmpdir)
 checkout="$home/elsewhere/paynani"
 mkdir -p "$checkout/harness"
 checkout=$(cd "$checkout" && pwd -P)
@@ -245,7 +262,7 @@ PY
 )
 check "the repo root is found from an arbitrary checkout" "$checkout" "$found"
 rm -rf "$home"
-check "the install root is the clone" "$ROOT" "$(py "$(mktemp -d)" "" root)"
+check "the install root is the clone" "$ROOT" "$(py "$(tmpdir)" "" root)"
 
 # ---------------------------------------------------------------------------
 # Every runtime-owned path is ignored by git.
@@ -293,7 +310,7 @@ fi
 # hang off the clone, and that split is deliberate: the harness owns that file
 # and this project does not.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 mkdir -p "$home/.hermes/workspace"
 printf 'PAYNANI_EMAIL=agent@example.com\n' >"$home/.hermes/workspace/.env"
 agree_all "hermes harness" "$home"
@@ -323,7 +340,7 @@ rm -rf "$home"
 # #88 — so this pins all three in agreement the same way the hermes and
 # openclaw cases above do.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 mkdir -p "$home/.claude/workspace"
 printf 'PAYNANI_EMAIL=agent@example.com\n' >"$home/.claude/workspace/.env"
 agree_all "claude harness" "$home"
@@ -349,7 +366,7 @@ rm -rf "$home"
 # only workspace/.env resolves under the runtime root, while state, runtime.env,
 # the manifest, Hermes secrets and the roster remain clone-owned.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 mkdir -p "$home/.codex/workspace"
 printf 'PAYNANI_EMAIL=agent@example.com\n' >"$home/.codex/workspace/.env"
 agree_all "codex harness" "$home"
@@ -379,7 +396,7 @@ rm -rf "$home"
 # The unrelated-deployment case above plants exactly this file; this states the
 # reason separately so the next reader cannot delete one and keep the other.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 mkdir -p "$home/.hermes"
 printf 'HERMES_TOKEN=not-ours\n' >"$home/.hermes/.env"
 agree_all "runtime own config" "$home"
@@ -397,7 +414,7 @@ rm -rf "$home"
 # this install keeps its own files. State, config and secrets stay in the
 # clone regardless.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 mkdir -p "$home/.openclaw/workspace"
 printf 'AGENT_EMAIL_ACCOUNT=agent@example.com\n' >"$home/.openclaw/workspace/.env"
 agree_all "openclaw harness" "$home"
@@ -426,7 +443,7 @@ rm -rf "$home"
 # today. Since #72 the OpenClaw credentials file no longer pins the layout, so
 # this host is an ordinary one and the fallback is the clone's own file.
 # ---------------------------------------------------------------------------
-home=$(mktemp -d)
+home=$(tmpdir)
 mkdir -p "$home/.hermes/workspace" "$home/.openclaw/workspace"
 printf 'PAYNANI_EMAIL=hermes@example.com\n' >"$home/.hermes/workspace/.env"
 printf 'AGENT_EMAIL_ACCOUNT=openclaw@example.com\n' >"$home/.openclaw/workspace/.env"
@@ -445,7 +462,7 @@ rm -rf "$home"
 # installer settles it with PAYNANI_ENV and records the answer here; before that
 # it settled it only for the systemd unit, and every other tool went on
 # resolving to a <clone>/.env that does not exist.
-home=$(mktemp -d)
+home=$(tmpdir)
 mkdir -p "$home/.openclaw/workspace" "$home/.claude/workspace"
 : >"$home/.openclaw/workspace/.env"
 : >"$home/.claude/workspace/.env"

--- a/scripts/test_preflight.sh
+++ b/scripts/test_preflight.sh
@@ -30,29 +30,60 @@ check() {   # description, expected, actual
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
+# `case` inside `$( )` is the shape that broke this whole file on macOS.
+#
+# bash 3.2 closes the command substitution at the first unbalanced `)`, and a
+# case pattern -- `*"IMAP host:"*)` -- is exactly that. The whole file was a
+# syntax error on any host with bash 3.2, which is every stock macOS, and the
+# suite reported `syntax error near unexpected token 'newline'` rather than a
+# failing assertion. bash 5 parses it, so nothing showed on Linux.
+#
+# Moving the case into a function body is the fix: the substitution now wraps a
+# plain call, and the pattern's `)` is nowhere near it.
+contains() {
+	case "$1" in
+		*"$2"*) echo yes ;;
+		*)      echo no  ;;
+	esac
+}
+
+# `timeout` is GNU coreutils and macOS does not ship it, so a bare `timeout 20`
+# here is a command that is not there -- exit 127, and every assertion about the
+# real exit status fails for a reason that has nothing to do with preflight.
+# Same trade as scripts/version.sh made for #68: keep the ceiling where the tool
+# exists, run without it where it does not. A test that runs unbounded beats one
+# that cannot run.
+limit=()
+if command -v timeout >/dev/null 2>&1; then
+	limit=(timeout 20)
+elif command -v gtimeout >/dev/null 2>&1; then
+	limit=(gtimeout 20)
+fi
+
+
 # ---------------------------------------------------------------------------
 # No credentials file, no terminal: the case an agent actually hits.
 # ---------------------------------------------------------------------------
-out=$(PAYNANI_ENV="$tmp/missing" timeout 20 python3 "$PREFLIGHT" </dev/null 2>&1)
+out=$(PAYNANI_ENV="$tmp/missing" ${limit[@]+"${limit[@]}"} python3 "$PREFLIGHT" </dev/null 2>&1)
 status=$?
 
 check "no credentials: exits 1" "1" "$status"
 check "no credentials: does not prompt for a host" "no" \
-    "$(case $out in *"IMAP host:"*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" "IMAP host:")"
 check "no credentials: names the file it looked in" "yes" \
-    "$(case $out in *"$tmp/missing"*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" "$tmp/missing")"
 check "no credentials: points at the setup form" "yes" \
-    "$(case $out in *setup_web.sh*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" setup_web.sh)"
 check "no credentials: says which step it belongs to" "yes" \
-    "$(case $out in *"AGENTS.md step 2"*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" "AGENTS.md step 2")"
 
 # ---------------------------------------------------------------------------
 # A file that exists but holds nothing useful is the same situation.
 # ---------------------------------------------------------------------------
 printf '# nothing here yet\n\n' >"$tmp/empty"
-out=$(PAYNANI_ENV="$tmp/empty" timeout 20 python3 "$PREFLIGHT" </dev/null 2>&1)
+out=$(PAYNANI_ENV="$tmp/empty" ${limit[@]+"${limit[@]}"} python3 "$PREFLIGHT" </dev/null 2>&1)
 check "empty credentials file: treated as nothing to check" "yes" \
-    "$(case $out in *"nothing to check yet"*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" "nothing to check yet")"
 
 # ---------------------------------------------------------------------------
 # With settings present it must get past the guard and actually try the server.
@@ -64,11 +95,11 @@ PAYNANI_IMAP_PORT=993
 PAYNANI_EMAIL=agent@example.com
 PAYNANI_PASSWORD=not-used
 EOF
-out=$(PAYNANI_ENV="$tmp/env" timeout 30 python3 "$PREFLIGHT" </dev/null 2>&1)
+out=$(PAYNANI_ENV="$tmp/env" ${limit[@]+"${limit[@]}"} python3 "$PREFLIGHT" </dev/null 2>&1)
 check "settings present: gets past the guard" "no" \
-    "$(case $out in *"nothing to check yet"*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" "nothing to check yet")"
 check "settings present: actually tries the server" "yes" \
-    "$(case $out in *no-such-host.invalid*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" no-such-host.invalid)"
 
 # ---------------------------------------------------------------------------
 # --help answers without opening a socket (issue #7).
@@ -77,29 +108,29 @@ check "settings present: actually tries the server" "yes" \
 # therefore names itself in the output the moment the network is touched. So
 # "does not mention the host" is a real assertion here and not a tautology.
 # ---------------------------------------------------------------------------
-out=$(PAYNANI_ENV="$tmp/env" timeout 20 python3 "$PREFLIGHT" --help </dev/null 2>&1)
+out=$(PAYNANI_ENV="$tmp/env" ${limit[@]+"${limit[@]}"} python3 "$PREFLIGHT" --help </dev/null 2>&1)
 status=$?
 
 check "--help: exits 0" "0" "$status"
 check "--help: prints the usage line" "yes" \
-    "$(case $out in *"Usage:"*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" "Usage:")"
 check "--help: does not connect" "no" \
-    "$(case $out in *no-such-host.invalid*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" no-such-host.invalid)"
 
-out=$(PAYNANI_ENV="$tmp/env" timeout 20 python3 "$PREFLIGHT" -h </dev/null 2>&1)
+out=$(PAYNANI_ENV="$tmp/env" ${limit[@]+"${limit[@]}"} python3 "$PREFLIGHT" -h </dev/null 2>&1)
 check "-h: same as --help" "yes" \
-    "$(case $out in *"Usage:"*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" "Usage:")"
 
 # An unknown flag is refused rather than ignored: silently doing nothing leaves
 # the caller believing it took effect.
-out=$(PAYNANI_ENV="$tmp/env" timeout 20 python3 "$PREFLIGHT" --no-such-flag </dev/null 2>&1)
+out=$(PAYNANI_ENV="$tmp/env" ${limit[@]+"${limit[@]}"} python3 "$PREFLIGHT" --no-such-flag </dev/null 2>&1)
 status=$?
 
 check "unknown flag: exits 2" "2" "$status"
 check "unknown flag: names the argument" "yes" \
-    "$(case $out in *--no-such-flag*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" --no-such-flag)"
 check "unknown flag: does not connect" "no" \
-    "$(case $out in *no-such-host.invalid*) echo yes ;; *) echo no ;; esac)"
+    "$(contains "$out" no-such-host.invalid)"
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Los tres defectos **de prueba** que destapó el job de macOS del #104 en su primera corrida. Ninguno toca código de producto: las tres suites verifican bien y asumen Linux al hacerlo.

Quedan fuera a propósito los dos que sí pueden ser de producto —el [#105](https://github.com/iaaorgmx/paynani/issues/105) del `flock` y el keepalive de `test_listener.py`— porque piden decisiones distintas y uno todavía espera un dato del Mac de @ximenasalazartob.

## `test_preflight.sh` no compilaba en macOS

No fallaba una aserción: **el archivo entero era inválido.**

```text
scripts/test_preflight.sh: command substitution: line 40: syntax error near unexpected token `newline'
```

bash 3.2 cierra una sustitución de comandos en el primer `)` sin balancear, y el patrón de un `case` es exactamente eso:

```bash
"$(case $out in *"IMAP host:"*) echo yes ;; *) echo no ;; esac)"
#                             ^ aquí termina el $( para bash 3.2
```

Doce líneas con esa forma. bash 5 la parsea, así que en Linux nunca se vio; macOS trae 3.2 de fábrica. El `case` se muda al cuerpo de una función `contains()` y la sustitución pasa a envolver una llamada simple, con el `)` del patrón lejos.

De paso, **seis `timeout` crudos**. En macOS es un comando ausente: exit 127, y toda aserción sobre el código de salida real falla por una razón que no tiene que ver con preflight. Mismo trato portátil que `version.sh` adoptó para el #68 — se conserva el techo donde la herramienta existe y se corre sin él donde no.

## `test_paths.sh` fallaba 27 aserciones, ninguna sobre rutas

```text
expected: /var/folders/…/tmp.twrQKyvsVG/.env
actual:   /private/var/folders/…/tmp.twrQKyvsVG/.env
```

macOS resuelve `/var` a `/private/var`, y las tres implementaciones bajo prueba resuelven las rutas que devuelven. Comparar la salida cruda de `mktemp -d` construía un `expected` que el código no puede producir nunca.

Ahora todo directorio temporal pasa por un `tmpdir()` que resuelve al crear, con `cd` y `pwd -P`, que es shell puro. **`realpath` y `readlink -f` son GNU y macOS no trae ninguno**: usar uno aquí habría cambiado este defecto por la familia que causó el #61, el #68 y el #80.

## `test_hermes_install.py` afirmaba códigos de salida de Linux

```text
AssertionError: 10 != 64 : install: macOS install currently supports --runtime openclaw and codex only
```

El 64 era correcto. `scripts/install.sh:17` entrega el install completo a `install_macos.py` en Darwin, y `install_macos.py:215` rechaza `--runtime hermes` con `EX_USAGE`. Las cinco pruebas de esa clase instalan Hermes, así que afirmaban semántica de Linux contra una plataforma que ya había dicho que no.

La clase se salta en macOS **con la razón escrita**. Y como saltarse sin reemplazar cobertura es justo lo que critiqué en el [#102](https://github.com/iaaorgmx/paynani/issues/102), en su lugar corre una prueba nueva que solo existe en macOS y fija la negativa:

- `EX_USAGE` **exacto**, no «distinto de cero»: un install que revienta a la mitad también es distinto de cero.
- El mensaje nombra los runtimes que sí soporta.
- Y nada quedó escrito en el árbol: `install.manifest`, `runtime.env`, `hermes` y `state` siguen sin existir. Rechazar significa rechazar.

Es decir, macOS pasa de cuatro fallos falsos a una comprobación que antes no tenía.

## Sobre la detección por sistema operativo

`HERMES_INSTALL_SUPPORTED` mira `platform.system()`, y quiero dejar dicho por qué eso no contradice la regla que este repo aprendió con el #68 y el #80.

Aquellas preguntaban «¿GNU o BSD?» sobre una **herramienta**, y lo preguntaban mirando la máquina; se rompían en cuanto una máquina tenía la otra. Esta pregunta es cuál instalador despacha el producto, y **el producto lo decide por sistema operativo** en `install.sh:17`, porque launchd y systemd son un hecho del sistema operativo. Los otros dos arreglos de este PR, en cambio, detectan por capacidad: `command -v timeout`, y `pwd -P` en vez de elegir entre `realpath` y `readlink -f`.

## Verificación

- `./scripts/test_all.sh` en Linux → **17 passed, 0 failed**
- `scripts/test_paths.sh` → 167 passed, 0 failed
- `scripts/test_preflight.sh` → 15 passed, 0 failed
- `scripts/test_hermes_install.py` → Ran 6 tests, OK (skipped=1) — la saltada es la nueva de macOS, correcto en Linux
- `bash -n` limpio en los dos scripts

**La verificación que importa la hace el propio `suite-macos` en este PR.** Es la primera vez que un arreglo de esta familia se puede comprobar sin pedirle a alguien que preste su Mac. Si el job pasa de seis rojos a dos, el #104 se pagó solo.

---
Metis Claude-Tob
AI Agent
Senior Full Stack Developer

Inteligencia Artificial Aplicada
https://iaa.org.mx/