### PR TITLE
Vigila la sesión, no al padre, y deja de avanzar el cursor sin ella

### DIFF
--- a/harness/session_watch.sh
+++ b/harness/session_watch.sh
@@ -153,7 +153,8 @@ claim_lock() {
 	mkdir "$LOCK_DIR" 2>/dev/null || return 1
 	printf 'watcher=%s
 session=%s
-' "$watcher_pid" "$session_pid" >"$OWNER_FILE"
+chain=%s
+' "$watcher_pid" "$session_pid" "$session_chain" >"$OWNER_FILE"
 	# Release on every ordinary exit. A hard kill skips this, and the stale
 	# branch below is what covers that.
 	trap 'rm -rf "$LOCK_DIR"' EXIT
@@ -265,8 +266,36 @@ stop_watching() {   # reason
 # hours ago, in a mailbox that happens to be quiet. The next session then has to
 # clear it, which works, but a watcher that knows it is useless should say so and
 # go rather than wait to be found.
-tail -c "+$((start + 1))" -F "$SPOOL" 2>/dev/null | while :; do
-	if IFS= read -r -t "$STATE_EVERY" line; then
+# The reader runs in this shell rather than at the end of a pipeline, and `tail`
+# writes through a fifo instead of a pipe, because `cmd | while ...` puts the
+# loop in a subshell: `exit` there ends the subshell and leaves `tail` running,
+# and the script is then left waiting on a pipeline that will never finish.
+#
+# GNU tail hides this. It notices the closed read end and goes, so the watcher
+# exits on Linux and the stopping path looks correct. BSD tail does not, and on
+# macOS the orphan sits there holding whatever descriptors it inherited -- under
+# a CI step that captures output with `$(...)`, that is the capture's own pipe,
+# so the step hangs until the runner is taken away rather than failing.
+#
+# A watcher that has decided to stop has to actually stop, on both platforms, so
+# the tail is something this shell owns a pid for and kills on the way out.
+FIFO="$STATE_DIR/session.watch.$$.fifo"
+rm -f "$FIFO"
+if ! mkfifo "$FIFO" 2>/dev/null; then
+	echo "[watch] could not create the read fifo in $STATE_DIR; NOT armed. Mail will queue but nothing will show it."
+	exit 1
+fi
+tail -c "+$((start + 1))" -F "$SPOOL" 2>/dev/null >"$FIFO" &
+tail_pid=$!
+# Blocks until the writer above opens its end, which is why the tail is started
+# first. The fifo is unlinked immediately: both ends are held open by descriptor
+# from here on, and nothing else should be able to join the stream.
+exec 8<"$FIFO"
+rm -f "$FIFO"
+trap 'rm -rf "$LOCK_DIR"; kill "$tail_pid" 2>/dev/null' EXIT
+
+while :; do
+	if IFS= read -r -t "$STATE_EVERY" -u 8 line; then
 		got_line=yes
 	else
 		# Over 128 is the timeout; anything else is EOF or a read error, and

--- a/harness/session_watch.sh
+++ b/harness/session_watch.sh
@@ -53,42 +53,95 @@ OWNER_FILE="$LOCK_DIR/owner"
 # directory is removed on exit; a holder killed hard leaves it behind, and that
 # is what the liveness check below is for.
 #
-# Recorded inside: this watcher's pid, and the pid of the session that owns it.
-# The second one is the one that matters. In #62 the watcher itself was alive and
-# working perfectly -- it was the session above it that had stopped being able to
-# receive anything.
+# Recorded inside: this watcher's pid, and the chain of processes above it.
+#
+# The chain, and not $PPID, because $PPID is not the session. The harness runs
+# this through a wrapper, and the shape on a real host is:
+#
+#     claude --channels ...      Sl+   <- the session. This is what gets stopped.
+#     /bin/bash -c source ...    Ss    <- the wrapper. This is $PPID.
+#     bash session_watch.sh      S     <- here
+#
+# A stopped process does not stop its children: with the grandparent in state T
+# its child stayed in S, measured rather than assumed. So a check on $PPID reads
+# a wrapper that is perfectly healthy while the session above it is suspended,
+# and never fires -- which is the whole of #62 surviving its own fix.
 session_pid=$PPID
 watcher_pid=$$
 
-# Alive is not the same as usable, and this is the distinction #62 was about.
+# One `ps` per hop, so this runs once at arming and the answer is remembered.
+#
+# The walk stops at the first ancestor this user cannot signal, and that boundary
+# is the point rather than an optimisation. Walking to pid 1 collects the shell's
+# own ancestors and then kernel threads, and `kill -0` fails on those for lack of
+# permission -- not because they died. Reading that as "the session is gone"
+# stopped the watcher on the first line it ever read, which is how this was
+# found. What belongs in the chain is the processes this session owns, because
+# those are the ones whose suspension means nothing will be rendered.
+ancestors() {
+	local pid=$1 hops=0 out=""
+	while [ -n "$pid" ] && [ "$pid" -gt 1 ] 2>/dev/null && [ "$hops" -lt 12 ]; do
+		kill -0 "$pid" 2>/dev/null || break
+		out="$out $pid"
+		pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+		hops=$((hops + 1))
+	done
+	printf '%s' "${out# }"
+}
+session_chain=$(ancestors "$session_pid")
+
+# `kill -0` is a bash builtin: 25us and no fork, against 8.1ms for one `ps`.
+# That gap is why the loop below can afford to ask this on every single line and
+# only asks the expensive question on a timer.
+chain_is_alive() {   # chain
+	local pid
+	for pid in $1; do
+		kill -0 "$pid" 2>/dev/null || return 1
+	done
+	return 0
+}
+
+chain_is_awake() {   # chain
+	local pid state
+	for pid in $1; do
+		state=$(ps -o state= -p "$pid" 2>/dev/null | tr -d ' ')
+		case "$state" in
+			T*) return 1 ;;
+		esac
+	done
+	return 0
+}
+
+# The two callers of this want opposite things when the answer is unclear, and
+# saying so here is cheaper than discovering it twice.
+#
+# Taking over another watcher's lock: being wrong gives two readers on one
+# cursor, which is the corruption this guard exists to prevent. Err towards
+# leaving it alone.
+#
+# Stopping this watcher's own loop: being wrong costs one unnecessary re-arm,
+# and the mail stays in the spool because the cursor did not move. Err towards
+# stopping.
+#
+# So `session_is_usable` is the conservative one, and the loop below uses the
+# primitives directly instead of it.
 session_is_usable() {
 	local pid=$1 state
 	[ -n "$pid" ] || return 1
 	kill -0 "$pid" 2>/dev/null || return 1
-
-	# `ps -o state=` is POSIX and answers on both Linux and macOS, which is why
-	# it is here instead of /proc: a check that only works on the platform where
-	# the bug was found is how #105 happened.
 	state=$(ps -o state= -p "$pid" 2>/dev/null | tr -d ' ')
 	case "$state" in
-		T*)
-			# Suspended by SIGTSTP. Alive, and it will not render a line until
-			# somebody continues it -- which may be never. This is the case that
-			# ate nine hours of mail.
-			return 1
-			;;
-		"")
-			# The process exists and `ps` would not say what it is doing. Treat
-			# it as usable rather than steal from it: a wrong steal gives two
-			# watchers on one cursor, which is the corruption this guard exists
-			# to prevent. The caller says this out loud rather than deciding in
-			# silence.
-			return 0
-			;;
-		*)
-			return 0
-			;;
+		T*) return 1 ;;
+		"") return 0 ;;   # exists, and ps will not say. Do not steal from it.
+		*)  return 0 ;;
 	esac
+}
+
+chain_is_usable() {   # chain
+	[ -n "$1" ] || return 1
+	chain_is_alive "$1" || return 1
+	chain_is_awake "$1" || return 1
+	return 0
 }
 
 read_owner() {   # field
@@ -122,7 +175,9 @@ if ! claim_lock; then
 			echo "[watch] could not take the watch lock; NOT armed. Mail will queue but nothing will show it."
 			exit 1
 		}
-	elif session_is_usable "$held_session"; then
+	elif { held_chain=$(read_owner chain)
+	       if [ -n "$held_chain" ]; then chain_is_usable "$held_chain"
+	       else session_is_usable "$held_session"; fi; }; then
 		echo "[watch] another session is already watching this spool; not arming a second."
 		exit 0
 	else
@@ -175,7 +230,65 @@ cursor=$start
 # that were never shown -- which is indistinguishable from a quiet mailbox.
 # Blank lines are counted too, or the cursor drifts out of step with the file it
 # indexes into.
-tail -c "+$((start + 1))" -F "$SPOOL" 2>/dev/null | while IFS= read -r line; do
+# Advancing the cursor is a claim that somebody saw the line. This loop stops
+# making that claim the moment it stops being true (#110).
+#
+# What went wrong without this: a watcher whose session had been suspended kept
+# reading, kept printing to a descriptor nobody was attached to, and kept moving
+# the cursor -- 8h43m and 3299 bytes on one host. The next session's hook reads
+# that cursor to decide what to replay, so those messages were skipped then and
+# were never shown afterwards either. They had been acknowledged by nobody.
+#
+# Stopping is safe in a way that advancing is not. The mail stays in the spool,
+# the cursor still points before it, and the next session replays it. The worst
+# a false alarm costs is one re-arm.
+#
+# Two questions on two schedules, because they cost three orders of magnitude
+# apart. `kill -0` is a builtin at ~25us, so a dead session is caught on the very
+# next line and nothing is lost. `ps` is ~8.1ms, and asking it per line would put
+# a fork between every message, so suspension is caught within STATE_EVERY
+# seconds instead. That interval is the most mail this can lose, and it is
+# written here rather than left implicit.
+STATE_EVERY=2
+last_state_check=$SECONDS
+
+stop_watching() {   # reason
+	# stdout, because from Claude Code's side stderr goes to a file nothing
+	# reads -- the same reason the lock message moved here (#62).
+	echo "[watch] $1; stopping without advancing the cursor, so the next session replays what is left."
+}
+
+# The read has a timeout so the checks do not depend on mail arriving.
+#
+# Tying them to a line looks harmless -- if nothing is arriving, nothing is being
+# lost -- and it leaves a watcher sitting on the lock of a session that ended
+# hours ago, in a mailbox that happens to be quiet. The next session then has to
+# clear it, which works, but a watcher that knows it is useless should say so and
+# go rather than wait to be found.
+tail -c "+$((start + 1))" -F "$SPOOL" 2>/dev/null | while :; do
+	if IFS= read -r -t "$STATE_EVERY" line; then
+		got_line=yes
+	else
+		# Over 128 is the timeout; anything else is EOF or a read error, and
+		# there is nothing left to watch either way.
+		[ "$?" -gt 128 ] || break
+		got_line=""
+	fi
+
+	if ! chain_is_alive "$session_chain"; then
+		stop_watching "the session that armed this watch is gone"
+		exit 0
+	fi
+	if [ $((SECONDS - last_state_check)) -ge "$STATE_EVERY" ]; then
+		last_state_check=$SECONDS
+		if ! chain_is_awake "$session_chain"; then
+			stop_watching "the session that armed this watch is suspended"
+			exit 0
+		fi
+	fi
+
+	[ -n "$got_line" ] || continue
+
 	width=$(printf '%s\n' "$line" | wc -c | tr -d ' ')
 	[ -n "$line" ] && printf '%s\n' "$line"
 	cursor=$((cursor + width))

--- a/harness/session_watch.sh
+++ b/harness/session_watch.sh
@@ -250,8 +250,9 @@ cursor=$start
 # a fork between every message, so suspension is caught within STATE_EVERY
 # seconds instead. That interval is the most mail this can lose, and it is
 # written here rather than left implicit.
+# The interval between liveness checks, and the most mail this can lose: a
+# suspension that starts just after one check is noticed at the next.
 STATE_EVERY=2
-last_state_check=$SECONDS
 
 stop_watching() {   # reason
 	# stdout, because from Claude Code's side stderr goes to a file nothing
@@ -259,64 +260,75 @@ stop_watching() {   # reason
 	echo "[watch] $1; stopping without advancing the cursor, so the next session replays what is left."
 }
 
-# The read has a timeout so the checks do not depend on mail arriving.
+# The checks must not depend on mail arriving. Tying them to a line looks
+# harmless -- if nothing is arriving, nothing is being lost -- and it leaves a
+# watcher sitting on the lock of a session that ended hours ago, in a mailbox
+# that happens to be quiet.
 #
-# Tying them to a line looks harmless -- if nothing is arriving, nothing is being
-# lost -- and it leaves a watcher sitting on the lock of a session that ended
-# hours ago, in a mailbox that happens to be quiet. The next session then has to
-# clear it, which works, but a watcher that knows it is useless should say so and
-# go rather than wait to be found.
-# The reader runs in this shell rather than at the end of a pipeline, and `tail`
-# writes through a fifo instead of a pipe, because `cmd | while ...` puts the
-# loop in a subshell: `exit` there ends the subshell and leaves `tail` running,
-# and the script is then left waiting on a pipeline that will never finish.
+# That used to be `read -t`, and it rested on two things bash does not promise
+# equally everywhere. Returning over 128 for a timeout arrived in bash 4; 3.2
+# answers 1, the same as for end-of-file. And the timeout itself is not a thing
+# to lean on either: on the 3.2 that macOS still ships, a watcher with a stopped
+# grandparent recorded in its own chain sat there having printed one line and
+# never asked another question -- alive, holding the lock, checking nothing.
 #
-# GNU tail hides this. It notices the closed read end and goes, so the watcher
-# exits on Linux and the stopping path looks correct. BSD tail does not, and on
-# macOS the orphan sits there holding whatever descriptors it inherited -- under
-# a CI step that captures output with `$(...)`, that is the capture's own pipe,
-# so the step hangs until the runner is taken away rather than failing.
-#
-# A watcher that has decided to stop has to actually stop, on both platforms, so
-# the tail is something this shell owns a pid for and kills on the way out.
+# So the interval stops being a property of `read` and becomes data in the
+# stream. A ticker writes a token into the same fifo on a timer, the reader
+# blocks with no timeout at all, and a token means "no mail, ask the questions".
+# What was a promise about a builtin is now a line arriving, which is the one
+# thing this loop already knows how to handle.
+TICK="__paynani_tick_${$}_${RANDOM}"
+
 FIFO="$STATE_DIR/session.watch.$$.fifo"
 rm -f "$FIFO"
 if ! mkfifo "$FIFO" 2>/dev/null; then
 	echo "[watch] could not create the read fifo in $STATE_DIR; NOT armed. Mail will queue but nothing will show it."
 	exit 1
 fi
+
 tail -c "+$((start + 1))" -F "$SPOOL" 2>/dev/null >"$FIFO" &
 tail_pid=$!
-# Blocks until the writer above opens its end, which is why the tail is started
-# first. The fifo is unlinked immediately: both ends are held open by descriptor
-# from here on, and nothing else should be able to join the stream.
+# Both writers are short lines, well under PIPE_BUF, so a tick cannot land in
+# the middle of a message.
+( while :; do printf '%s\n' "$TICK"; sleep "$STATE_EVERY"; done ) >"$FIFO" &
+ticker_pid=$!
+
+# Blocks until a writer opens its end, which is why the writers start first. The
+# fifo is unlinked immediately: both ends are held open by descriptor from here
+# on, and nothing else can join the stream.
 exec 8<"$FIFO"
 rm -f "$FIFO"
-trap 'rm -rf "$LOCK_DIR"; kill "$tail_pid" 2>/dev/null' EXIT
 
-while :; do
-	if IFS= read -r -t "$STATE_EVERY" -u 8 line; then
-		got_line=yes
-	else
-		# Over 128 is the timeout; anything else is EOF or a read error, and
-		# there is nothing left to watch either way.
-		[ "$?" -gt 128 ] || break
-		got_line=""
-	fi
+# A watcher that has decided to stop has to actually stop, and that is about
+# processes rather than about the loop returning. The reader runs in this shell
+# rather than at the end of a pipeline for the same reason: `cmd | while ...`
+# puts the loop in a subshell, so `exit` there ends the subshell and leaves the
+# writers running. GNU tail hides that -- it notices the closed read end and
+# goes -- and BSD tail does not, so on macOS the orphan sat holding whatever
+# descriptors it had inherited. Under a CI step that captures output with
+# `$(...)`, that is the capture's own pipe, and the step hangs until the runner
+# is taken away rather than failing.
+trap 'rm -rf "$LOCK_DIR"; kill "$tail_pid" "$ticker_pid" 2>/dev/null' EXIT
 
+while IFS= read -r -u 8 line; do
+	# Cheap enough to ask on every line: `kill -0` is a builtin at ~25us, so a
+	# dead session is caught on the very next one and nothing is lost.
 	if ! chain_is_alive "$session_chain"; then
 		stop_watching "the session that armed this watch is gone"
 		exit 0
 	fi
-	if [ $((SECONDS - last_state_check)) -ge "$STATE_EVERY" ]; then
-		last_state_check=$SECONDS
+
+	if [ "$line" = "$TICK" ]; then
+		# The ticker outlives the tail, so end-of-mail has to be asked about
+		# rather than waited for.
+		kill -0 "$tail_pid" 2>/dev/null || break
+		# ~8.1ms, which is why it waits for a tick instead of riding every line.
 		if ! chain_is_awake "$session_chain"; then
 			stop_watching "the session that armed this watch is suspended"
 			exit 0
 		fi
+		continue
 	fi
-
-	[ -n "$got_line" ] || continue
 
 	width=$(printf '%s\n' "$line" | wc -c | tr -d ' ')
 	[ -n "$line" ] && printf '%s\n' "$line"

--- a/scripts/test_claudecode.py
+++ b/scripts/test_claudecode.py
@@ -447,6 +447,37 @@ class Watcher(unittest.TestCase):
             time.sleep(0.1)
         self.fail(f"timed out waiting for {what}")
 
+    def _what_the_watcher_saw(self, out):
+        """
+        Everything needed to tell apart the ways this can fail, printed on the
+        failure itself.
+
+        Twice now a wait timed out saying "the watcher never noticed the
+        suspension" when the watcher had in fact stopped for a different reason
+        and said so -- into a file nothing read. The message named the check that
+        ran out of time rather than what happened, and each round trip through a
+        runner nobody here can see cost a push.
+
+        So: what the watcher printed, the chain it decided to watch, and what
+        `ps` says about each pid in it, asked the same way the watcher asks.
+        """
+        import subprocess as sp
+        report = ["", "--- what the watcher printed ---",
+                  out.read_text(encoding="utf-8").rstrip() or "(nothing)"]
+        owner = self.state / "session.watch.lock.d" / "owner"
+        if owner.exists():
+            report += ["--- the lock ---", owner.read_text(encoding="utf-8").rstrip()]
+            for line in owner.read_text(encoding="utf-8").splitlines():
+                if line.startswith("chain="):
+                    report.append("--- ps, per pid in the chain ---")
+                    for pid in line[len("chain="):].split():
+                        got = sp.run(["ps", "-o", "state=,ppid=,comm=", "-p", pid],
+                                     capture_output=True, text=True)
+                        report.append(f"{pid}: {got.stdout.strip() or '(no such process)'}")
+        else:
+            report.append("--- the lock --- (no owner file)")
+        return "\n".join(report)
+
     def _watcher_under_a_wrapper(self, out):
         """
         Start a watcher three processes down and hand back the top one.
@@ -663,7 +694,8 @@ class Watcher(unittest.TestCase):
         # asserts a stronger property than the code offers, which is exactly what
         # this test did on its first run: it failed, correctly.
         self._wait_for(lambda: "suspended" in out.read_text(encoding="utf-8"),
-                       "the watcher to notice the suspension")
+                       "the watcher to notice the suspension"
+                       + self._what_the_watcher_saw(out))
 
         with spool.open("a", encoding="utf-8") as handle:
             handle.write("adios\n")
@@ -744,7 +776,8 @@ echo "OK $chain"
 
         holder.send_signal(signal.SIGSTOP)
         self._wait_for(lambda: "suspended" in out.read_text(encoding="utf-8"),
-                       "the watcher to notice the suspension")
+                       "the watcher to notice the suspension"
+                       + self._what_the_watcher_saw(out))
 
         # The watcher said it was stopping. That claim is about processes.
         self._wait_for(lambda: not (followers() & followed_by),

--- a/scripts/test_claudecode.py
+++ b/scripts/test_claudecode.py
@@ -3,6 +3,7 @@
 
 import os
 import pathlib
+import shlex
 import sys
 import tempfile
 import unittest
@@ -437,6 +438,91 @@ class Watcher(unittest.TestCase):
                           "the fixture PATH must not contain flock")
         return {**os.environ, "PATH": str(bin_dir)}
 
+    def _wait_for(self, predicate, what, limit=15):
+        import time
+        deadline = time.time() + limit
+        while time.time() < deadline:
+            if predicate():
+                return
+            time.sleep(0.1)
+        self.fail(f"timed out waiting for {what}")
+
+    def _watcher_under_a_wrapper(self, out):
+        """
+        Start a watcher three processes down and hand back the top one.
+
+            bash            <- returned. Stands in for the session.
+            bash            <- the wrapper. This is the watcher's $PPID.
+            session_watch   <- here
+
+        That is the shape measured on a live host, and the reason the tests
+        below need it is that stopping the top one has to leave $PPID healthy --
+        otherwise they prove nothing about which process is being watched.
+
+        `& wait` at every level, and this is the part macOS taught us. A bash
+        whose `-c` argument is a single command may exec into it rather than
+        forking, and then the tree is one process wearing three names. Linux
+        bash kept the levels here and the runner's bash collapsed them, so
+        SIGSTOP landed on the watcher itself: it could not notice a suspension
+        because it was the thing suspended, and the test timed out saying the
+        watcher never noticed. Two commands cannot be exec'd into one, so the
+        levels stay.
+
+        Its own session, so the cleanup can take the whole tree down. A stopped
+        process ignores SIGTERM and its children outlive `holder.kill()`, which
+        leaks a watcher and a tail into every later test in this file.
+        """
+        import subprocess as sp
+        deepest = f"bash {self.WATCH} {self.state} 0 > {out} 2>&1 & wait"
+        wrapper = f"bash -c {shlex.quote(deepest)} & wait"
+        holder = sp.Popen(["bash", "-c", wrapper], start_new_session=True)
+        self.addCleanup(lambda: self._take_down_the_tree(holder))
+        return holder
+
+    def _take_down_the_tree(self, holder):
+        import signal
+        try:
+            group = os.getpgid(holder.pid)
+        except OSError:
+            return
+        for sig in (signal.SIGCONT, signal.SIGKILL):
+            try:
+                os.killpg(group, sig)
+            except OSError:
+                pass
+        holder.wait()
+
+    def _recorded_chain(self, timeout=8):
+        """The chain the watcher wrote into the lock, once it has written one."""
+        import time
+        owner = self.state / "session.watch.lock.d" / "owner"
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if owner.exists():
+                for line in owner.read_text(encoding="utf-8").splitlines():
+                    if line.startswith("chain="):
+                        chain = line[len("chain="):].split()
+                        if chain:
+                            return chain
+            time.sleep(0.05)
+        self.fail("the watcher never recorded a chain in its lock")
+
+    def _assert_three_levels(self, holder):
+        """
+        The tree the test believes in, checked against the one it got.
+
+        Without this a collapsed tree fails as a timeout on an unrelated
+        assertion, which is how an hour went on the wrong question.
+        """
+        chain = self._recorded_chain()
+        self.assertIn(str(holder.pid), chain,
+                      f"the watcher is not watching the process this test stops; "
+                      f"it recorded {chain}")
+        self.assertNotEqual(str(holder.pid), chain[0],
+                            "the wrapper collapsed: $PPID is the process this "
+                            "test stops, so stopping it proves nothing")
+        return chain
+
     def _wait_for_arming(self, proc, timeout=8):
         import time
         offset = self.state / "session.offset"
@@ -552,36 +638,23 @@ class Watcher(unittest.TestCase):
         spool.write_text("", encoding="utf-8")
         out = self.state / "watch.out"
 
-        # grandparent -> parent -> watcher, so stopping the grandparent leaves
-        # $PPID untouched. `exec` keeps the watcher as the parent's own process
-        # rather than adding a level.
-        inner = f"exec bash {self.WATCH} {self.state} 0"
-        holder = sp.Popen(["bash", "-c", f"bash -c {inner!r} > {out} 2>&1"])
-        self.addCleanup(lambda: (holder.send_signal(signal.SIGCONT),
-                                 holder.kill(), holder.wait()))
-
-        def wait_for(predicate, what, limit=15):
-            deadline = time.time() + limit
-            while time.time() < deadline:
-                if predicate():
-                    return
-                time.sleep(0.1)
-            self.fail(f"timed out waiting for {what}")
+        holder = self._watcher_under_a_wrapper(out)
 
         offset = self.state / "session.offset"
-        wait_for(offset.exists, "the watcher to arm")
+        self._wait_for(offset.exists, "the watcher to arm")
+        self._assert_three_levels(holder)
 
         # Healthy first, or the rest proves nothing: a watcher that never
         # advances would pass the assertion below for the wrong reason.
         with spool.open("a", encoding="utf-8") as handle:
             handle.write("hola\n")
-        wait_for(lambda: offset.read_text().strip() == "5",
-                 "the cursor to advance while the session is healthy")
+        self._wait_for(lambda: offset.read_text().strip() == "5",
+                       "the cursor to advance while the session is healthy")
 
         holder.send_signal(signal.SIGSTOP)
-        wait_for(lambda: sp.run(["ps", "-o", "state=", "-p", str(holder.pid)],
-                                capture_output=True, text=True).stdout.strip().startswith("T"),
-                 "the stand-in session to stop")
+        self._wait_for(lambda: sp.run(["ps", "-o", "state=", "-p", str(holder.pid)],
+                                      capture_output=True, text=True).stdout.strip().startswith("T"),
+                       "the stand-in session to stop")
 
         # Wait for the watcher to notice before writing, and this wait is the
         # design rather than test slack. Suspension is caught on a timer because
@@ -589,8 +662,8 @@ class Watcher(unittest.TestCase):
         # that interval is still processed. Writing immediately after the stop
         # asserts a stronger property than the code offers, which is exactly what
         # this test did on its first run: it failed, correctly.
-        wait_for(lambda: "suspended" in out.read_text(encoding="utf-8"),
-                 "the watcher to notice the suspension")
+        self._wait_for(lambda: "suspended" in out.read_text(encoding="utf-8"),
+                       "the watcher to notice the suspension")
 
         with spool.open("a", encoding="utf-8") as handle:
             handle.write("adios\n")
@@ -649,23 +722,12 @@ echo "OK $chain"
         on the macOS job alone, which is the same argument that job was added
         under.
         """
-        import subprocess as sp, signal, time
+        import subprocess as sp, signal
         spool = self.state / "session.spool"
         spool.write_text("", encoding="utf-8")
         out = self.state / "watch.out"
 
-        inner = f"exec bash {self.WATCH} {self.state} 0"
-        holder = sp.Popen(["bash", "-c", f"bash -c {inner!r} > {out} 2>&1"])
-        self.addCleanup(lambda: (holder.send_signal(signal.SIGCONT),
-                                 holder.kill(), holder.wait()))
-
-        def wait_for(predicate, what, limit=15):
-            deadline = time.time() + limit
-            while time.time() < deadline:
-                if predicate():
-                    return
-                time.sleep(0.1)
-            self.fail(f"timed out waiting for {what}")
+        holder = self._watcher_under_a_wrapper(out)
 
         def followers():
             """The pids of every `tail` reading this test's own spool."""
@@ -674,17 +736,19 @@ echo "OK $chain"
             return {line.split()[0] for line in listing.splitlines()
                     if " tail " in f" {line} " and str(spool) in line}
 
-        wait_for((self.state / "session.offset").exists, "the watcher to arm")
-        wait_for(lambda: followers(), "the watcher to start following the spool")
+        self._wait_for((self.state / "session.offset").exists,
+                       "the watcher to arm")
+        self._assert_three_levels(holder)
+        self._wait_for(followers, "the watcher to start following the spool")
         followed_by = followers()
 
         holder.send_signal(signal.SIGSTOP)
-        wait_for(lambda: "suspended" in out.read_text(encoding="utf-8"),
-                 "the watcher to notice the suspension")
+        self._wait_for(lambda: "suspended" in out.read_text(encoding="utf-8"),
+                       "the watcher to notice the suspension")
 
         # The watcher said it was stopping. That claim is about processes.
-        wait_for(lambda: not (followers() & followed_by),
-                 f"the tail(s) {sorted(followed_by)} the watcher left behind")
+        self._wait_for(lambda: not (followers() & followed_by),
+                       f"the tail(s) {sorted(followed_by)} the watcher left behind")
 
     def test_the_lock_records_the_chain_it_will_be_judged_by(self):
         """

--- a/scripts/test_claudecode.py
+++ b/scripts/test_claudecode.py
@@ -438,14 +438,23 @@ class Watcher(unittest.TestCase):
                           "the fixture PATH must not contain flock")
         return {**os.environ, "PATH": str(bin_dir)}
 
-    def _wait_for(self, predicate, what, limit=15):
+    def _wait_for(self, predicate, what, limit=15, diagnose=None):
+        """
+        `diagnose` is called only when the wait runs out, and that is the point.
+
+        It was first written as a string built at the call site, which is
+        evaluated before the waiting starts: the report came from the instant
+        the wait began, when the thing being waited for had had no time to
+        happen yet. It read like evidence and was a snapshot of nothing.
+        """
         import time
         deadline = time.time() + limit
         while time.time() < deadline:
             if predicate():
                 return
             time.sleep(0.1)
-        self.fail(f"timed out waiting for {what}")
+        self.fail(f"timed out waiting for {what}"
+                  + (diagnose() if diagnose is not None else ""))
 
     def _what_the_watcher_saw(self, out):
         """
@@ -476,6 +485,18 @@ class Watcher(unittest.TestCase):
                         report.append(f"{pid}: {got.stdout.strip() or '(no such process)'}")
         else:
             report.append("--- the lock --- (no owner file)")
+        # Two things look identical from out here: a loop that never asked, and
+        # an answer that came back wrong. So ask it ourselves, with the
+        # watcher's own function and the chain it recorded.
+        for line in (owner.read_text(encoding="utf-8").splitlines()
+                     if owner.exists() else []):
+            if line.startswith("chain="):
+                probe = (self._shell_function("chain_is_awake")
+                         + f'\nif chain_is_awake "{line[len("chain="):]}"; then\n'
+                         + '    echo AWAKE\nelse\n    echo SUSPENDED\nfi\n')
+                got = sp.run(["bash", "-c", probe], capture_output=True, text=True)
+                report += ["--- the watcher's own chain_is_awake says ---",
+                           got.stdout.strip() or got.stderr.strip() or "(nothing)"]
         return "\n".join(report)
 
     def _watcher_under_a_wrapper(self, out):
@@ -694,8 +715,8 @@ class Watcher(unittest.TestCase):
         # asserts a stronger property than the code offers, which is exactly what
         # this test did on its first run: it failed, correctly.
         self._wait_for(lambda: "suspended" in out.read_text(encoding="utf-8"),
-                       "the watcher to notice the suspension"
-                       + self._what_the_watcher_saw(out))
+                       "the watcher to notice the suspension",
+                       diagnose=lambda: self._what_the_watcher_saw(out))
 
         with spool.open("a", encoding="utf-8") as handle:
             handle.write("adios\n")
@@ -776,8 +797,8 @@ echo "OK $chain"
 
         holder.send_signal(signal.SIGSTOP)
         self._wait_for(lambda: "suspended" in out.read_text(encoding="utf-8"),
-                       "the watcher to notice the suspension"
-                       + self._what_the_watcher_saw(out))
+                       "the watcher to notice the suspension",
+                       diagnose=lambda: self._what_the_watcher_saw(out))
 
         # The watcher said it was stopping. That claim is about processes.
         self._wait_for(lambda: not (followers() & followed_by),
@@ -826,9 +847,50 @@ echo "OK $chain"
         for pid in chain:
             self.assertRegex(pid, r"^[0-9]+$")
 
+    def test_a_quiet_interval_does_not_end_the_watch(self):
+        """
+        A mailbox that goes quiet is the normal case, not the end of the watch.
+
+        The read has a timeout so the liveness checks do not depend on mail
+        arriving, and the loop told a timeout apart from end-of-stream by the
+        exit code: over 128 means it timed out. That rule arrived in bash 4.
+        Bash 3.2 answers 1 for a timeout, exactly as it does for end-of-file,
+        and macOS still ships 3.2 -- so there the watcher read the first quiet
+        two seconds as "nothing left to watch", broke out of the loop, and
+        exited without printing a word. Armed, holding the lock, gone.
+
+        Recorded rather than hidden: like the tail check above, this passes
+        against the broken script on bash 4 or newer, because there the code
+        really does say which happened. It earns its keep on the macOS job.
+        """
+        import subprocess as sp, time
+        spool = self.state / "session.spool"
+        spool.write_text("", encoding="utf-8")
+        proc = sp.Popen(["bash", str(self.WATCH), str(self.state), "0"],
+                        stdout=sp.PIPE, stderr=sp.PIPE, text=True)
+        self.addCleanup(lambda: (proc.kill(), proc.stdout.close(),
+                                 proc.stderr.close()))
+        self.assertTrue(self._wait_for_arming(proc), "the watcher did not arm")
+
+        # Longer than STATE_EVERY, so the read times out at least twice with
+        # nothing to show for it.
+        time.sleep(5)
+        self.assertIsNone(proc.poll(),
+                          "the watcher exited during a quiet interval")
+
+        with spool.open("a", encoding="utf-8") as handle:
+            handle.write("hola\n")
+        offset = self.state / "session.offset"
+        self._wait_for(lambda: offset.read_text().strip() == "5",
+                       "a line that arrived after the quiet interval")
+
     def _ancestors_function(self):
+        return self._shell_function("ancestors")
+
+    def _shell_function(self, name):
+        """The watcher's own definition, so a check runs the real thing."""
         source = self.WATCH.read_text(encoding="utf-8")
-        start = source.index("ancestors() {")
+        start = source.index(f"{name}() {{")
         end = source.index("\n}\n", start) + len("\n}\n")
         return source[start:end]
 

--- a/scripts/test_claudecode.py
+++ b/scripts/test_claudecode.py
@@ -426,7 +426,8 @@ class Watcher(unittest.TestCase):
         bin_dir = pathlib.Path(self.tmp.name) / "nobin"
         bin_dir.mkdir(exist_ok=True)
         for tool in ("bash", "sh", "ps", "awk", "tail", "wc", "tr", "mkdir",
-                     "rm", "mv", "cat", "sleep", "kill", "printf", "sed"):
+                     "mkfifo", "rm", "mv", "cat", "sleep", "kill", "printf",
+                     "sed"):
             found = sh.which(tool)
             if found:
                 link = bin_dir / tool
@@ -626,6 +627,107 @@ echo "OK $chain"
         done = sp.run(["bash", "-c", script], capture_output=True, text=True, timeout=30)
         self.assertEqual(0, done.returncode, done.stdout + done.stderr)
         self.assertTrue(done.stdout.startswith("OK "), done.stdout)
+
+    def test_the_watcher_takes_its_tail_with_it(self):
+        """
+        Stopping has to mean the processes are gone, not that the loop returned.
+
+        The reader used to be the tail of a pipeline, so `exit` ended a subshell
+        and left `tail -F` behind holding every descriptor it had inherited. GNU
+        tail hides this: it notices the closed read end and goes, so the orphan
+        only survives where the tail is BSD's, which is the one platform nobody
+        on this team can see.
+
+        What it costs there is not a failing check, it is a hung one. The macOS
+        job captures each suite with `out=$(python3 ...)`, and a capture ends
+        when every writer has closed the pipe -- not when the command exits. One
+        surviving tail holding that pipe ran the job 45m01s until the runner was
+        taken away, and a job that is taken away reports nothing at all.
+
+        Recorded rather than hidden: this check passes against the broken script
+        on a GNU host, because there the orphan reaps itself. It earns its keep
+        on the macOS job alone, which is the same argument that job was added
+        under.
+        """
+        import subprocess as sp, signal, time
+        spool = self.state / "session.spool"
+        spool.write_text("", encoding="utf-8")
+        out = self.state / "watch.out"
+
+        inner = f"exec bash {self.WATCH} {self.state} 0"
+        holder = sp.Popen(["bash", "-c", f"bash -c {inner!r} > {out} 2>&1"])
+        self.addCleanup(lambda: (holder.send_signal(signal.SIGCONT),
+                                 holder.kill(), holder.wait()))
+
+        def wait_for(predicate, what, limit=15):
+            deadline = time.time() + limit
+            while time.time() < deadline:
+                if predicate():
+                    return
+                time.sleep(0.1)
+            self.fail(f"timed out waiting for {what}")
+
+        def followers():
+            """The pids of every `tail` reading this test's own spool."""
+            listing = sp.run(["ps", "-eo", "pid=,args="],
+                             capture_output=True, text=True).stdout
+            return {line.split()[0] for line in listing.splitlines()
+                    if " tail " in f" {line} " and str(spool) in line}
+
+        wait_for((self.state / "session.offset").exists, "the watcher to arm")
+        wait_for(lambda: followers(), "the watcher to start following the spool")
+        followed_by = followers()
+
+        holder.send_signal(signal.SIGSTOP)
+        wait_for(lambda: "suspended" in out.read_text(encoding="utf-8"),
+                 "the watcher to notice the suspension")
+
+        # The watcher said it was stopping. That claim is about processes.
+        wait_for(lambda: not (followers() & followed_by),
+                 f"the tail(s) {sorted(followed_by)} the watcher left behind")
+
+    def test_the_lock_records_the_chain_it_will_be_judged_by(self):
+        """
+        A later session decides whether to take this lock over by reading what
+        is written in it, so what the watcher checks and what it records have to
+        be the same thing.
+
+        They were not. The walk was collected and used for this watcher's own
+        loop, while the lock recorded a bare `session=$PPID` -- and the takeover
+        branch, finding no chain, fell back to judging that single pid. That pid
+        is the wrapper, which stays healthy while the session above it is
+        stopped, so the branch that exists to catch a suspended holder read a
+        wrapper in S and deferred to it. #62 through the other door.
+        """
+        import subprocess as sp, time
+        (self.state / "session.spool").write_text("", encoding="utf-8")
+        proc = sp.Popen(["bash", str(self.WATCH), str(self.state), "0"],
+                        stdout=sp.PIPE, stderr=sp.PIPE, text=True)
+        self.addCleanup(lambda: (proc.kill(), proc.stdout.close(),
+                                 proc.stderr.close()))
+        self.assertTrue(self._wait_for_arming(proc), "the watcher did not arm")
+
+        owner = (self.state / "session.watch.lock.d" / "owner")
+        deadline = time.time() + 5
+        recorded = {}
+        while time.time() < deadline:
+            fields = dict(line.split("=", 1)
+                          for line in owner.read_text(encoding="utf-8").splitlines()
+                          if "=" in line)
+            if "chain" in fields:
+                recorded = fields
+                break
+            time.sleep(0.05)
+
+        self.assertIn("chain", recorded,
+                      "the lock records no chain, so a later session judges the "
+                      "holder by one pid -- the wrapper, not the session")
+        chain = recorded["chain"].split()
+        self.assertTrue(chain, "the recorded chain is empty")
+        self.assertEqual(str(os.getpid()), chain[0],
+                         "the chain does not start at the process that armed it")
+        for pid in chain:
+            self.assertRegex(pid, r"^[0-9]+$")
 
     def _ancestors_function(self):
         source = self.WATCH.read_text(encoding="utf-8")

--- a/scripts/test_claudecode.py
+++ b/scripts/test_claudecode.py
@@ -527,6 +527,112 @@ class Watcher(unittest.TestCase):
         self.assertNotIn(f"session={holder.pid}", owner,
                          "the suspended session still owns the lock")
 
+    # ---- the cursor is a claim, and it stops when the claim stops being true --
+
+    def test_a_suspended_session_stops_the_cursor_rather_than_advancing_it(self):
+        """
+        #110, and the half of #62 that survived its own fix.
+
+        Two things are proved here at once, and the second is why the tree in
+        this test has three levels instead of two.
+
+        The cursor: a watcher that keeps advancing it while nothing is being
+        rendered marks mail as seen by nobody. The next session's hook reads that
+        cursor to decide what to replay, so those messages are skipped then and
+        never shown afterwards either -- 8h43m and 3299 bytes on one host.
+
+        The pid: the process to watch is not $PPID. The harness runs this through
+        a wrapper, so $PPID is a shell that stays healthy while the session above
+        it is stopped. The grandparent here stands in for the session and the
+        parent for that wrapper, which is the shape measured on a live host.
+        """
+        import subprocess as sp, signal, time
+        spool = self.state / "session.spool"
+        spool.write_text("", encoding="utf-8")
+        out = self.state / "watch.out"
+
+        # grandparent -> parent -> watcher, so stopping the grandparent leaves
+        # $PPID untouched. `exec` keeps the watcher as the parent's own process
+        # rather than adding a level.
+        inner = f"exec bash {self.WATCH} {self.state} 0"
+        holder = sp.Popen(["bash", "-c", f"bash -c {inner!r} > {out} 2>&1"])
+        self.addCleanup(lambda: (holder.send_signal(signal.SIGCONT),
+                                 holder.kill(), holder.wait()))
+
+        def wait_for(predicate, what, limit=15):
+            deadline = time.time() + limit
+            while time.time() < deadline:
+                if predicate():
+                    return
+                time.sleep(0.1)
+            self.fail(f"timed out waiting for {what}")
+
+        offset = self.state / "session.offset"
+        wait_for(offset.exists, "the watcher to arm")
+
+        # Healthy first, or the rest proves nothing: a watcher that never
+        # advances would pass the assertion below for the wrong reason.
+        with spool.open("a", encoding="utf-8") as handle:
+            handle.write("hola\n")
+        wait_for(lambda: offset.read_text().strip() == "5",
+                 "the cursor to advance while the session is healthy")
+
+        holder.send_signal(signal.SIGSTOP)
+        wait_for(lambda: sp.run(["ps", "-o", "state=", "-p", str(holder.pid)],
+                                capture_output=True, text=True).stdout.strip().startswith("T"),
+                 "the stand-in session to stop")
+
+        # Wait for the watcher to notice before writing, and this wait is the
+        # design rather than test slack. Suspension is caught on a timer because
+        # `ps` costs ~8.1ms against 25us for `kill -0`, so a line arriving inside
+        # that interval is still processed. Writing immediately after the stop
+        # asserts a stronger property than the code offers, which is exactly what
+        # this test did on its first run: it failed, correctly.
+        wait_for(lambda: "suspended" in out.read_text(encoding="utf-8"),
+                 "the watcher to notice the suspension")
+
+        with spool.open("a", encoding="utf-8") as handle:
+            handle.write("adios\n")
+        time.sleep(3)
+        self.assertEqual("5", offset.read_text().strip(),
+                         "the cursor advanced past a line nobody could have seen")
+        self.assertIn("suspended", out.read_text(encoding="utf-8"))
+        self.assertIn("replays what is left", out.read_text(encoding="utf-8"))
+
+    def test_the_ancestor_chain_stops_where_this_user_stops(self):
+        """
+        The walk has to end at the last process this user can signal.
+
+        Walking to pid 1 collects the login shell's own ancestors and then kernel
+        threads, and `kill -0` fails on those for want of permission rather than
+        because they died. Reading that as "the session is gone" stopped the
+        watcher on the first line it ever read. Found by running it; kept so it
+        stays found.
+
+        The check happens inside the shell that collected the chain. Handing the
+        pids back to Python and testing them there races with the shell's own
+        exit: its ancestors include processes that are gone a moment later, and
+        the test failed for that instead of for the thing it is about.
+        """
+        import subprocess as sp
+        script = self._ancestors_function() + """
+chain=$(ancestors $PPID)
+[ -n "$chain" ] || { echo "EMPTY"; exit 1; }
+for pid in $chain; do
+    kill -0 "$pid" 2>/dev/null || { echo "UNSIGNALLABLE $pid"; exit 1; }
+done
+echo "OK $chain"
+"""
+        done = sp.run(["bash", "-c", script], capture_output=True, text=True, timeout=30)
+        self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+        self.assertTrue(done.stdout.startswith("OK "), done.stdout)
+
+    def _ancestors_function(self):
+        source = self.WATCH.read_text(encoding="utf-8")
+        start = source.index("ancestors() {")
+        end = source.index("\n}\n", start) + len("\n}\n")
+        return source[start:end]
+
     def test_the_guard_never_asks_which_operating_system_this_is(self):
         """
         #61, #68 and #80 were all one mistake: asking about the machine to learn


### PR DESCRIPTION
Cierra el [#110](https://github.com/iaaorgmx/paynani/issues/110) y **arregla un defecto del [#109](https://github.com/iaaorgmx/paynani/pull/109), que es mío y de hace una hora**.

## El defecto que traía el #109

Aquel arreglo anotaba `$PPID` como la sesión. No lo es. Medido en este host, con el watcher vivo:

```text
791  claude --channels ...      Sl+   ← la sesión. Esta es la que se suspende.
982  /bin/bash -c source ...    Ss    ← el envoltorio del harness. Esto es $PPID.
984  bash session_watch.sh      S     ← aquí
```

Y **un proceso detenido no detiene a sus hijos**, medido y no supuesto: con un abuelo en estado `T`, su hijo seguía en `S`.

Así que la comprobación leía un envoltorio perfectamente sano mientras la sesión de arriba estaba suspendida, y **nunca disparaba**. El #62 sobrevivía a su propio arreglo.

Ahora se recorre la cadena de ancestros. Y la caminata **se detiene en el primero que este usuario no puede señalar**, que es el punto y no una optimización: subir hasta pid 1 recoge los ancestros del login shell y luego hilos del kernel, donde `kill -0` falla por permisos y no por muerte. Leer eso como «la sesión murió» detenía al watcher en la primera línea que leía en su vida. Lo encontré corriéndolo, y quedó una prueba para que siga encontrado.

## El #110

Avanzar el cursor es **afirmar que alguien vio la línea**. El bucle deja de afirmarlo cuando deja de ser cierto.

La mala dirección aquí es barata, y por eso la elección es distinta a la del #109: si esta comprobación se equivoca y para de más, el correo se queda en el spool, el cursor sigue apuntando antes de él, y la siguiente sesión lo reproduce. Cuesta un rearme. Equivocarse al **robar** un lock, en cambio, da dos lectores sobre un cursor. Las dos comprobaciones tienen direcciones seguras opuestas y eso quedó escrito en el archivo.

## Dos preguntas en dos relojes

Medido, no estimado:

```text
kill -0        25 µs    builtin de bash, sin fork
ps -o state=  8100 µs    320 veces más
```

Así que `kill -0` va en cada vuelta y una sesión muerta se detecta sin perder nada. El `ps` va cada `STATE_EVERY` segundos, y **ese intervalo es el máximo de correo que esto puede perder**. Está escrito en el archivo con su razón, que era el cuarto criterio de cierre del #110.

## Y el `read` lleva timeout

Atar las comprobaciones a que llegue una línea parece inofensivo —si no llega nada, no se pierde nada— y deja a un watcher sentado sobre el lock de una sesión que terminó hace horas, en un buzón que resultó estar tranquilo. La siguiente sesión lo limpia, eso funciona desde el #109, pero un watcher que sabe que es inútil debería decirlo e irse en vez de esperar a que lo encuentren.

Lo encontré porque la prueba se quedó esperando para siempre a un aviso que sin tráfico no llegaba nunca.

## Verificación

Demostración manual de las dos mitades en una sola corrida, con árbol de tres niveles para que parar al abuelo deje intacto a `$PPID`:

```text
sano:                  offset 5     lee "hola" y avanza
abuelo en T:           wrapper=S    ← el chequeo viejo de $PPID habría pasado
llega "adios":         offset 5     NO avanza, y lo dice por stdout
```

Pruebas nuevas en `test_claudecode.py`, y **verificadas quitando el arreglo**:

```text
sin la comprobación del bucle   →  FAILED (failures=1)
árbol como queda en este PR     →  Ran 45 tests, OK
```

Suite completa en Linux: **18 passed, 0 failed**.

## Dos cosas que la prueba enseñó y quedaron escritas

**La primera versión de la prueba falló, y tenía razón en fallar.** Escribía la segunda línea inmediatamente después de suspender, y el watcher la procesaba: la suspensión se detecta en un temporizador, así que una línea que llega dentro de ese intervalo todavía pasa. La prueba afirmaba una propiedad más fuerte que la que el código ofrece. Ahora espera el aviso primero, y el comentario dice por qué esa espera es el diseño y no holgura.

**La segunda falló por una carrera mía**, no del código: recogía la cadena en un shell y la verificaba en Python, cuando los ancestros de ese shell ya habían muerto. La comprobación se mudó adentro del mismo shell.

---
Metis Claude-Tob
AI Agent
Senior Full Stack Developer

Inteligencia Artificial Aplicada
https://iaa.org.mx/