### PR TITLE
Arregla el lock del watcher, que fallaba en dos direcciones

### DIFF
--- a/harness/session_watch.sh
+++ b/harness/session_watch.sh
@@ -27,17 +27,137 @@ mkdir -p "$STATE_DIR"
 # arms a watcher at all. Here it must, because nothing can push into a Claude
 # Code session -- so the guard moves here instead of disappearing.
 #
-# A second session arming this exits immediately rather than quietly halving the
-# accuracy of both.
-exec 9>"$LOCK"
-if ! flock -n 9; then
-	# stdout, not stderr (#62). From Claude Code's side, stderr on this command
-	# goes to a file nothing reads; the session sees "Monitor ended without
-	# producing output (exit 0)", which is indistinguishable from a quiet
-	# mailbox. A stdout line is a notification and actually reaches the session
-	# that just found out it is not armed.
-	echo "[watch] another session is already watching this spool; not arming a second."
-	exit 0
+# The guard used to be `flock -n` on a file descriptor, and it failed in two
+# directions at once.
+#
+# On macOS it failed always (#105). `flock` is util-linux and macOS does not
+# ship it, so the command exited 127, `! flock -n 9` was true, and every session
+# took the "somebody else is watching" branch and exited 0 without arming. The
+# line it printed was not a silence -- it was a reassuring lie, which is worse.
+#
+# On Linux it failed when the holder was alive but useless (#62). The guard
+# assumed whoever holds the lock is a session that will render what it reads. A
+# watcher whose parent session had been suspended for nearly nine hours kept
+# draining the spool and advancing the cursor, so the next session could not arm,
+# did not know it, and never replayed the backlog either: it had been
+# acknowledged by nobody. Every indicator green, no mail delivered.
+#
+# What replaces it holds to the same rule -- exactly one watcher -- and adds the
+# question the old one never asked: is the watcher that holds this lock attached
+# to a session that can still show a message to a person?
+LOCK_DIR="$LOCK.d"
+OWNER_FILE="$LOCK_DIR/owner"
+
+# `mkdir` is the lock. It is atomic on every POSIX filesystem and it needs no
+# binary that a platform might not ship, which is the whole of #105. The
+# directory is removed on exit; a holder killed hard leaves it behind, and that
+# is what the liveness check below is for.
+#
+# Recorded inside: this watcher's pid, and the pid of the session that owns it.
+# The second one is the one that matters. In #62 the watcher itself was alive and
+# working perfectly -- it was the session above it that had stopped being able to
+# receive anything.
+session_pid=$PPID
+watcher_pid=$$
+
+# Alive is not the same as usable, and this is the distinction #62 was about.
+session_is_usable() {
+	local pid=$1 state
+	[ -n "$pid" ] || return 1
+	kill -0 "$pid" 2>/dev/null || return 1
+
+	# `ps -o state=` is POSIX and answers on both Linux and macOS, which is why
+	# it is here instead of /proc: a check that only works on the platform where
+	# the bug was found is how #105 happened.
+	state=$(ps -o state= -p "$pid" 2>/dev/null | tr -d ' ')
+	case "$state" in
+		T*)
+			# Suspended by SIGTSTP. Alive, and it will not render a line until
+			# somebody continues it -- which may be never. This is the case that
+			# ate nine hours of mail.
+			return 1
+			;;
+		"")
+			# The process exists and `ps` would not say what it is doing. Treat
+			# it as usable rather than steal from it: a wrong steal gives two
+			# watchers on one cursor, which is the corruption this guard exists
+			# to prevent. The caller says this out loud rather than deciding in
+			# silence.
+			return 0
+			;;
+		*)
+			return 0
+			;;
+	esac
+}
+
+read_owner() {   # field
+	[ -r "$OWNER_FILE" ] || return 1
+	awk -v want="$1" -F'=' '$1 == want { print $2 }' "$OWNER_FILE" 2>/dev/null
+}
+
+claim_lock() {
+	mkdir "$LOCK_DIR" 2>/dev/null || return 1
+	printf 'watcher=%s
+session=%s
+' "$watcher_pid" "$session_pid" >"$OWNER_FILE"
+	# Release on every ordinary exit. A hard kill skips this, and the stale
+	# branch below is what covers that.
+	trap 'rm -rf "$LOCK_DIR"' EXIT
+	return 0
+}
+
+if ! claim_lock; then
+	held_session=$(read_owner session)
+	held_watcher=$(read_owner watcher)
+
+	if [ -z "$held_session" ]; then
+		# A lock directory with no readable owner is not a watcher, it is
+		# wreckage: an older version, or a process killed between mkdir and the
+		# write. Taking it over is right, and saying so is what keeps this from
+		# being the silent branch all over again.
+		echo "[watch] found a watch lock with no owner recorded; taking it over."
+		rm -rf "$LOCK_DIR"
+		claim_lock || {
+			echo "[watch] could not take the watch lock; NOT armed. Mail will queue but nothing will show it."
+			exit 1
+		}
+	elif session_is_usable "$held_session"; then
+		echo "[watch] another session is already watching this spool; not arming a second."
+		exit 0
+	else
+		# The holder is gone, or suspended and going to stay that way. Its
+		# watcher is either dead with it or still draining into a session that
+		# cannot show anything -- #62 either way.
+		echo "[watch] the session holding this watch (pid $held_session) is gone or suspended; taking over."
+		if [ -n "$held_watcher" ] && kill -0 "$held_watcher" 2>/dev/null; then
+			# Stop the orphan before arming, or two readers advance one cursor
+			# and the corruption this guard prevents happens anyway.
+			kill "$held_watcher" 2>/dev/null || true
+			echo "[watch] stopped the orphaned watcher (pid $held_watcher)."
+		fi
+		rm -rf "$LOCK_DIR"
+		claim_lock || {
+			echo "[watch] could not take the watch lock after clearing it; NOT armed. Mail will queue but nothing will show it."
+			exit 1
+		}
+	fi
+fi
+
+# Cross-version guard, and only where it can matter.
+#
+# A watcher from before this change holds `flock` on the lock *file*, and knows
+# nothing about the directory above. Honouring the old lock where `flock` exists
+# keeps the two versions excluding each other through an upgrade. Where `flock`
+# does not exist there is nothing to honour and nothing to miss: on macOS the old
+# script never armed at all, so no legacy watcher can be running there.
+if command -v flock >/dev/null 2>&1; then
+	exec 9>"$LOCK"
+	if ! flock -n 9; then
+		echo "[watch] a watcher from a previous version still holds this spool; not arming a second."
+		echo "[watch] restart that session, or end it, and arm again."
+		exit 0
+	fi
 fi
 
 # Arming the watch is what acknowledges the backlog the hook just replayed.

--- a/scripts/test_claudecode.py
+++ b/scripts/test_claudecode.py
@@ -376,8 +376,12 @@ class Watcher(unittest.TestCase):
         first = sp.Popen(["bash", str(self.WATCH), str(self.state), "0"],
                          stdout=sp.PIPE, stderr=sp.PIPE, text=True)
         self.addCleanup(lambda: (first.kill(), first.stdout.close(), first.stderr.close()))
+        # The lock is the directory, not the file. The file was the flock
+        # target and it is only created where `flock` exists, so waiting on it
+        # made this test hang on any host without it -- macOS, where the thing
+        # under test was broken in the first place (#105).
         deadline = __import__("time").time() + 5
-        while not (self.state / "session.watch.lock").exists():
+        while not (self.state / "session.watch.lock.d").exists():
             if __import__("time").time() > deadline:
                 self.fail("first watcher never took the lock")
             __import__("time").sleep(0.05)
@@ -405,6 +409,137 @@ class Watcher(unittest.TestCase):
                 self.fail("offset was never written")
             time.sleep(0.05)
         self.assertGreaterEqual(int(offset.read_text().strip()), 4)
+
+    # ---- a host without flock: what #105 was ------------------------------
+    #
+    # `flock` is util-linux and macOS does not ship it. The old guard read the
+    # missing command's exit 127 as "somebody else holds this", so every session
+    # on a Mac announced a watcher that did not exist and armed nothing.
+    #
+    # These run against a PATH built out of symlinks to what the script actually
+    # uses, minus flock. That is closer to the real thing than mocking, and it
+    # runs on Linux, so the platform that has the tool still proves the branch
+    # for the platform that does not.
+
+    def _path_without_flock(self):
+        import shutil as sh
+        bin_dir = pathlib.Path(self.tmp.name) / "nobin"
+        bin_dir.mkdir(exist_ok=True)
+        for tool in ("bash", "sh", "ps", "awk", "tail", "wc", "tr", "mkdir",
+                     "rm", "mv", "cat", "sleep", "kill", "printf", "sed"):
+            found = sh.which(tool)
+            if found:
+                link = bin_dir / tool
+                if not link.exists():
+                    link.symlink_to(found)
+        self.assertIsNone(sh.which("flock", path=str(bin_dir)),
+                          "the fixture PATH must not contain flock")
+        return {**os.environ, "PATH": str(bin_dir)}
+
+    def _wait_for_arming(self, proc, timeout=8):
+        import time
+        offset = self.state / "session.offset"
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if offset.exists() and (self.state / "session.watch.lock.d").exists():
+                return True
+            if proc.poll() is not None:
+                return False
+            time.sleep(0.05)
+        return False
+
+    def test_it_arms_without_the_flock_binary(self):
+        """#105: no flock is not the same as somebody else is watching."""
+        import subprocess as sp
+        (self.state / "session.spool").write_text("", encoding="utf-8")
+        proc = sp.Popen(["bash", str(self.WATCH), str(self.state), "0"],
+                        stdout=sp.PIPE, stderr=sp.PIPE, text=True,
+                        env=self._path_without_flock())
+        self.addCleanup(lambda: (proc.kill(), proc.stdout.close(), proc.stderr.close()))
+        self.assertTrue(self._wait_for_arming(proc),
+                        "the watcher did not arm on a host without flock")
+
+    def test_two_without_flock_still_yield_exactly_one_watcher(self):
+        """
+        The guard has to keep guarding once the binary it used is gone.
+
+        Losing exclusivity here is not a smaller bug than #105, it is the one the
+        guard was written for: two readers advancing one cursor is how events got
+        duplicated and the record of what had been seen was corrupted.
+        """
+        import subprocess as sp
+        env = self._path_without_flock()
+        (self.state / "session.spool").write_text("", encoding="utf-8")
+        first = sp.Popen(["bash", str(self.WATCH), str(self.state), "0"],
+                         stdout=sp.PIPE, stderr=sp.PIPE, text=True, env=env)
+        self.addCleanup(lambda: (first.kill(), first.stdout.close(), first.stderr.close()))
+        self.assertTrue(self._wait_for_arming(first))
+
+        second = sp.run(["bash", str(self.WATCH), str(self.state), "0"],
+                        capture_output=True, text=True, timeout=15, env=env)
+        self.assertEqual(0, second.returncode)
+        self.assertIn("already watching", second.stdout)
+        self.assertEqual("", second.stderr)
+
+    # ---- a holder that is alive and useless: what #62 was -----------------
+
+    def test_a_suspended_session_is_taken_over_rather_than_deferred_to(self):
+        """
+        #62, and the reason this is not just a portability fix.
+
+        A watcher whose parent session had been suspended for nearly nine hours
+        kept draining the spool and advancing the cursor. The next session could
+        not arm, was not told, and never replayed the backlog either, because the
+        offset said it had been seen. Every indicator green, no mail delivered.
+
+        Alive is not the same as usable, and the guard has to ask the second
+        question.
+        """
+        import subprocess as sp, signal, time
+        (self.state / "session.spool").write_text("", encoding="utf-8")
+
+        # Something alive and stopped, standing in for the suspended session.
+        holder = sp.Popen(["sleep", "300"])
+        self.addCleanup(lambda: (holder.kill(), holder.wait()))
+        holder.send_signal(signal.SIGSTOP)
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            state = sp.run(["ps", "-o", "state=", "-p", str(holder.pid)],
+                           capture_output=True, text=True).stdout.strip()
+            if state.startswith("T"):
+                break
+            time.sleep(0.05)
+        else:
+            self.skipTest("could not put the stand-in holder into a stopped state")
+
+        lock = self.state / "session.watch.lock.d"
+        lock.mkdir()
+        (lock / "owner").write_text(
+            f"watcher={holder.pid}\nsession={holder.pid}\n", encoding="utf-8")
+
+        proc = sp.Popen(["bash", str(self.WATCH), str(self.state), "0"],
+                        stdout=sp.PIPE, stderr=sp.PIPE, text=True)
+        self.addCleanup(lambda: (proc.kill(), proc.stdout.close(), proc.stderr.close()))
+        self.assertTrue(self._wait_for_arming(proc),
+                        "the watcher deferred to a suspended session instead of taking over")
+
+        owner = (lock / "owner").read_text(encoding="utf-8")
+        self.assertNotIn(f"session={holder.pid}", owner,
+                         "the suspended session still owns the lock")
+
+    def test_the_guard_never_asks_which_operating_system_this_is(self):
+        """
+        #61, #68 and #80 were all one mistake: asking about the machine to learn
+        about a tool. The rule this file enforces on itself is the one that
+        would have prevented them.
+        """
+        source = self.WATCH.read_text(encoding="utf-8")
+        code = "\n".join(line for line in source.splitlines()
+                          if not line.lstrip().startswith("#"))
+        for name in ("uname", "OSTYPE", "Darwin", "darwin"):
+            self.assertNotIn(name, code,
+                             f"the watcher decides something by {name}; "
+                             "detect the capability instead")
 
 
 class HookRegistration(unittest.TestCase):


### PR DESCRIPTION
Cierra el [#105](https://github.com/iaaorgmx/paynani/issues/105) y la mitad del [#62](https://github.com/iaaorgmx/paynani/issues/62) que seguía abierta. Van juntos porque son **las mismas ocho líneas** y dos causas del mismo fallo: `exit 0` sin armar, con un mensaje que afirma que otra sesión está vigilando.

## Los dos fallos, y por qué el segundo es peor

| | qué pasaba | quién lo veía |
|---|---|---|
| **#105**, macOS | `flock` es de util-linux y macOS no lo trae. El comando salía 127, `! flock -n 9` era verdadero, y **toda** sesión en un Mac anunciaba un vigilante inexistente | nadie: `exit 0`, y el mensaje sonaba tranquilizador |
| **#62**, Linux | La guarda daba por hecho que quien tiene el lock es una sesión que va a renderizar lo que lee | nadie: mismo `exit 0` |

El #62 pasó en este host. Un watcher cuya sesión padre llevaba **8 h 43 min suspendida** seguía drenando el spool y avanzando el cursor de 12297 a 15596. La siguiente sesión no podía armar, no se enteraba, y tampoco reproducía el backlog, porque el offset decía que ya se había visto. Todos los indicadores en verde, cero correo entregado.

El CHANGELOG de 0.4.0 ya había nombrado lo que faltaba:

> Es la primera mitad del arreglo. La segunda —distinguir un dueño vivo del lock de uno huérfano o suspendido— sigue abierta.

## El arreglo

**El lock es un `mkdir`.** Atómico en POSIX y sin depender de un binario que una plataforma pueda no traer, que es todo el #105.

**Dentro se anota el pid del watcher y el de su sesión.** El segundo es el que importa: en el #62 el watcher estaba perfectamente vivo y trabajando bien — era la sesión de arriba la que ya no podía recibir nada.

**Vivo no es lo mismo que utilizable.** Si el dueño está muerto, o suspendido con `SIGTSTP`, se toma el relevo. Y antes de armar se detiene al huérfano, porque si no, dos lectores avanzan un cursor y ocurre justo la corrupción que esta guarda existe para impedir.

El estado se pregunta con `ps -o state=`, que es POSIX y contesta igual en Linux y en macOS. Está ahí en vez de `/proc` por la razón obvia: una comprobación que solo funciona en la plataforma donde se encontró el bug es exactamente cómo nació el #105.

**Un caso se decide hacia el lado conservador y se dice en voz alta.** Si el proceso existe y `ps` no quiere decir qué está haciendo, se lo trata como utilizable en vez de robarle el lock: un relevo equivocado da dos watchers sobre un cursor, y eso es peor que uno de más esperando. Pero no se decide en silencio.

**Y donde `flock` existe se sigue respetando el lock viejo del archivo**, para que un watcher de la versión anterior y uno nuevo se excluyan durante una actualización. Donde no existe no hay nada que respetar ni nada que perder: ahí el script viejo nunca armó.

## Verificación

**Lado a lado, en un `PATH` construido sin `flock`:**

```text
harness/session_watch.sh de main
  flock: command not found
  [watch] another session is already watching this spool; not arming a second.
  exit 0 · offset: NO escrito          ← el #105

harness/session_watch.sh de esta rama
  (sin salida, armado)
  exit 124, el timeout lo mató vigilando · offset: escrito
```

**Cuatro pruebas nuevas en `test_claudecode.py`**, y la existente corregida para esperar el directorio de lock en vez del archivo, que solo se crea donde hay `flock` — por eso colgaba en macOS, la plataforma donde estaba el defecto.

- arma sin el binario `flock`;
- **dos invocaciones sin `flock` siguen dando exactamente un watcher** — el criterio de cierre del #105, y no es un requisito menor que el otro: perder la exclusividad es el bug para el que se escribió la guarda;
- una sesión suspendida se releva en vez de cederle el paso;
- y el archivo no menciona `uname`, `$OSTYPE` ni `Darwin` en ninguna línea de código.

**Las pruebas no son falsos positivos.** Lo comprobé rompiendo el arreglo a propósito:

```text
volviendo a la guarda que depende de flock   →  FAILED (failures=3)
volviendo a asumir que el dueño sirve        →  FAILED (failures=1)
árbol como queda en este PR                  →  Ran 43 tests, OK
```

**Suite completa en Linux:** `17 passed, 0 failed`.

La de macOS la hace `suite-macos` en este PR, y es el primero de esta familia que se puede comprobar ahí sin pedirle el Mac a nadie.

## Lo que este PR no hace

No toca el `test_roster.sh` de los acentos ni el keepalive de `test_listener.py`. Los dos siguen esperando: el keepalive, una línea de salida del Mac de @ximenasalazartob; los acentos, un juicio sobre si es la prueba o la misma superficie que el README le hace comprobar a cada persona que instala.

Si `suite-macos` queda en verde salvo por esos dos, el siguiente paso es cerrarlos y **entonces** agregar el job a los checks requeridos.

---
Metis Claude-Tob
AI Agent
Senior Full Stack Developer

Inteligencia Artificial Aplicada
https://iaa.org.mx/
